### PR TITLE
Integrate newsletter signup into blog post footers

### DIFF
--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { BlogLayout } from '@/components/BlogLayout';
+import NewsletterCta from '@/components/NewsletterCta';
 
 interface BlogPost {
   slug: string;
@@ -94,6 +95,15 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     >
       <MarkdownRenderer source={post.content} />
       
+      {/* Newsletter CTA specific to blog posts */}
+      <div className="mt-16">
+        <NewsletterCta
+          title="Enjoyed this post? Join the newsletter"
+          description="Monthly updates on RunMat, Rust internals, and performance tips."
+          align="center"
+        />
+      </div>
+
       <div className="mt-16 not-prose">
         <Card>
           <CardContent className="p-6 text-center">

--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import { Heart } from "lucide-react";
 import { SiGithub } from "react-icons/si";
 import Logo from "@/components/Logo";
-import SubscribeForm from "@/components/SubscribeForm";
+import NewsletterCta from "@/components/NewsletterCta";
 
 export default function Footer() {
   // Default to plain Dystr URL during SSR; hydrate with UTM params on client
@@ -39,7 +39,12 @@ export default function Footer() {
           <p className="text-left text-sm leading-loose text-muted-foreground">
             A modern, high-performance runtime for MATLAB and GNU Octave code.
           </p>
-          <div className="w-full"><SubscribeForm /></div>
+          <NewsletterCta
+            title="Subscribe to our newsletter"
+            description="Get updates on releases, benchmarks, and deep dives."
+            align="left"
+            className="w-full"
+          />
         </div>
         <div className="flex items-center gap-4 md:flex-[0_0_auto] absolute right-4 top-4 md:static">
           <Link

--- a/website/components/NewsletterCta.tsx
+++ b/website/components/NewsletterCta.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React from "react";
+import SubscribeForm from "@/components/SubscribeForm";
+
+type NewsletterCtaProps = {
+  title?: string;
+  description?: string;
+  align?: "left" | "center";
+  className?: string;
+};
+
+export default function NewsletterCta({
+  title,
+  description,
+  align = "left",
+  className = "",
+}: NewsletterCtaProps) {
+  const textAlignClass = align === "center" ? "text-center" : "text-left";
+  const formWrapClass = align === "center" ? "flex justify-center" : "";
+
+  return (
+    <section className={`not-prose ${className}`} aria-label="Newsletter signup">
+      {(title || description) && (
+        <div className={`${textAlignClass} mb-4`}>
+          {title && (
+            <h3 className="text-lg font-semibold">{title}</h3>
+          )}
+          {description && (
+            <p className="text-sm text-muted-foreground mt-1">{description}</p>
+          )}
+        </div>
+      )}
+      <div className={formWrapClass}>
+        <SubscribeForm />
+      </div>
+    </section>
+  );
+}
+


### PR DESCRIPTION
Add a reusable newsletter CTA component to blog posts and refactor the site footer to use it, maximizing reuse.

---
<a href="https://cursor.com/background-agent?bcId=bc-54da5c9a-3425-4467-adb8-951757e581ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54da5c9a-3425-4467-adb8-951757e581ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

