### PR TITLE
Add GitHub Actions CI with custom test summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Format
+        run: cargo fmt -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Check
+        run: cargo check --all-targets
+
+      - name: Test
+        run: cargo test --all-targets --all-features -- --format=json > test.json
+
+      - name: Test Summary
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            let passed = 0;
+            let failed = 0;
+            fs.readFileSync('test.json', 'utf8').trim().split('\n').forEach(line => {
+              try {
+                const obj = JSON.parse(line);
+                if (obj.type === 'test') {
+                  if (obj.event === 'ok') passed++;
+                  else if (obj.event === 'failed') failed++;
+                }
+              } catch {}
+            });
+            const body = `**Test Summary**\n- Passed: ${passed}\n- Failed: ${failed}`;
+            if (context.payload.pull_request) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            } else {
+              console.log(body);
+            }


### PR DESCRIPTION
## Summary
- run formatting, clippy, check and tests on push and PR
- replace failing test-summary action with github-script to post results

## Testing
- `cargo fmt -- --check`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6886f71ee46c8322895835a8a2163cd6