### PR TITLE
Implement rustmat-repl tokenizer

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -29,7 +29,7 @@ kebab-case crates (lexer, parser, IR passes, runtime, GC, JIT, kernel, etc.).
 
 - [x] Expand lexer to cover MATLAB operators, keywords and comments.
 - [x] Introduce `rustmat-parser` crate producing an AST.
-- [ ] Basic `rustmat-repl` that tokenizes input and prints tokens.
+- [x] Basic `rustmat-repl` that tokenizes input and prints tokens.
 - [ ] Set up CI with `cargo fmt` and `cargo check`.
 
 ### Milestone P1 – Language Core
@@ -66,3 +66,18 @@ kebab-case crates (lexer, parser, IR passes, runtime, GC, JIT, kernel, etc.).
 
 ### 2025-07-31
 - Introduced `rustmat-parser` crate with simple AST and parser tests.
+
+### 2025-08-01
+- Added basic rustmat-repl that tokenizes input and prints tokens. Included integration tests.
+
+### 2025-08-02
+- Expanded REPL test suite with edge cases and error handling.
+- Updated docs to describe the tokenizing behaviour.
+
+### 2025-08-03
+- Fixed clippy warning in `format_tokens` and added binary test.
+
+### 2025-08-04
+- Removed `assert_cmd` and `predicates` dev dependencies to avoid pulling in an
+  extra version of `regex-syntax`. Rewrote the REPL binary test using
+  `std::process::Command`.

--- a/crates/rustmat-repl/src/lib.rs
+++ b/crates/rustmat-repl/src/lib.rs
@@ -1,0 +1,11 @@
+use rustmat_lexer::tokenize;
+
+/// Tokenize the input string and return a space separated string of token names.
+pub fn format_tokens(input: &str) -> String {
+    let tokens = tokenize(input);
+    tokens
+        .into_iter()
+        .map(|t| format!("{t:?}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}

--- a/crates/rustmat-repl/src/main.rs
+++ b/crates/rustmat-repl/src/main.rs
@@ -1,3 +1,21 @@
+use std::io::{self, Write};
+
 fn main() {
-    println!("rustmat repl placeholder");
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        if stdout.write_all(b"> ").is_err() || stdout.flush().is_err() {
+            break;
+        }
+        if stdin.read_line(&mut line).unwrap_or(0) == 0 {
+            break; // EOF
+        }
+        let output = rustmat_repl::format_tokens(line.trim_end());
+        if writeln!(stdout, "{output}").is_err() {
+            break;
+        }
+    }
 }

--- a/crates/rustmat-repl/tests/repl.rs
+++ b/crates/rustmat-repl/tests/repl.rs
@@ -1,0 +1,70 @@
+use rustmat_repl::format_tokens;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+#[test]
+fn tokenize_simple_input() {
+    let result = format_tokens("x = 1 + 2;");
+    assert_eq!(result, "Ident Assign Integer Plus Integer Semicolon");
+}
+
+#[test]
+fn handles_whitespace_and_comments() {
+    let result = format_tokens("foo % comment\n+");
+    assert_eq!(result, "Ident Plus");
+}
+
+#[test]
+fn empty_input_yields_empty_string() {
+    let result = format_tokens("");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn unknown_char_produces_error() {
+    let result = format_tokens("$");
+    assert_eq!(result, "Error");
+}
+
+#[test]
+fn unterminated_string_is_error_token() {
+    let result = format_tokens("'oops");
+    assert!(result.contains("Error"));
+}
+
+#[test]
+fn keywords_are_case_sensitive() {
+    let result = format_tokens("IF ELSE");
+    assert_eq!(result, "Ident Ident");
+}
+
+#[test]
+fn complex_expression_tokens() {
+    let result = format_tokens("1 * (2 + 3)");
+    assert_eq!(result, "Integer Star LParen Integer Plus Integer RParen");
+}
+
+#[test]
+fn multiple_statements() {
+    let result = format_tokens("x=1; y=2;");
+    assert_eq!(
+        result,
+        "Ident Assign Integer Semicolon Ident Assign Integer Semicolon"
+    );
+}
+
+#[test]
+fn repl_binary_processes_single_line() -> Result<(), Box<dyn std::error::Error>> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rustmat-repl"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()?;
+    child.stdin.as_mut().unwrap().write_all(b"x=1\n")?;
+    let output = child.wait_with_output()?;
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "> Ident Assign Integer\n> "
+    );
+    Ok(())
+}

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -15,7 +15,7 @@ cargo build
 
 ## Running the REPL
 
-At this early stage the REPL only prints a placeholder message:
+At this early stage the REPL simply tokenizes input and prints the token names:
 
 ```bash
 cargo run -p rustmat-repl


### PR DESCRIPTION
## Summary
- implement`rustmat-repl` with tokenizer output

## Testing
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
