### PR TITLE
Create reusable headings nav component

### DIFF
--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -92,6 +92,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
       readTime={post.frontmatter.readTime}
       author={post.frontmatter.author}
       tags={post.frontmatter.tags}
+      tocSource={post.content}
     >
       <MarkdownRenderer source={post.content} />
       

--- a/website/app/docs/[...slug]/page.tsx
+++ b/website/app/docs/[...slug]/page.tsx
@@ -7,6 +7,7 @@ import { DocsContentSwitch } from "@/components/DocsContentSwitch";
 import { DocsArticleVisibility } from "@/components/DocsArticleVisibility";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { slugifyHeading } from "@/lib/utils";
+import { OnThisPage } from "@/components/OnThisPage";
 
 // Polyfill URL.canParse for Node environments that don't support it yet (e.g., Node 18)
 const _u = URL;
@@ -75,7 +76,6 @@ export default async function DocPage({ params }: { params: Promise<{ slug?: str
   }
   if (!source) notFound();
   const crumbs = findPathBySlug(slug) ?? [];
-  const headings = extractHeadings(source);
   return (
     <div className="grid lg:grid-cols-[minmax(0,1fr)_260px] gap-8">
       <article className="prose dark:prose-invert max-w-none scroll-smooth">
@@ -102,44 +102,9 @@ export default async function DocPage({ params }: { params: Promise<{ slug?: str
         {/* Client search/results overlay */}
         <DocsContentSwitch source={source} />
       </article>
-      <aside className="hidden lg:block">
-        <div className="sticky top-24">
-          <div className="text-sm font-semibold text-foreground/90 mb-2">On this page</div>
-          <ul className="text-sm space-y-2">
-            {headings.map((h, i) => (
-              <li key={i} className={h.depth > 2 ? "pl-4" : undefined}>
-                <a href={`#${h.id}`} className="text-muted-foreground hover:text-foreground">
-                  {h.text}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </aside>
+      <OnThisPage source={source} />
     </div>
   );
-}
-
-type Heading = { depth: number; text: string; id: string };
-
-function extractHeadings(md: string): Heading[] {
-  const lines = md.split(/\r?\n/);
-  const out: Heading[] = [];
-  let inFence = false;
-  for (const raw of lines) {
-    const line = raw.trim();
-    if (/^```/.test(line)) { inFence = !inFence; continue; }
-    if (inFence) continue; // ignore code fences
-    // Support ATX-style headings (## .. ######) and Setext-style (underlines of --- or === for previous line)
-    const m = /^(#{2,6})\s+(.+)$/.exec(line);
-    if (!m) continue;
-    const depth = m[1].length; // 2..6
-    // Remove backticks and inline code markers
-    const text = m[2].replace(/`/g, "");
-    const id = slugifyHeading(text);
-    out.push({ depth, text, id });
-  }
-  return out;
 }
 
 // Map well-known slug prefixes to repo files when not present in the manifest

--- a/website/components/BlogLayout.tsx
+++ b/website/components/BlogLayout.tsx
@@ -2,6 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { ArrowLeft, Calendar, Clock, User } from "lucide-react";
+import { OnThisPage } from "@/components/OnThisPage";
 
 interface BlogLayoutProps {
   children: React.ReactNode;
@@ -11,6 +12,7 @@ interface BlogLayoutProps {
   readTime: string;
   author: string;
   tags: string[];
+  tocSource?: string;
 }
 
 export function BlogLayout({
@@ -20,7 +22,8 @@ export function BlogLayout({
   date,
   readTime,
   author,
-  tags
+  tags,
+  tocSource
 }: BlogLayoutProps) {
   return (
     <div className="min-h-screen bg-background">
@@ -69,8 +72,11 @@ export function BlogLayout({
 
         {/* Article Content */}
         <article className="max-w-none">
-          <div className="blog-content">
+          <div className="blog-content relative">
             {children}
+            {tocSource ? (
+              <OnThisPage source={tocSource} variant="outside" />
+            ) : null}
           </div>
         </article>
       </div>

--- a/website/components/OnThisPage.tsx
+++ b/website/components/OnThisPage.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { slugifyHeading } from "@/lib/utils";
+
+type Heading = { depth: number; text: string; id: string };
+
+type OnThisPageProps = {
+  source: string;
+  title?: string;
+  /**
+   * inline: render as a normal aside in-flow (for docs grid)
+   * outside: position the aside just outside the right edge of its relatively positioned container (for blog)
+   */
+  variant?: "inline" | "outside";
+  className?: string;
+};
+
+function extractHeadings(md: string): Heading[] {
+  const lines = md.split(/\r?\n/);
+  const out: Heading[] = [];
+  let inFence = false;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (/^```/.test(line)) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    const m = /^(#{2,6})\s+(.+)$/.exec(line);
+    if (!m) continue;
+    const depth = m[1].length;
+    const text = m[2].replace(/`/g, "");
+    const id = slugifyHeading(text);
+    out.push({ depth, text, id });
+  }
+  return out;
+}
+
+export function OnThisPage({ source, title = "On this page", variant = "inline", className }: OnThisPageProps) {
+  const headings = extractHeadings(source);
+  const baseAside = variant === "outside"
+    ? "hidden lg:block absolute left-full ml-8 w-[260px]"
+    : "hidden lg:block";
+  return (
+    <aside className={[baseAside, className].filter(Boolean).join(" ")}> 
+      <div className="sticky top-24">
+        <div className="text-sm font-semibold text-foreground/90 mb-2">{title}</div>
+        <ul className="text-sm space-y-2">
+          {headings.map((h, i) => (
+            <li key={i} className={h.depth > 2 ? "pl-4" : undefined}>
+              <a href={`#${h.id}`} className="text-muted-foreground hover:text-foreground">
+                {h.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}
+
+export type { Heading };


### PR DESCRIPTION
Unify right-side heading navigation across docs and blog pages by extracting it into a reusable `OnThisPage` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-064b1941-e414-419c-b41e-15fba9b8b6f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-064b1941-e414-419c-b41e-15fba9b8b6f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

