### PR TITLE
Adding ZMQ Transport for Jupyter Kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,6 +1457,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2403,6 +2404,15 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -4090,7 +4100,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "runmat"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "atty",
@@ -4124,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "runmat-accelerate"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -4140,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "runmat-accelerate-api"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -4148,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "runmat-builtins"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "inventory",
  "runmat-accelerate-api",
@@ -4160,7 +4170,7 @@ dependencies = [
 
 [[package]]
 name = "runmat-gc"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "criterion",
  "log",
@@ -4196,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "runmat-ignition"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "runmat-builtins",
  "runmat-gc",
@@ -4209,10 +4219,13 @@ dependencies = [
 
 [[package]]
 name = "runmat-kernel"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "chrono",
  "env_logger 0.11.8",
+ "futures",
+ "hex",
+ "hmac",
  "log",
  "runmat-builtins",
  "runmat-hir",
@@ -4224,6 +4237,7 @@ dependencies = [
  "runmat-snapshot",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -4233,14 +4247,14 @@ dependencies = [
 
 [[package]]
 name = "runmat-lexer"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "logos",
 ]
 
 [[package]]
 name = "runmat-macros"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "inventory",
  "proc-macro2",
@@ -4252,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "runmat-parser"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "logos",
  "runmat-lexer",
@@ -4261,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "runmat-plot"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "atty",
  "bytemuck",
@@ -4295,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "runmat-repl"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "env_logger 0.11.8",
@@ -4315,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "runmat-runtime"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "accelerate-src",
  "blas",
@@ -4339,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "runmat-snapshot"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4371,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "runmat-turbine"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "cranelift",
  "cranelift-codegen",
@@ -4889,6 +4903,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/crates/runmat-accelerate-api/Cargo.toml
+++ b/crates/runmat-accelerate-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-accelerate-api"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 
 [dependencies]

--- a/crates/runmat-accelerate/Cargo.toml
+++ b/crates/runmat-accelerate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-accelerate"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Pluggable GPU acceleration layer for RunMat (CUDA, ROCm, Metal, Vulkan/Spir-V)"

--- a/crates/runmat-builtins/Cargo.toml
+++ b/crates/runmat-builtins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-builtins"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Dystr Team"]
 license-file = "../LICENSE.md"

--- a/crates/runmat-gc/Cargo.toml
+++ b/crates/runmat-gc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-gc"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "Generational garbage collector for RunMat with optional pointer compression"
 authors = ["Dystr Team"]

--- a/crates/runmat-ignition/Cargo.toml
+++ b/crates/runmat-ignition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-ignition"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Dystr Team"]
 license-file = "../LICENSE.md"

--- a/crates/runmat-kernel/Cargo.toml
+++ b/crates/runmat-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-kernel"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Dystr Team"]
 license-file = "../LICENSE.md"
@@ -22,6 +22,10 @@ runmat-runtime = { workspace = true }
 runmat-repl = { workspace = true }
 runmat-snapshot = { workspace = true }
 runmat-plot = { workspace = true }
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+futures = "0.3"
 
 [features]
 default = ["jupyter"]

--- a/crates/runmat-kernel/src/lib.rs
+++ b/crates/runmat-kernel/src/lib.rs
@@ -12,6 +12,7 @@ pub mod execution;
 pub mod jupyter_plotting;
 pub mod protocol;
 pub mod server;
+pub mod transport;
 
 pub use connection::ConnectionInfo;
 pub use execution::ExecutionEngine;

