### PR TITLE
Create reusable table of contents component

### DIFF
--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import matter from 'gray-matter';
 import { MarkdownRenderer } from '@/components/MarkdownRenderer';
+import { TableOfContents } from '@/components/TableOfContents';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 
@@ -93,36 +94,43 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
       author={post.frontmatter.author}
       tags={post.frontmatter.tags}
     >
-      <MarkdownRenderer source={post.content} />
-      
-      {/* Newsletter CTA specific to blog posts */}
-      <div className="mt-16">
-        <NewsletterCta
-          title="Enjoyed this post? Join the newsletter"
-          description="Monthly updates on RunMat, Rust internals, and performance tips."
-          align="center"
-        />
-      </div>
+      <div className="grid lg:grid-cols-[minmax(0,1fr)_260px] gap-8">
+        <article className="prose dark:prose-invert max-w-none scroll-smooth">
+          <MarkdownRenderer source={post.content} />
+          
+          {/* Newsletter CTA specific to blog posts */}
+          <div className="mt-16">
+            <NewsletterCta
+              title="Enjoyed this post? Join the newsletter"
+              description="Monthly updates on RunMat, Rust internals, and performance tips."
+              align="center"
+            />
+          </div>
 
-      <div className="mt-16 not-prose">
-        <Card>
-          <CardContent className="p-6 text-center">
-            <h3 className="text-lg font-semibold mb-3">
-              Ready to try RunMat?
-            </h3>
-            <p className="text-muted-foreground mb-4">
-              Get started with the modern MATLAB runtime today.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              <Button asChild>
-                <Link href="/download">Download RunMat</Link>
-              </Button>
-              <Button variant="outline" asChild>
-                <Link href="/docs/getting-started">Get Started</Link>
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+          <div className="mt-16 not-prose">
+            <Card>
+              <CardContent className="p-6 text-center">
+                <h3 className="text-lg font-semibold mb-3">
+                  Ready to try RunMat?
+                </h3>
+                <p className="text-muted-foreground mb-4">
+                  Get started with the modern MATLAB runtime today.
+                </p>
+                <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                  <Button asChild>
+                    <Link href="/download">Download RunMat</Link>
+                  </Button>
+                  <Button variant="outline" asChild>
+                    <Link href="/docs/getting-started">Get Started</Link>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </article>
+        <aside className="hidden lg:block">
+          <TableOfContents source={post.content} />
+        </aside>
       </div>
     </BlogLayout>
   );

--- a/website/app/docs/[...slug]/page.tsx
+++ b/website/app/docs/[...slug]/page.tsx
@@ -7,6 +7,7 @@ import { DocsContentSwitch } from "@/components/DocsContentSwitch";
 import { DocsArticleVisibility } from "@/components/DocsArticleVisibility";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { slugifyHeading } from "@/lib/utils";
+import { TableOfContents } from "@/components/TableOfContents";
 
 // Polyfill URL.canParse for Node environments that don't support it yet (e.g., Node 18)
 const _u = URL;
@@ -75,7 +76,6 @@ export default async function DocPage({ params }: { params: Promise<{ slug?: str
   }
   if (!source) notFound();
   const crumbs = findPathBySlug(slug) ?? [];
-  const headings = extractHeadings(source);
   return (
     <div className="grid lg:grid-cols-[minmax(0,1fr)_260px] gap-8">
       <article className="prose dark:prose-invert max-w-none scroll-smooth">
@@ -103,43 +103,10 @@ export default async function DocPage({ params }: { params: Promise<{ slug?: str
         <DocsContentSwitch source={source} />
       </article>
       <aside className="hidden lg:block">
-        <div className="sticky top-24">
-          <div className="text-sm font-semibold text-foreground/90 mb-2">On this page</div>
-          <ul className="text-sm space-y-2">
-            {headings.map((h, i) => (
-              <li key={i} className={h.depth > 2 ? "pl-4" : undefined}>
-                <a href={`#${h.id}`} className="text-muted-foreground hover:text-foreground">
-                  {h.text}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
+        <TableOfContents source={source} />
       </aside>
     </div>
   );
-}
-
-type Heading = { depth: number; text: string; id: string };
-
-function extractHeadings(md: string): Heading[] {
-  const lines = md.split(/\r?\n/);
-  const out: Heading[] = [];
-  let inFence = false;
-  for (const raw of lines) {
-    const line = raw.trim();
-    if (/^```/.test(line)) { inFence = !inFence; continue; }
-    if (inFence) continue; // ignore code fences
-    // Support ATX-style headings (## .. ######) and Setext-style (underlines of --- or === for previous line)
-    const m = /^(#{2,6})\s+(.+)$/.exec(line);
-    if (!m) continue;
-    const depth = m[1].length; // 2..6
-    // Remove backticks and inline code markers
-    const text = m[2].replace(/`/g, "");
-    const id = slugifyHeading(text);
-    out.push({ depth, text, id });
-  }
-  return out;
 }
 
 // Map well-known slug prefixes to repo files when not present in the manifest

--- a/website/components/TableOfContents.tsx
+++ b/website/components/TableOfContents.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { slugifyHeading } from "@/lib/utils";
+
+type Heading = { depth: number; text: string; id: string };
+
+function extractHeadings(md: string): Heading[] {
+  const lines = md.split(/\r?\n/);
+  const out: Heading[] = [];
+  let inFence = false;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (/^```/.test(line)) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    const m = /^(#{2,6})\s+(.+)$/.exec(line);
+    if (!m) continue;
+    const depth = m[1].length;
+    const text = m[2].replace(/`/g, "");
+    const id = slugifyHeading(text);
+    out.push({ depth, text, id });
+  }
+  return out;
+}
+
+export function TableOfContents({ source, title = "On this page" }: { source: string; title?: string }) {
+  const headings = React.useMemo(() => extractHeadings(source), [source]);
+  if (!headings.length) return null;
+  return (
+    <div className="sticky top-24">
+      <div className="text-sm font-semibold text-foreground/90 mb-2">{title}</div>
+      <ul className="text-sm space-y-2">
+        {headings.map((h, i) => (
+          <li key={i} className={h.depth > 2 ? "pl-4" : undefined}>
+            <a href={`#${h.id}`} className="text-muted-foreground hover:text-foreground">
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export { extractHeadings };
+


### PR DESCRIPTION
Extract headings extraction and right-side navigation into a reusable `TableOfContents` component and apply it to both docs and blog pages to unify the table of contents display and reduce code duplication.

---
<a href="https://cursor.com/background-agent?bcId=bc-acc646d2-6b59-42f5-869a-0593ba59d07e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-acc646d2-6b59-42f5-869a-0593ba59d07e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

