### PR TITLE
Extract and reuse headings nav component

### DIFF
--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { BlogLayout } from '@/components/BlogLayout';
 import NewsletterCta from '@/components/NewsletterCta';
+import { PageToc } from '@/components/PageToc';
 
 interface BlogPost {
   slug: string;
@@ -93,7 +94,11 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
       author={post.frontmatter.author}
       tags={post.frontmatter.tags}
     >
-      <MarkdownRenderer source={post.content} />
+      <div className="relative">
+        {/* Position the TOC to the right of the content without shrinking copy width */}
+        <PageToc source={post.content} className="absolute left-full ml-12 w-[260px]" />
+        <MarkdownRenderer source={post.content} />
+      </div>
       
       {/* Newsletter CTA specific to blog posts */}
       <div className="mt-16">

--- a/website/app/docs/[...slug]/page.tsx
+++ b/website/app/docs/[...slug]/page.tsx
@@ -6,7 +6,7 @@ import { docsTree, findNodeBySlug, findPathBySlug, flatten, DocsNode } from "@/c
 import { DocsContentSwitch } from "@/components/DocsContentSwitch";
 import { DocsArticleVisibility } from "@/components/DocsArticleVisibility";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
-import { slugifyHeading } from "@/lib/utils";
+import { PageToc } from "@/components/PageToc";
 
 // Polyfill URL.canParse for Node environments that don't support it yet (e.g., Node 18)
 const _u = URL;
@@ -75,7 +75,7 @@ export default async function DocPage({ params }: { params: Promise<{ slug?: str
   }
   if (!source) notFound();
   const crumbs = findPathBySlug(slug) ?? [];
-  const headings = extractHeadings(source);
+  
   return (
     <div className="grid lg:grid-cols-[minmax(0,1fr)_260px] gap-8">
       <article className="prose dark:prose-invert max-w-none scroll-smooth">
@@ -102,44 +102,9 @@ export default async function DocPage({ params }: { params: Promise<{ slug?: str
         {/* Client search/results overlay */}
         <DocsContentSwitch source={source} />
       </article>
-      <aside className="hidden lg:block">
-        <div className="sticky top-24">
-          <div className="text-sm font-semibold text-foreground/90 mb-2">On this page</div>
-          <ul className="text-sm space-y-2">
-            {headings.map((h, i) => (
-              <li key={i} className={h.depth > 2 ? "pl-4" : undefined}>
-                <a href={`#${h.id}`} className="text-muted-foreground hover:text-foreground">
-                  {h.text}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </aside>
+      <PageToc source={source} />
     </div>
   );
-}
-
-type Heading = { depth: number; text: string; id: string };
-
-function extractHeadings(md: string): Heading[] {
-  const lines = md.split(/\r?\n/);
-  const out: Heading[] = [];
-  let inFence = false;
-  for (const raw of lines) {
-    const line = raw.trim();
-    if (/^```/.test(line)) { inFence = !inFence; continue; }
-    if (inFence) continue; // ignore code fences
-    // Support ATX-style headings (## .. ######) and Setext-style (underlines of --- or === for previous line)
-    const m = /^(#{2,6})\s+(.+)$/.exec(line);
-    if (!m) continue;
-    const depth = m[1].length; // 2..6
-    // Remove backticks and inline code markers
-    const text = m[2].replace(/`/g, "");
-    const id = slugifyHeading(text);
-    out.push({ depth, text, id });
-  }
-  return out;
 }
 
 // Map well-known slug prefixes to repo files when not present in the manifest

--- a/website/components/PageToc.tsx
+++ b/website/components/PageToc.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { cn, slugifyHeading } from "@/lib/utils";
+
+type Heading = { depth: number; text: string; id: string };
+
+function extractHeadings(md: string): Heading[] {
+  const lines = md.split(/\r?\n/);
+  const out: Heading[] = [];
+  let inFence = false;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (/^```/.test(line)) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    const m = /^(#{2,6})\s+(.+)$/.exec(line);
+    if (!m) continue;
+    const depth = m[1].length;
+    const text = m[2].replace(/`/g, "");
+    const id = slugifyHeading(text);
+    out.push({ depth, text, id });
+  }
+  return out;
+}
+
+export function PageToc({ source, className }: { source: string; className?: string }) {
+  const headings = extractHeadings(source);
+  if (headings.length === 0) return null;
+  return (
+    <aside className={cn("hidden lg:block", className)}>
+      <div className="sticky top-24">
+        <div className="text-sm font-semibold text-foreground/90 mb-2">On this page</div>
+        <ul className="text-sm space-y-2">
+          {headings.map((h, i) => (
+            <li key={i} className={h.depth > 2 ? "pl-4" : undefined}>
+              <a href={`#${h.id}`} className="text-muted-foreground hover:text-foreground">
+                {h.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}
+
+export { extractHeadings };
+


### PR DESCRIPTION
Unify the right-side 'On this page' navigation across documentation and blog pages by extracting it into a reusable component.

The `PageToc` component is positioned absolutely on blog pages to ensure the main content width is not affected, fulfilling the requirement that 'The Blog copy width should not be shortened'.

---
<a href="https://cursor.com/background-agent?bcId=bc-002955c7-c8e6-4e95-8b7f-5ad42271b301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-002955c7-c8e6-4e95-8b7f-5ad42271b301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

