### PR TITLE
Create reusable nav component for docs and blog

### DIFF
--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import matter from 'gray-matter';
 import { MarkdownRenderer } from '@/components/MarkdownRenderer';
+import { OnThisPage, extractHeadings } from '@/components/OnThisPage';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 
@@ -83,6 +84,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
   if (!post) {
     notFound();
   }
+  const headings = extractHeadings(post.content);
 
   return (
     <BlogLayout
@@ -93,36 +95,40 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
       author={post.frontmatter.author}
       tags={post.frontmatter.tags}
     >
-      <MarkdownRenderer source={post.content} />
-      
-      {/* Newsletter CTA specific to blog posts */}
-      <div className="mt-16">
-        <NewsletterCta
-          title="Enjoyed this post? Join the newsletter"
-          description="Monthly updates on RunMat, Rust internals, and performance tips."
-          align="center"
-        />
-      </div>
+      <div className="grid lg:grid-cols-[minmax(0,1fr)_260px] gap-8">
+        <div>
+          <MarkdownRenderer source={post.content} />
+          {/* Newsletter CTA specific to blog posts */}
+          <div className="mt-16">
+            <NewsletterCta
+              title="Enjoyed this post? Join the newsletter"
+              description="Monthly updates on RunMat, Rust internals, and performance tips."
+              align="center"
+            />
+          </div>
 
-      <div className="mt-16 not-prose">
-        <Card>
-          <CardContent className="p-6 text-center">
-            <h3 className="text-lg font-semibold mb-3">
-              Ready to try RunMat?
-            </h3>
-            <p className="text-muted-foreground mb-4">
-              Get started with the modern MATLAB runtime today.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              <Button asChild>
-                <Link href="/download">Download RunMat</Link>
-              </Button>
-              <Button variant="outline" asChild>
-                <Link href="/docs/getting-started">Get Started</Link>
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+          <div className="mt-16 not-prose">
+            <Card>
+              <CardContent className="p-6 text-center">
+                <h3 className="text-lg font-semibold mb-3">
+                  Ready to try RunMat?
+                </h3>
+                <p className="text-muted-foreground mb-4">
+                  Get started with the modern MATLAB runtime today.
+                </p>
+                <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                  <Button asChild>
+                    <Link href="/download">Download RunMat</Link>
+                  </Button>
+                  <Button variant="outline" asChild>
+                    <Link href="/docs/getting-started">Get Started</Link>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+        <OnThisPage headings={headings} />
       </div>
     </BlogLayout>
   );

--- a/website/app/docs/[...slug]/page.tsx
+++ b/website/app/docs/[...slug]/page.tsx
@@ -6,7 +6,7 @@ import { docsTree, findNodeBySlug, findPathBySlug, flatten, DocsNode } from "@/c
 import { DocsContentSwitch } from "@/components/DocsContentSwitch";
 import { DocsArticleVisibility } from "@/components/DocsArticleVisibility";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
-import { slugifyHeading } from "@/lib/utils";
+import { OnThisPage, extractHeadings } from "@/components/OnThisPage";
 
 // Polyfill URL.canParse for Node environments that don't support it yet (e.g., Node 18)
 const _u = URL;
@@ -102,44 +102,9 @@ export default async function DocPage({ params }: { params: Promise<{ slug?: str
         {/* Client search/results overlay */}
         <DocsContentSwitch source={source} />
       </article>
-      <aside className="hidden lg:block">
-        <div className="sticky top-24">
-          <div className="text-sm font-semibold text-foreground/90 mb-2">On this page</div>
-          <ul className="text-sm space-y-2">
-            {headings.map((h, i) => (
-              <li key={i} className={h.depth > 2 ? "pl-4" : undefined}>
-                <a href={`#${h.id}`} className="text-muted-foreground hover:text-foreground">
-                  {h.text}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </aside>
+      <OnThisPage headings={headings} />
     </div>
   );
-}
-
-type Heading = { depth: number; text: string; id: string };
-
-function extractHeadings(md: string): Heading[] {
-  const lines = md.split(/\r?\n/);
-  const out: Heading[] = [];
-  let inFence = false;
-  for (const raw of lines) {
-    const line = raw.trim();
-    if (/^```/.test(line)) { inFence = !inFence; continue; }
-    if (inFence) continue; // ignore code fences
-    // Support ATX-style headings (## .. ######) and Setext-style (underlines of --- or === for previous line)
-    const m = /^(#{2,6})\s+(.+)$/.exec(line);
-    if (!m) continue;
-    const depth = m[1].length; // 2..6
-    // Remove backticks and inline code markers
-    const text = m[2].replace(/`/g, "");
-    const id = slugifyHeading(text);
-    out.push({ depth, text, id });
-  }
-  return out;
 }
 
 // Map well-known slug prefixes to repo files when not present in the manifest

--- a/website/components/OnThisPage.tsx
+++ b/website/components/OnThisPage.tsx
@@ -1,0 +1,42 @@
+import { slugifyHeading } from "@/lib/utils";
+
+type Heading = { depth: number; text: string; id: string };
+
+export function extractHeadings(md: string): Heading[] {
+  const lines = md.split(/\r?\n/);
+  const out: Heading[] = [];
+  let inFence = false;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (/^```/.test(line)) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    const m = /^(#{2,6})\s+(.+)$/.exec(line);
+    if (!m) continue;
+    const depth = m[1].length;
+    const text = m[2].replace(/`/g, "");
+    const id = slugifyHeading(text);
+    out.push({ depth, text, id });
+  }
+  return out;
+}
+
+export function OnThisPage({ headings }: { headings: Heading[] }) {
+  if (!headings?.length) return null;
+  return (
+    <aside className="hidden lg:block">
+      <div className="sticky top-24">
+        <div className="text-sm font-semibold text-foreground/90 mb-2">On this page</div>
+        <ul className="text-sm space-y-2">
+          {headings.map((h, i) => (
+            <li key={i} className={h.depth > 2 ? "pl-4" : undefined}>
+              <a href={`#${h.id}`} className="text-muted-foreground hover:text-foreground">
+                {h.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}
+


### PR DESCRIPTION
Extract the "On this page" headings navigation into a reusable component and apply it to both documentation and blog pages to ensure consistent navigation and reduce code duplication.

---
<a href="https://cursor.com/background-agent?bcId=bc-781b9772-fcde-4ce6-bb20-6598845f973a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-781b9772-fcde-4ce6-bb20-6598845f973a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

