### PR TITLE
Implement elseif and expand ignition tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustmat-ignition"
+version = "0.0.1"
+dependencies = [
+ "rustmat-hir",
+ "rustmat-parser",
+]
+
+[[package]]
 name = "rustmat-lexer"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/rustmat-lexer",
     "crates/rustmat-parser",
     "crates/rustmat-repl",
-    "crates/rustmat-hir"
+    "crates/rustmat-hir",
+    "crates/rustmat-ignition"
 ]
 resolver = "2"

--- a/PLAN.md
+++ b/PLAN.md
@@ -38,7 +38,7 @@ kebab-case crates (lexer, parser, IR passes, runtime, GC, JIT, kernel, etc.).
  - [x] Extend parser to support control flow, function definitions and array
       indexing so that typical MATLAB files can be parsed without errors.
 - [x] High-level IR (`rustmat-hir`) with scope and type annotations.
-- [ ] Simple interpreter running on an unoptimised bytecode (`rustmat-ignition`).
+- [x] Simple interpreter running on an unoptimised bytecode (`rustmat-ignition`).
 - [ ] Headless plotting backend emitting SVG/PNG.
 - [ ] Jupyter kernel communication skeleton.
 
@@ -117,3 +117,13 @@ kebab-case crates (lexer, parser, IR passes, runtime, GC, JIT, kernel, etc.).
 
 ### 2025-08-11
 - Fixed clippy warnings in `rustmat-hir` after review.
+
+### 2025-08-12
+- Implemented `rustmat-ignition` crate with a simple bytecode interpreter. The
+  interpreter supports numeric operations, variable assignments, `if`, `while`
+  and `for` loops with break/continue. Added comprehensive tests covering
+  normal execution, error cases and edge conditions. All workspace tests pass.
+
+### 2025-08-13
+- Added support for `elseif` branches in the Ignition compiler and updated the
+  interpreter tests accordingly. Marked the interpreter milestone complete.

--- a/crates/rustmat-ignition/Cargo.toml
+++ b/crates/rustmat-ignition/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rustmat-ignition"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+rustmat-hir = { path = "../rustmat-hir" }
+rustmat-parser = { path = "../rustmat-parser" }
+
+[dev-dependencies]
+rustmat-parser = { path = "../rustmat-parser" }
+rustmat-hir = { path = "../rustmat-hir" }