--- a/crates/runmat-kernel/src/server.rs
+++ b/crates/runmat-kernel/src/server.rs
@@ -15,8 +15,6 @@ use crate::{
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
-#[allow(unused_imports)]
-use tokio::task::JoinHandle;
 
 /// Main kernel server managing all communication channels
 pub struct KernelServer {

--- a/crates/runmat-kernel/src/server.rs
+++ b/crates/runmat-kernel/src/server.rs
@@ -5,18 +5,25 @@
 
 use crate::{
     execution::{ExecutionStats, ExecutionStatus},
-    protocol::{ExecuteReply, ExecuteRequest, ExecutionState, JupyterMessage, MessageType},
+    protocol::{
+        ErrorContent, ExecuteReply, ExecuteRequest, ExecuteResult, ExecutionState, JupyterMessage,
+        MessageType, Status,
+    },
+    transport::{recv_jupyter_message, send_jupyter_message},
     ConnectionInfo, ExecutionEngine, KernelConfig, KernelError, KernelInfo, Result,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
+#[allow(unused_imports)]
 use tokio::task::JoinHandle;
 
 /// Main kernel server managing all communication channels
 pub struct KernelServer {
     /// Kernel configuration
     config: KernelConfig,
+    /// ZMQ context (must outlive all sockets)
+    ctx: Option<zmq::Context>,
     /// Execution engine
     engine: Arc<tokio::sync::Mutex<ExecutionEngine>>,
     /// Broadcast channel for status updates
@@ -24,7 +31,7 @@ pub struct KernelServer {
     /// Shutdown signal
     shutdown_tx: mpsc::Sender<()>,
     /// Server task handles
-    tasks: Vec<JoinHandle<Result<()>>>,
+    tasks: Vec<std::thread::JoinHandle<Result<()>>>,
     /// Message router for handling Jupyter protocol messages
     router: Option<Arc<MessageRouter>>,
 }
@@ -45,6 +52,7 @@ impl KernelServer {
 
         Self {
             config,
+            ctx: None,
             engine,
             status_tx,
             shutdown_tx,
@@ -60,24 +68,16 @@ impl KernelServer {
         // Validate connection info
         self.config.connection.validate()?;
 
-        // Create ZMQ context
+        // Create ZMQ context and keep it alive on self
         let ctx = zmq::Context::new();
+        self.ctx = Some(ctx.clone());
 
-        // Create and bind sockets
-        let shell_socket = ctx.socket(zmq::ROUTER)?;
-        shell_socket.bind(&self.config.connection.shell_url())?;
-
-        let iopub_socket = ctx.socket(zmq::PUB)?;
-        iopub_socket.bind(&self.config.connection.iopub_url())?;
-
-        let stdin_socket = ctx.socket(zmq::ROUTER)?;
-        stdin_socket.bind(&self.config.connection.stdin_url())?;
-
-        let control_socket = ctx.socket(zmq::ROUTER)?;
-        control_socket.bind(&self.config.connection.control_url())?;
-
-        let heartbeat_socket = ctx.socket(zmq::REP)?;
-        heartbeat_socket.bind(&self.config.connection.heartbeat_url())?;
+        // Precompute URLs; sockets will be opened/bound in their own threads
+        let shell_url = self.config.connection.shell_url();
+        let iopub_url = self.config.connection.iopub_url();
+        let stdin_url = self.config.connection.stdin_url();
+        let control_url = self.config.connection.control_url();
+        let heartbeat_url = self.config.connection.heartbeat_url();
 
         log::info!(
             "Kernel bound to ports: shell={}, iopub={}, stdin={}, control={}, hb={}",
@@ -104,11 +104,341 @@ impl KernelServer {
         // Store router for the server to use
         self.router = Some(Arc::clone(&router));
 
-        // Send initial status
-        let _ = self.status_tx.send(ExecutionState::Starting);
+        // Channel to serialize IOPub publishing onto a single ZMQ socket/thread
+        let (iopub_tx, mut iopub_rx) = tokio::sync::mpsc::unbounded_channel::<JupyterMessage>();
 
-        // Kernel is now idle and ready
-        let _ = self.status_tx.send(ExecutionState::Idle);
+        // Spawn IOPub publisher task
+        let session_for_iopub = self.config.session_id.clone();
+        let key_for_iopub = self.config.connection.key.clone();
+        let scheme_for_iopub = self.config.connection.signature_scheme.clone();
+        let ctx_iopub = ctx.clone();
+        let iopub_task = std::thread::spawn(move || -> Result<()> {
+            let socket = ctx_iopub.socket(zmq::PUB).map_err(KernelError::Zmq)?;
+            socket.bind(&iopub_url).map_err(KernelError::Zmq)?;
+            while let Some(mut msg) = iopub_rx.blocking_recv() {
+                msg.header.session = session_for_iopub.clone();
+                if msg.parent_header.is_none() {
+                    msg.parent_header = Some(crate::protocol::MessageHeader::new(
+                        MessageType::Status,
+                        &session_for_iopub,
+                    ));
+                }
+                if let Err(e) =
+                    send_jupyter_message(&socket, &[], &key_for_iopub, &scheme_for_iopub, &msg)
+                {
+                    log::error!("Failed to publish IOPub message: {e}");
+                }
+            }
+            Ok(())
+        });
+        self.tasks.push(iopub_task);
+
+        // Spawn Heartbeat echo task (REP -> echo request)
+        let ctx_hb = ctx.clone();
+        let hb_task = std::thread::spawn(move || -> Result<()> {
+            let socket = ctx_hb.socket(zmq::REP).map_err(KernelError::Zmq)?;
+            socket.bind(&heartbeat_url).map_err(KernelError::Zmq)?;
+            loop {
+                let msg = socket.recv_multipart(0).map_err(KernelError::Zmq)?;
+                socket.send_multipart(msg, 0).map_err(KernelError::Zmq)?;
+            }
+        });
+        self.tasks.push(hb_task);
+
+        // Spawn Shell loop
+        let engine_shell = Arc::clone(&self.engine);
+        let router_shell = Arc::clone(&router);
+        let session_id_shell = self.config.session_id.clone();
+        let key_shell = self.config.connection.key.clone();
+        let scheme_shell = self.config.connection.signature_scheme.clone();
+        let iopub_tx_shell = iopub_tx.clone();
+        let ctx_shell = ctx.clone();
+        let shell_task = std::thread::spawn(move || -> Result<()> {
+            let shell_socket = ctx_shell.socket(zmq::ROUTER).map_err(KernelError::Zmq)?;
+            shell_socket.bind(&shell_url).map_err(KernelError::Zmq)?;
+            loop {
+                let (ids, msg) = recv_jupyter_message(&shell_socket, &key_shell, &scheme_shell)?;
+
+                match msg.header.msg_type.clone() {
+                    MessageType::KernelInfoRequest => {
+                        // IOPub busy
+                        let status_busy = Status {
+                            execution_state: ExecutionState::Busy,
+                        };
+                        let mut status_msg = JupyterMessage::reply(
+                            &msg,
+                            MessageType::Status,
+                            serde_json::to_value(status_busy)?,
+                        );
+                        status_msg.header.session = session_id_shell.clone();
+                        let _ = iopub_tx_shell.send(status_msg);
+
+                        let mut reply = futures::executor::block_on(
+                            router_shell.handle_kernel_info_request(&msg),
+                        )?;
+                        reply.header.session = session_id_shell.clone();
+                        send_jupyter_message(
+                            &shell_socket,
+                            &ids,
+                            &key_shell,
+                            &scheme_shell,
+                            &reply,
+                        )?;
+
+                        // IOPub idle
+                        let status_idle = Status {
+                            execution_state: ExecutionState::Idle,
+                        };
+                        let mut status_msg = JupyterMessage::reply(
+                            &msg,
+                            MessageType::Status,
+                            serde_json::to_value(status_idle)?,
+                        );
+                        status_msg.header.session = session_id_shell.clone();
+                        let _ = iopub_tx_shell.send(status_msg);
+                    }
+                    MessageType::ExecuteRequest => {
+                        let exec_req: ExecuteRequest = serde_json::from_value(msg.content.clone())?;
+
+                        // IOPub busy
+                        let mut status_msg = JupyterMessage::reply(
+                            &msg,
+                            MessageType::Status,
+                            serde_json::to_value(Status {
+                                execution_state: ExecutionState::Busy,
+                            })?,
+                        );
+                        status_msg.header.session = session_id_shell.clone();
+                        let _ = iopub_tx_shell.send(status_msg);
+
+                        // Predict next count and publish execute_input
+                        let predicted = {
+                            let eng = futures::executor::block_on(engine_shell.lock());
+                            eng.execution_count() + 1
+                        };
+                        let mut input_msg = JupyterMessage::reply(
+                            &msg,
+                            MessageType::ExecuteInput,
+                            serde_json::json!({"code": exec_req.code, "execution_count": predicted}),
+                        );
+                        input_msg.header.session = session_id_shell.clone();
+                        let _ = iopub_tx_shell.send(input_msg);
+
+                        let exec_result = {
+                            let mut eng = futures::executor::block_on(engine_shell.lock());
+                            let req_again: ExecuteRequest =
+                                serde_json::from_value(msg.content.clone())?;
+                            eng.execute(&req_again.code)
+                                .map_err(|e| KernelError::Execution(e.to_string()))?
+                        };
+
+                        let status = match exec_result.status {
+                            ExecutionStatus::Success => crate::protocol::ExecutionStatus::Ok,
+                            ExecutionStatus::Error => crate::protocol::ExecutionStatus::Error,
+                            ExecutionStatus::Interrupted | ExecutionStatus::Timeout => {
+                                crate::protocol::ExecutionStatus::Abort
+                            }
+                        };
+
+                        let exec_count = {
+                            let eng = futures::executor::block_on(engine_shell.lock());
+                            eng.execution_count()
+                        };
+
+                        match exec_result.status {
+                            ExecutionStatus::Success => {
+                                if let Some(val) = exec_result.result {
+                                    let mut data = std::collections::HashMap::new();
+                                    data.insert(
+                                        "text/plain".to_string(),
+                                        serde_json::json!(val.to_string()),
+                                    );
+                                    let res = ExecuteResult {
+                                        execution_count: exec_count,
+                                        data,
+                                        metadata: std::collections::HashMap::new(),
+                                    };
+                                    let mut res_msg = JupyterMessage::reply(
+                                        &msg,
+                                        MessageType::ExecuteResult,
+                                        serde_json::to_value(res)?,
+                                    );
+                                    res_msg.header.session = session_id_shell.clone();
+                                    let _ = iopub_tx_shell.send(res_msg);
+                                }
+                            }
+                            ExecutionStatus::Error => {
+                                if let Some(err) = exec_result.error {
+                                    let ec = ErrorContent {
+                                        ename: err.error_type,
+                                        evalue: err.message,
+                                        traceback: err.traceback,
+                                    };
+                                    let mut err_msg = JupyterMessage::reply(
+                                        &msg,
+                                        MessageType::Error,
+                                        serde_json::to_value(ec)?,
+                                    );
+                                    err_msg.header.session = session_id_shell.clone();
+                                    let _ = iopub_tx_shell.send(err_msg);
+                                }
+                            }
+                            _ => {}
+                        }
+
+                        let reply = ExecuteReply {
+                            status,
+                            execution_count: exec_count,
+                            user_expressions: HashMap::new(),
+                            payload: Vec::new(),
+                        };
+                        let mut reply_msg = JupyterMessage::reply(
+                            &msg,
+                            MessageType::ExecuteReply,
+                            serde_json::to_value(reply)?,
+                        );
+                        reply_msg.header.session = session_id_shell.clone();
+                        send_jupyter_message(
+                            &shell_socket,
+                            &ids,
+                            &key_shell,
+                            &scheme_shell,
+                            &reply_msg,
+                        )?;
+
+                        // IOPub idle
+                        let mut status_msg = JupyterMessage::reply(
+                            &msg,
+                            MessageType::Status,
+                            serde_json::to_value(Status {
+                                execution_state: ExecutionState::Idle,
+                            })?,
+                        );
+                        status_msg.header.session = session_id_shell.clone();
+                        let _ = iopub_tx_shell.send(status_msg);
+                    }
+                    other => {
+                        log::warn!("Unhandled shell message: {:?}", other);
+                        if let Ok(Some(reply)) = futures::executor::block_on(async {
+                            router_shell.route_message(&msg).await
+                        }) {
+                            send_jupyter_message(
+                                &shell_socket,
+                                &ids,
+                                &key_shell,
+                                &scheme_shell,
+                                &reply,
+                            )?;
+                        }
+                    }
+                }
+            }
+        });
+        self.tasks.push(shell_task);
+
+        // Control loop
+        let router_ctrl = Arc::clone(&router);
+        let key_ctrl = self.config.connection.key.clone();
+        let scheme_ctrl = self.config.connection.signature_scheme.clone();
+        let session_ctrl = self.config.session_id.clone();
+        let iopub_tx_ctrl = iopub_tx.clone();
+        let ctx_ctrl = ctx.clone();
+        let control_task = std::thread::spawn(move || -> Result<()> {
+            let control_socket = ctx_ctrl.socket(zmq::ROUTER).map_err(KernelError::Zmq)?;
+            control_socket
+                .bind(&control_url)
+                .map_err(KernelError::Zmq)?;
+            loop {
+                let (ids, msg) = recv_jupyter_message(&control_socket, &key_ctrl, &scheme_ctrl)?;
+                match msg.header.msg_type.clone() {
+                    MessageType::ShutdownRequest | MessageType::InterruptRequest => {
+                        let mut status_msg = JupyterMessage::reply(
+                            &msg,
+                            MessageType::Status,
+                            serde_json::to_value(Status {
+                                execution_state: ExecutionState::Busy,
+                            })?,
+                        );
+                        status_msg.header.session = session_ctrl.clone();
+                        let _ = iopub_tx_ctrl.send(status_msg);
+
+                        let mut reply =
+                            futures::executor::block_on(router_ctrl.route_message(&msg))?
+                                .unwrap_or_else(|| {
+                                    JupyterMessage::reply(
+                                        &msg,
+                                        MessageType::InterruptReply,
+                                        serde_json::json!({"status":"ok"}),
+                                    )
+                                });
+                        reply.header.session = session_ctrl.clone();
+                        send_jupyter_message(
+                            &control_socket,
+                            &ids,
+                            &key_ctrl,
+                            &scheme_ctrl,
+                            &reply,
+                        )?;
+
+                        let mut status_msg = JupyterMessage::reply(
+                            &msg,
+                            MessageType::Status,
+                            serde_json::to_value(Status {
+                                execution_state: ExecutionState::Idle,
+                            })?,
+                        );
+                        status_msg.header.session = session_ctrl.clone();
+                        let _ = iopub_tx_ctrl.send(status_msg);
+                    }
+                    _ => {}
+                }
+            }
+        });
+        self.tasks.push(control_task);
+
+        // Stdin loop
+        let key_stdin = self.config.connection.key.clone();
+        let scheme_stdin = self.config.connection.signature_scheme.clone();
+        let session_stdin = self.config.session_id.clone();
+        let ctx_stdin = ctx.clone();
+        let stdin_task = std::thread::spawn(move || -> Result<()> {
+            let stdin_socket = ctx_stdin.socket(zmq::ROUTER).map_err(KernelError::Zmq)?;
+            stdin_socket.bind(&stdin_url).map_err(KernelError::Zmq)?;
+            loop {
+                let (ids, msg) = recv_jupyter_message(&stdin_socket, &key_stdin, &scheme_stdin)?;
+                if matches!(msg.header.msg_type, MessageType::InputRequest) {
+                    let mut reply = JupyterMessage::reply(
+                        &msg,
+                        MessageType::InputReply,
+                        serde_json::json!({"value": ""}),
+                    );
+                    reply.header.session = session_stdin.clone();
+                    send_jupyter_message(&stdin_socket, &ids, &key_stdin, &scheme_stdin, &reply)?;
+                }
+            }
+        });
+        self.tasks.push(stdin_task);
+
+        // Initial status via IOPub: starting -> idle
+        let mut start_msg = JupyterMessage::new(
+            MessageType::Status,
+            &self.config.session_id,
+            serde_json::to_value(Status {
+                execution_state: ExecutionState::Starting,
+            })?,
+        );
+        start_msg.parent_header = None;
+        let _ = iopub_tx.send(start_msg);
+
+        let mut idle_msg = JupyterMessage::new(
+            MessageType::Status,
+            &self.config.session_id,
+            serde_json::to_value(Status {
+                execution_state: ExecutionState::Idle,
+            })?,
+        );
+        idle_msg.parent_header = None;
+        let _ = iopub_tx.send(idle_msg);
 
         log::info!("RunMat kernel is ready for connections");
 
@@ -126,8 +456,10 @@ impl KernelServer {
 
         // Wait for all tasks to complete
         for task in self.tasks.drain(..) {
-            if let Err(e) = task.await {
-                log::error!("Task failed during shutdown: {e:?}");
+            match task.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => log::error!("Task failed during shutdown: {e:?}"),
+                Err(e) => log::error!("Task panicked: {e:?}"),
             }
         }
 

--- a/crates/runmat-kernel/src/transport.rs
+++ b/crates/runmat-kernel/src/transport.rs
@@ -1,0 +1,212 @@
+//! ZMQ transport and Jupyter v5 framing utilities
+//!
+//! Implements multipart message encoding/decoding with HMAC signatures
+//! according to the Jupyter messaging protocol. Used by the kernel server
+//! to read requests from the shell/control channels and publish results on
+//! the IOPub channel.
+
+use crate::protocol::{JupyterMessage, MessageHeader};
+use crate::{KernelError, Result};
+use hmac::{Hmac, Mac};
+use serde_json::Value as JsonValue;
+use sha2::Sha256;
+use std::env;
+
+const DELIM: &str = "<IDS|MSG>";
+
+/// Signature algorithm supported by the kernel
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SignatureAlg {
+    None,
+    HmacSha256,
+}
+
+impl SignatureAlg {
+    pub fn from_scheme(scheme: &str) -> Self {
+        match scheme.to_ascii_lowercase().as_str() {
+            "hmac-sha256" => SignatureAlg::HmacSha256,
+            _ => SignatureAlg::None,
+        }
+    }
+}
+
+/// Compute Jupyter message signature for the 4 JSON frames
+fn compute_signature(alg: SignatureAlg, key: &[u8], frames: &[Vec<u8>]) -> String {
+    match alg {
+        SignatureAlg::None => String::new(),
+        SignatureAlg::HmacSha256 => {
+            let mut mac = Hmac::<Sha256>::new_from_slice(key).unwrap();
+            for frame in frames {
+                mac.update(frame);
+            }
+            let bytes = mac.finalize().into_bytes();
+            hex::encode(bytes)
+        }
+    }
+}
+
+/// Decode a multipart message received from a ZMQ socket into routing identities
+/// and a structured `JupyterMessage`. Verifies the HMAC signature if a key exists.
+pub fn recv_jupyter_message(
+    socket: &zmq::Socket,
+    key: &str,
+    scheme: &str,
+) -> Result<(Vec<Vec<u8>>, JupyterMessage)> {
+    let trace = env::var("RUNMAT_KERNEL_ZMQ_TRACE").is_ok();
+    // Receive all frames for one message
+    let frames = socket.recv_multipart(0).map_err(KernelError::Zmq)?;
+
+    // Split identities and content frames
+    let mut ids: Vec<Vec<u8>> = Vec::new();
+    let mut idx = 0usize;
+    while idx < frames.len() {
+        if frames[idx] == DELIM.as_bytes() {
+            idx += 1; // skip delim
+            break;
+        }
+        ids.push(frames[idx].clone());
+        idx += 1;
+    }
+
+    if idx >= frames.len() {
+        return Err(KernelError::Protocol(
+            "Missing <IDS|MSG> delimiter".to_string(),
+        ));
+    }
+
+    // We require at least signature + 4 JSON frames
+    if frames.len() - idx < 5 {
+        return Err(KernelError::Protocol(
+            "Incomplete message (expected signature + 4 JSON frames)".to_string(),
+        ));
+    }
+
+    let signature = &frames[idx];
+    let header = &frames[idx + 1];
+    let parent_header = &frames[idx + 2];
+    let metadata = &frames[idx + 3];
+    let content = &frames[idx + 4];
+    let buffers: Vec<Vec<u8>> = frames[idx + 5..].to_vec();
+
+    // Validate signature if key present
+    let alg = if key.is_empty() {
+        SignatureAlg::None
+    } else {
+        SignatureAlg::from_scheme(scheme)
+    };
+
+    if !matches!(alg, SignatureAlg::None) {
+        let expected = compute_signature(
+            alg,
+            key.as_bytes(),
+            &[
+                header.clone(),
+                parent_header.clone(),
+                metadata.clone(),
+                content.clone(),
+            ],
+        );
+        let provided = String::from_utf8_lossy(signature).to_string();
+        if expected != provided {
+            if trace {
+                eprintln!(
+                    "[ZMQ-TRACE] signature mismatch: expected {} provided {}",
+                    expected, provided
+                );
+            }
+            return Err(KernelError::Protocol("Invalid HMAC signature".to_string()));
+        }
+    }
+
+    // Build structured message
+    let header: MessageHeader = serde_json::from_slice(header)?;
+    // Parent header can be {} or null. Treat both as None.
+    let parent_val: JsonValue = serde_json::from_slice(parent_header)?;
+    let parent_header: Option<MessageHeader> = match parent_val {
+        JsonValue::Null => None,
+        JsonValue::Object(ref m) if m.is_empty() => None,
+        other => Some(serde_json::from_value(other).map_err(KernelError::Json)?),
+    };
+    let metadata_map: serde_json::Map<String, JsonValue> = serde_json::from_slice(metadata)?;
+    let metadata: std::collections::HashMap<String, JsonValue> = metadata_map.into_iter().collect();
+    let content: JsonValue = serde_json::from_slice(content)?;
+
+    let msg = JupyterMessage {
+        header,
+        parent_header,
+        metadata,
+        content,
+        buffers,
+    };
+
+    if trace {
+        eprintln!(
+            "[ZMQ-TRACE] RECV type={:?} session={}",
+            msg.header.msg_type, msg.header.session
+        );
+    }
+
+    Ok((ids, msg))
+}
+
+/// Encode and send a `JupyterMessage` with given routing identities on a ZMQ socket.
+pub fn send_jupyter_message(
+    socket: &zmq::Socket,
+    ids: &[Vec<u8>],
+    key: &str,
+    scheme: &str,
+    msg: &JupyterMessage,
+) -> Result<()> {
+    let trace = env::var("RUNMAT_KERNEL_ZMQ_TRACE").is_ok();
+    let alg = if key.is_empty() {
+        SignatureAlg::None
+    } else {
+        SignatureAlg::from_scheme(scheme)
+    };
+
+    // Serialize frames
+    let header = serde_json::to_vec(&msg.header)?;
+    let parent_header = if let Some(ref p) = msg.parent_header {
+        serde_json::to_vec(p)?
+    } else {
+        // Parent header can be an empty JSON object according to protocol
+        serde_json::to_vec(&serde_json::json!({}))?
+    };
+    let metadata = serde_json::to_vec(&msg.metadata)?;
+    let content = serde_json::to_vec(&msg.content)?;
+
+    let signature = compute_signature(
+        alg,
+        key.as_bytes(),
+        &[
+            header.clone(),
+            parent_header.clone(),
+            metadata.clone(),
+            content.clone(),
+        ],
+    );
+
+    // Assemble multipart frames
+    let mut frames: Vec<Vec<u8>> = Vec::new();
+    frames.extend_from_slice(ids);
+    frames.push(DELIM.as_bytes().to_vec());
+    frames.push(signature.into_bytes());
+    frames.push(header);
+    frames.push(parent_header);
+    frames.push(metadata);
+    frames.push(content);
+    frames.extend_from_slice(&msg.buffers);
+
+    socket
+        .send_multipart(frames, 0)
+        .map_err(KernelError::Zmq)?;
+
+    if trace {
+        eprintln!(
+            "[ZMQ-TRACE] SEND type={:?} session={}",
+            msg.header.msg_type, msg.header.session
+        );
+    }
+
+    Ok(())
+}

--- a/crates/runmat-kernel/src/transport.rs
+++ b/crates/runmat-kernel/src/transport.rs
@@ -197,9 +197,7 @@ pub fn send_jupyter_message(
     frames.push(content);
     frames.extend_from_slice(&msg.buffers);
 
-    socket
-        .send_multipart(frames, 0)
-        .map_err(KernelError::Zmq)?;
+    socket.send_multipart(frames, 0).map_err(KernelError::Zmq)?;
 
     if trace {
         eprintln!(

--- a/crates/runmat-kernel/tests/zmq_integration.rs
+++ b/crates/runmat-kernel/tests/zmq_integration.rs
@@ -1,0 +1,148 @@
+use runmat_kernel::{
+    protocol::{ExecuteRequest, JupyterMessage, MessageType},
+    transport::{recv_jupyter_message, send_jupyter_message},
+    KernelConfig, KernelServer,
+};
+use std::collections::HashMap;
+
+fn poll_readable(socket: &zmq::Socket, timeout_ms: i64) -> bool {
+    // Fallback polling via get_events since PollItem construction is limited
+    let start = std::time::Instant::now();
+    loop {
+        if let Ok(ev) = socket.get_events() {
+            if ev.contains(zmq::POLLIN) {
+                return true;
+            }
+        }
+        if start.elapsed().as_millis() as i64 >= timeout_ms {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn zmq_kernel_info_roundtrip() {
+    let mut config = KernelConfig::default();
+    config.connection.assign_ports().unwrap();
+
+    let mut server = KernelServer::new(config.clone());
+    server.start().await.unwrap();
+
+    // Setup client sockets
+    let ctx = zmq::Context::new();
+    let shell = ctx.socket(zmq::DEALER).unwrap();
+    shell.set_rcvtimeo(5000).unwrap();
+    shell.set_sndtimeo(5000).unwrap();
+    shell.connect(&config.connection.shell_url()).unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    // Build and send KernelInfoRequest
+    let req = JupyterMessage::new(
+        MessageType::KernelInfoRequest,
+        &config.session_id,
+        serde_json::json!({}),
+    );
+    send_jupyter_message(
+        &shell,
+        &[],
+        &config.connection.key,
+        &config.connection.signature_scheme,
+        &req,
+    )
+    .unwrap();
+
+    // Wait for reply
+    assert!(poll_readable(&shell, 5000));
+    let (_ids, msg) = recv_jupyter_message(
+        &shell,
+        &config.connection.key,
+        &config.connection.signature_scheme,
+    )
+    .expect("kernel_info reply");
+    assert_eq!(msg.header.msg_type, MessageType::KernelInfoReply);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn zmq_execute_request_and_iopub() {
+    let mut config = KernelConfig::default();
+    config.connection.assign_ports().unwrap();
+
+    let mut server = KernelServer::new(config.clone());
+    server.start().await.unwrap();
+
+    let ctx = zmq::Context::new();
+    let shell = ctx.socket(zmq::DEALER).unwrap();
+    shell.connect(&config.connection.shell_url()).unwrap();
+
+    let iopub = ctx.socket(zmq::SUB).unwrap();
+    iopub.set_rcvtimeo(5000).unwrap();
+    iopub.set_subscribe(b"").unwrap();
+    iopub.connect(&config.connection.iopub_url()).unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    // Heartbeat check
+    let hb = ctx.socket(zmq::REQ).unwrap();
+    hb.set_rcvtimeo(2000).unwrap();
+    hb.set_sndtimeo(2000).unwrap();
+    hb.connect(&config.connection.heartbeat_url()).unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    hb.send("ping", 0).unwrap();
+    let pong = hb.recv_string(0).unwrap().unwrap();
+    assert_eq!(pong, "ping");
+
+    let exec_req = ExecuteRequest {
+        code: "a = 10".to_string(),
+        silent: false,
+        store_history: true,
+        user_expressions: HashMap::new(),
+        allow_stdin: false,
+        stop_on_error: false,
+    };
+    let req = JupyterMessage::new(
+        MessageType::ExecuteRequest,
+        &config.session_id,
+        serde_json::to_value(&exec_req).unwrap(),
+    );
+    send_jupyter_message(
+        &shell,
+        &[],
+        &config.connection.key,
+        &config.connection.signature_scheme,
+        &req,
+    )
+    .unwrap();
+
+    // Expect a shell reply and some IOPub traffic
+    assert!(poll_readable(&shell, 5000));
+    let (_ids, reply) = recv_jupyter_message(
+        &shell,
+        &config.connection.key,
+        &config.connection.signature_scheme,
+    )
+    .expect("execute reply");
+    assert_eq!(reply.header.msg_type, MessageType::ExecuteReply);
+
+    // Drain IOPub until we see either ExecuteResult or Error
+    let mut saw_any = false;
+    let mut attempts = 0;
+    while attempts < 50 {
+        if poll_readable(&iopub, 200) {
+            let (_id, msg) = recv_jupyter_message(
+                &iopub,
+                &config.connection.key,
+                &config.connection.signature_scheme,
+            )
+            .expect("iopub message");
+            match msg.header.msg_type {
+                MessageType::ExecuteResult | MessageType::Error => {
+                    saw_any = true;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        attempts += 1;
+    }
+    assert!(saw_any, "expected ExecuteResult or Error on IOPub");
+}

--- a/crates/runmat-lexer/Cargo.toml
+++ b/crates/runmat-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-lexer"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Dystr Team"]
 license-file = "../LICENSE.md"

--- a/crates/runmat-macros/Cargo.toml
+++ b/crates/runmat-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-macros"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Dystr Team"]
 license-file = "../LICENSE.md"

--- a/crates/runmat-parser/Cargo.toml
+++ b/crates/runmat-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-parser"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Dystr Team"]
 license-file = "../LICENSE.md"

--- a/crates/runmat-plot/Cargo.toml
+++ b/crates/runmat-plot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-plot"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Dystr Team"]
 license-file = "../LICENSE.md"

--- a/crates/runmat-repl/Cargo.toml
+++ b/crates/runmat-repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-repl"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Dystr Team"]
 license-file = "../LICENSE.md"

--- a/crates/runmat-runtime/Cargo.toml
+++ b/crates/runmat-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-runtime"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Dystr Team"]
 license-file = "../LICENSE.md"

--- a/crates/runmat-snapshot/Cargo.toml
+++ b/crates/runmat-snapshot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-snapshot"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Dystr Team"]
 description = "High-performance snapshot creator for preloading RunMat standard library"

--- a/crates/runmat-turbine/Cargo.toml
+++ b/crates/runmat-turbine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat-turbine"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "Cranelift-based JIT compiler for RunMat - the optimizing tier of our V8-inspired execution model"
 authors = ["Dystr Team"]

--- a/runmat/Cargo.toml
+++ b/runmat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runmat"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "High-performance MATLAB/Octave runtime with Jupyter kernel support"
 authors = ["Dystr Team"]


### PR DESCRIPTION
This adds a Jupyter v5 ZMQ transport (HMAC framing) and refactors the kernel to a thread-per-socket server with a persistent ZMQ context. It implements shell/control/stdin/heartbeat/IOPub loops and adds headless ZMQ tests for kernel_info and execute (incl. IOPub status/result). 

Note: some of the message frames; e.g., HistoryRequest/Inspect/Complete are not implemented yet. 