--- a/crates/rustmat-ignition/src/lib.rs
+++ b/crates/rustmat-ignition/src/lib.rs
@@ -1,0 +1,377 @@
+use rustmat_hir::{HirExpr, HirExprKind, HirProgram, HirStmt};
+
+#[derive(Debug, Clone)]
+pub enum Instr {
+    LoadConst(f64),
+    LoadVar(usize),
+    StoreVar(usize),
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Neg,
+    Pow,
+    LessEqual,
+    JumpIfFalse(usize),
+    Jump(usize),
+    Pop,
+    Halt,
+}
+
+#[derive(Debug)]
+pub struct Bytecode {
+    pub instructions: Vec<Instr>,
+    pub var_count: usize,
+}
+
+pub fn compile(prog: &HirProgram) -> Result<Bytecode, String> {
+    let mut c = Compiler::new(prog);
+    c.compile_program(prog)?;
+    Ok(Bytecode {
+        instructions: c.instructions,
+        var_count: c.var_count,
+    })
+}
+
+struct Compiler {
+    instructions: Vec<Instr>,
+    var_count: usize,
+    loop_stack: Vec<LoopLabels>,
+}
+
+struct LoopLabels {
+    break_jumps: Vec<usize>,
+    continue_jumps: Vec<usize>,
+}
+
+impl Compiler {
+    fn new(prog: &HirProgram) -> Self {
+        let mut max_var = 0;
+        fn visit_stmts(stmts: &[HirStmt], max: &mut usize) {
+            for s in stmts {
+                match s {
+                    HirStmt::Assign(id, _) => {
+                        if id.0 + 1 > *max {
+                            *max = id.0 + 1;
+                        }
+                    }
+                    HirStmt::If {
+                        then_body,
+                        elseif_blocks,
+                        else_body,
+                        ..
+                    } => {
+                        visit_stmts(then_body, max);
+                        for (_, b) in elseif_blocks {
+                            visit_stmts(b, max);
+                        }
+                        if let Some(b) = else_body {
+                            visit_stmts(b, max);
+                        }
+                    }
+                    HirStmt::While { body, .. } => visit_stmts(body, max),
+                    HirStmt::For { var, body, .. } => {
+                        if var.0 + 1 > *max {
+                            *max = var.0 + 1;
+                        }
+                        visit_stmts(body, max);
+                    }
+                    HirStmt::Function { .. } => {}
+                    HirStmt::ExprStmt(_) | HirStmt::Break | HirStmt::Continue | HirStmt::Return => {
+                    }
+                }
+            }
+        }
+        visit_stmts(&prog.body, &mut max_var);
+        Self {
+            instructions: Vec::new(),
+            var_count: max_var,
+            loop_stack: Vec::new(),
+        }
+    }
+
+    fn emit(&mut self, instr: Instr) -> usize {
+        let pc = self.instructions.len();
+        self.instructions.push(instr);
+        pc
+    }
+
+    fn compile_program(&mut self, prog: &HirProgram) -> Result<(), String> {
+        for stmt in &prog.body {
+            self.compile_stmt(stmt)?;
+        }
+        self.emit(Instr::Halt);
+        Ok(())
+    }
+
+    fn compile_stmt(&mut self, stmt: &HirStmt) -> Result<(), String> {
+        match stmt {
+            HirStmt::ExprStmt(expr) => {
+                self.compile_expr(expr)?;
+                self.emit(Instr::Pop);
+            }
+            HirStmt::Assign(id, expr) => {
+                self.compile_expr(expr)?;
+                self.emit(Instr::StoreVar(id.0));
+            }
+            HirStmt::If {
+                cond,
+                then_body,
+                elseif_blocks,
+                else_body,
+            } => {
+                // compile initial condition
+                self.compile_expr(cond)?;
+                let mut last_jump = self.emit(Instr::JumpIfFalse(usize::MAX));
+                // then-body
+                for s in then_body {
+                    self.compile_stmt(s)?;
+                }
+                let mut end_jumps = Vec::new();
+                end_jumps.push(self.emit(Instr::Jump(usize::MAX)));
+                // process elseif blocks
+                for (c, b) in elseif_blocks {
+                    self.patch(last_jump, Instr::JumpIfFalse(self.instructions.len()));
+                    self.compile_expr(c)?;
+                    last_jump = self.emit(Instr::JumpIfFalse(usize::MAX));
+                    for s in b {
+                        self.compile_stmt(s)?;
+                    }
+                    end_jumps.push(self.emit(Instr::Jump(usize::MAX)));
+                }
+                // else block
+                self.patch(last_jump, Instr::JumpIfFalse(self.instructions.len()));
+                if let Some(body) = else_body {
+                    for s in body {
+                        self.compile_stmt(s)?;
+                    }
+                }
+                let end = self.instructions.len();
+                for j in end_jumps {
+                    self.patch(j, Instr::Jump(end));
+                }
+            }
+            HirStmt::While { cond, body } => {
+                let start = self.instructions.len();
+                self.compile_expr(cond)?;
+                let jump_end = self.emit(Instr::JumpIfFalse(usize::MAX));
+                let labels = LoopLabels {
+                    break_jumps: Vec::new(),
+                    continue_jumps: Vec::new(),
+                };
+                self.loop_stack.push(labels);
+                for s in body {
+                    self.compile_stmt(s)?;
+                }
+                let labels = self.loop_stack.pop().unwrap();
+                for j in labels.continue_jumps {
+                    self.patch(j, Instr::Jump(start));
+                }
+                self.emit(Instr::Jump(start));
+                let end = self.instructions.len();
+                self.patch(jump_end, Instr::JumpIfFalse(end));
+                for j in labels.break_jumps {
+                    self.patch(j, Instr::Jump(end));
+                }
+            }
+            HirStmt::For { var, expr, body } => {
+                if let HirExprKind::Range(start, step, end) = &expr.kind {
+                    if step.is_some() {
+                        return Err("step in range not supported".into());
+                    }
+                    self.compile_expr(start)?;
+                    self.emit(Instr::StoreVar(var.0));
+                    self.compile_expr(end)?;
+                    let end_var = self.var_count;
+                    self.var_count += 1;
+                    self.emit(Instr::StoreVar(end_var));
+                    let loop_start = self.instructions.len();
+                    self.emit(Instr::LoadVar(var.0));
+                    self.emit(Instr::LoadVar(end_var));
+                    self.emit(Instr::LessEqual);
+                    let jump_end = self.emit(Instr::JumpIfFalse(usize::MAX));
+                    self.loop_stack.push(LoopLabels {
+                        break_jumps: Vec::new(),
+                        continue_jumps: Vec::new(),
+                    });
+                    for s in body {
+                        self.compile_stmt(s)?;
+                    }
+                    let labels = self.loop_stack.pop().unwrap();
+                    for j in labels.continue_jumps {
+                        self.patch(j, Instr::Jump(self.instructions.len()));
+                    }
+                    self.emit(Instr::LoadVar(var.0));
+                    self.emit(Instr::LoadConst(1.0));
+                    self.emit(Instr::Add);
+                    self.emit(Instr::StoreVar(var.0));
+                    self.emit(Instr::Jump(loop_start));
+                    let end = self.instructions.len();
+                    self.patch(jump_end, Instr::JumpIfFalse(end));
+                    for j in labels.break_jumps {
+                        self.patch(j, Instr::Jump(end));
+                    }
+                } else {
+                    return Err("for loop expects range".into());
+                }
+            }
+            HirStmt::Break => {
+                if let Some(labels) = self.loop_stack.last_mut() {
+                    let idx = self.instructions.len();
+                    self.instructions.push(Instr::Jump(usize::MAX));
+                    labels.break_jumps.push(idx);
+                } else {
+                    return Err("break outside loop".into());
+                }
+            }
+            HirStmt::Continue => {
+                if let Some(labels) = self.loop_stack.last_mut() {
+                    let idx = self.instructions.len();
+                    self.instructions.push(Instr::Jump(usize::MAX));
+                    labels.continue_jumps.push(idx);
+                } else {
+                    return Err("continue outside loop".into());
+                }
+            }
+            HirStmt::Return => {
+                self.emit(Instr::Halt);
+            }
+            HirStmt::Function { .. } => {
+                return Err("function definitions not supported".into());
+            }
+        }
+        Ok(())
+    }
+
+    fn compile_expr(&mut self, expr: &HirExpr) -> Result<(), String> {
+        match &expr.kind {
+            HirExprKind::Number(n) => {
+                let val: f64 = n.parse().map_err(|_| "invalid number")?;
+                self.emit(Instr::LoadConst(val));
+            }
+            HirExprKind::Var(id) => {
+                self.emit(Instr::LoadVar(id.0));
+            }
+            HirExprKind::Unary(op, e) => {
+                self.compile_expr(e)?;
+                match op {
+                    rustmat_parser::UnOp::Plus => {}
+                    rustmat_parser::UnOp::Minus => {
+                        self.emit(Instr::Neg);
+                    }
+                }
+            }
+            HirExprKind::Binary(a, op, b) => {
+                self.compile_expr(a)?;
+                self.compile_expr(b)?;
+                match op {
+                    rustmat_parser::BinOp::Add => self.emit(Instr::Add),
+                    rustmat_parser::BinOp::Sub => self.emit(Instr::Sub),
+                    rustmat_parser::BinOp::Mul => self.emit(Instr::Mul),
+                    rustmat_parser::BinOp::Div | rustmat_parser::BinOp::LeftDiv => {
+                        self.emit(Instr::Div)
+                    }
+                    rustmat_parser::BinOp::Pow => self.emit(Instr::Pow),
+                    rustmat_parser::BinOp::Colon => {
+                        return Err("colon operator not supported".into())
+                    }
+                };
+            }
+            HirExprKind::Range(..) => {
+                return Err("standalone range not supported".into());
+            }
+            HirExprKind::Matrix(_) | HirExprKind::Index(..) | HirExprKind::Colon => {
+                return Err("expression not supported".into());
+            }
+        }
+        Ok(())
+    }
+
+    fn patch(&mut self, idx: usize, instr: Instr) {
+        self.instructions[idx] = instr;
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Value {
+    Num(f64),
+}
+
+impl Value {
+    pub fn as_num(&self) -> f64 {
+        match *self {
+            Value::Num(n) => n,
+        }
+    }
+}
+
+pub fn interpret(bytecode: &Bytecode) -> Result<Vec<Value>, String> {
+    let mut stack: Vec<Value> = Vec::new();
+    let mut vars = vec![Value::Num(0.0); bytecode.var_count];
+    let mut pc: usize = 0;
+    while pc < bytecode.instructions.len() {
+        match bytecode.instructions[pc].clone() {
+            Instr::LoadConst(c) => stack.push(Value::Num(c)),
+            Instr::LoadVar(i) => stack.push(vars[i].clone()),
+            Instr::StoreVar(i) => {
+                let val = stack.pop().ok_or("stack underflow")?;
+                if i >= vars.len() {
+                    vars.resize(i + 1, Value::Num(0.0));
+                }
+                vars[i] = val;
+            }
+            Instr::Add => binary(&mut stack, |a, b| a + b)?,
+            Instr::Sub => binary(&mut stack, |a, b| a - b)?,
+            Instr::Mul => binary(&mut stack, |a, b| a * b)?,
+            Instr::Div => binary(&mut stack, |a, b| a / b)?,
+            Instr::Pow => binary(&mut stack, |a, b| a.powf(b))?,
+            Instr::Neg => unary(&mut stack, |a| -a)?,
+            Instr::LessEqual => {
+                let b = stack.pop().ok_or("stack underflow")?.as_num();
+                let a = stack.pop().ok_or("stack underflow")?.as_num();
+                stack.push(Value::Num(if a <= b { 1.0 } else { 0.0 }));
+            }
+            Instr::JumpIfFalse(target) => {
+                let cond = stack.pop().ok_or("stack underflow")?.as_num();
+                if cond == 0.0 {
+                    pc = target;
+                    continue;
+                }
+            }
+            Instr::Jump(target) => {
+                pc = target;
+                continue;
+            }
+            Instr::Pop => {
+                stack.pop();
+            }
+            Instr::Halt => break,
+        }
+        pc += 1;
+    }
+    Ok(vars)
+}
+
+fn binary<F>(stack: &mut Vec<Value>, f: F) -> Result<(), String>
+where
+    F: Fn(f64, f64) -> f64,
+{
+    let b = stack.pop().ok_or("stack underflow")?.as_num();
+    let a = stack.pop().ok_or("stack underflow")?.as_num();
+    stack.push(Value::Num(f(a, b)));
+    Ok(())
+}
+
+fn unary<F>(stack: &mut Vec<Value>, f: F) -> Result<(), String>
+where
+    F: Fn(f64) -> f64,
+{
+    let a = stack.pop().ok_or("stack underflow")?.as_num();
+    stack.push(Value::Num(f(a)));
+    Ok(())
+}
+
+pub fn execute(program: &HirProgram) -> Result<Vec<Value>, String> {
+    let bc = compile(program)?;
+    interpret(&bc)
+}

--- a/crates/rustmat-ignition/tests/interpreter.rs
+++ b/crates/rustmat-ignition/tests/interpreter.rs
@@ -1,0 +1,84 @@
+use rustmat_hir::lower;
+use rustmat_ignition::execute;
+use rustmat_parser::parse;
+
+#[test]
+fn arithmetic_and_assignment() {
+    let ast = parse("x=1+2; y=x*3;").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert_eq!(vars.len() >= 2, true);
+    assert_eq!(vars[0].as_num(), 3.0);
+    assert_eq!(vars[1].as_num(), 9.0);
+}
+
+#[test]
+fn while_loop_decrements() {
+    let ast = parse("x=3; y=0; while x; y=y+1; x=x-1; end").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert_eq!(vars[0].as_num(), 0.0); // x
+    assert_eq!(vars[1].as_num(), 3.0); // y
+}
+
+#[test]
+fn for_loop_sum() {
+    let ast = parse("s=0; for i=1:4; s=s+i; end").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert_eq!(vars[0].as_num(), 10.0);
+}
+
+#[test]
+fn continue_in_loop() {
+    let ast = parse("x=0; for i=1:3; if i-2; x=x+i; else; continue; end; end").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert_eq!(vars[0].as_num(), 4.0);
+}
+
+#[test]
+fn break_in_loop() {
+    let ast = parse("x=0; while 1; x=x+1; break; x=x+1; end").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert_eq!(vars[0].as_num(), 1.0);
+}
+
+#[test]
+fn range_with_step_errors() {
+    let ast = parse("for i=1:2:3; end").unwrap();
+    let hir = lower(&ast).unwrap();
+    assert!(execute(&hir).is_err());
+}
+
+#[test]
+fn unsupported_matrix_errors() {
+    let ast = parse("x=[1,2]").unwrap();
+    let hir = lower(&ast).unwrap();
+    assert!(execute(&hir).is_err());
+}
+
+#[test]
+fn for_loop_start_greater_than_end() {
+    let ast = parse("x=1; for i=3:1; x=2; end").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert_eq!(vars[0].as_num(), 1.0); // x unchanged
+}
+
+#[test]
+fn elseif_executes_correct_branch() {
+    let ast = parse("x=0; if 0; x=1; elseif 1; x=2; else; x=3; end").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert_eq!(vars[0].as_num(), 2.0);
+}
+
+#[test]
+fn else_branch_when_all_false() {
+    let ast = parse("x=0; if 0; x=1; elseif 0; x=2; else; x=3; end").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert_eq!(vars[0].as_num(), 3.0);
+}


### PR DESCRIPTION
## Summary
- support `elseif` clauses in the Ignition compiler
- mark interpreter milestone complete in PLAN
- log `elseif` support in the development plan
- test else/elseif behaviour

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6887226497508322bcad03beb63047f9