### PR TITLE
Fix nextjs build errors

### DIFF
--- a/crates/runmat-runtime/src/builtins/logical/logical.rs
+++ b/crates/runmat-runtime/src/builtins/logical/logical.rs
@@ -183,7 +183,7 @@ See the references below and the RunMat source for implementation details.
 
 ## Source & Feedback
 - Implementation: `crates/runmat-runtime/src/builtins/logical/logical.rs`
-- Issues & feature requests: <https://github.com/runmat-org/runmat/issues/new/choose>
+- Issues & feature requests: [https://github.com/runmat-org/runmat/issues/new/choose](https://github.com/runmat-org/runmat/issues/new/choose)
 "#;
 
 pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {

--- a/crates/runmat-runtime/src/builtins/math/elementwise/double.rs
+++ b/crates/runmat-runtime/src/builtins/math/elementwise/double.rs
@@ -195,7 +195,7 @@ precision.
 
 ## Source & Feedback
 - Implementation: `crates/runmat-runtime/src/builtins/math/elementwise/double.rs`
-- Issues & feature requests: <https://github.com/runmat-org/runmat/issues/new/choose>
+- Issues & feature requests: [https://github.com/runmat-org/runmat/issues/new/choose](https://github.com/runmat-org/runmat/issues/new/choose)
 "#;
 
 pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {

--- a/crates/runmat-runtime/src/builtins/math/elementwise/single.rs
+++ b/crates/runmat-runtime/src/builtins/math/elementwise/single.rs
@@ -202,7 +202,7 @@ implementation.
 
 ## Source & Feedback
 - Implementation: `crates/runmat-runtime/src/builtins/math/elementwise/single.rs`
-- Issues & feature requests: <https://github.com/runmat-org/runmat/issues/new/choose>
+- Issues & feature requests: [https://github.com/runmat-org/runmat/issues/new/choose](https://github.com/runmat-org/runmat/issues/new/choose)
 "#;
 
 pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {

--- a/website/app/blog/opengraph-image.tsx
+++ b/website/app/blog/opengraph-image.tsx
@@ -2,7 +2,6 @@ import { createOgResponse, OG_SIZE } from '@/lib/og';
 
 export const size = { width: OG_SIZE.width, height: OG_SIZE.height };
 export const contentType = 'image/png';
-export const runtime = 'edge';
 export const dynamic = 'force-static';
 
 export default function Image() {

--- a/website/app/docs/getting-started/opengraph-image.tsx
+++ b/website/app/docs/getting-started/opengraph-image.tsx
@@ -2,7 +2,6 @@ import { createOgResponse, OG_SIZE } from '@/lib/og';
 
 export const size = { width: OG_SIZE.width, height: OG_SIZE.height };
 export const contentType = 'image/png';
-export const runtime = 'edge';
 export const dynamic = 'force-static';
 
 export default function Image() {

--- a/website/app/docs/how-it-works/opengraph-image.tsx
+++ b/website/app/docs/how-it-works/opengraph-image.tsx
@@ -2,7 +2,6 @@ import { createOgResponse, OG_SIZE } from '@/lib/og';
 
 export const size = { width: OG_SIZE.width, height: OG_SIZE.height };
 export const contentType = 'image/png';
-export const runtime = 'edge';
 export const dynamic = 'force-static';
 
 export default function Image() {

--- a/website/app/docs/opengraph-image.tsx
+++ b/website/app/docs/opengraph-image.tsx
@@ -2,7 +2,6 @@ import { createOgResponse, OG_SIZE } from '@/lib/og';
 
 export const size = { width: OG_SIZE.width, height: OG_SIZE.height };
 export const contentType = 'image/png';
-export const runtime = 'edge';
 export const dynamic = 'force-static';
 
 export default function Image() {

--- a/website/app/opengraph-image.tsx
+++ b/website/app/opengraph-image.tsx
@@ -2,7 +2,6 @@ import { createOgResponse, OG_SIZE } from '@/lib/og';
 
 export const size = { width: OG_SIZE.width, height: OG_SIZE.height };
 export const contentType = 'image/png';
-export const runtime = 'edge';
 export const dynamic = 'force-static';
 
 export default function Image() {

--- a/website/content/builtins.json
+++ b/website/content/builtins.json
@@ -533,8 +533,7 @@
     ],
     "keywords": [
       "any",
-      "logical",
-      "reduction",
+      "logical reduction",
       "omitnan",
       "all",
       "gpu"
@@ -5025,7 +5024,7 @@
     "category": [
       "acceleration/gpu"
     ],
-    "summary": "Bring gpuArray data back to host memory.",
+    "summary": "Transfer gpuArray data back to host memory, recursively handling cells, structs, and objects.",
     "description": "`gather(X)` copies data that resides on the GPU or in another distributed storage back into host memory.",
     "status": "implemented",
     "signatures": [
@@ -5077,8 +5076,10 @@
     "keywords": [
       "gather",
       "gpuArray",
+      "download",
+      "host copy",
       "accelerate",
-      "download"
+      "residency"
     ],
     "internal": false,
     "mdxPath": "builtins-mdx/gather.mdx"
@@ -14711,10 +14712,32 @@
     "category": [
       "math/reduction"
     ],
-    "summary": "Variance of scalars, vectors, matrices, or N-D tensors.",
+    "summary": "Variance of scalars, vectors, matrices, or N-D tensors with MATLAB-compatible options.",
     "description": "`var(x)` measures the spread of the elements in `x` by returning their variance.",
     "status": "implemented",
     "signatures": [
+      {
+        "in": [
+          "x"
+        ],
+        "inTypes": [
+          "Tensor"
+        ],
+        "out": [
+          "out"
+        ],
+        "outTypes": [
+          "double"
+        ],
+        "nargin": {
+          "min": 0,
+          "max": 1
+        },
+        "nargout": {
+          "min": 0,
+          "max": 1
+        }
+      },
       {
         "in": [
           "x",
@@ -14733,28 +14756,6 @@
         "nargin": {
           "min": 0,
           "max": 2
-        },
-        "nargout": {
-          "min": 0,
-          "max": 1
-        }
-      },
-      {
-        "in": [
-          "x"
-        ],
-        "inTypes": [
-          "Tensor"
-        ],
-        "out": [
-          "out"
-        ],
-        "outTypes": [
-          "double"
-        ],
-        "nargin": {
-          "min": 0,
-          "max": 1
         },
         "nargout": {
           "min": 0,
@@ -14827,28 +14828,6 @@
     "signatures": [
       {
         "in": [
-          "x"
-        ],
-        "inTypes": [
-          "any"
-        ],
-        "out": [
-          "out"
-        ],
-        "outTypes": [
-          "any"
-        ],
-        "nargin": {
-          "min": 0,
-          "max": 1
-        },
-        "nargout": {
-          "min": 0,
-          "max": 1
-        }
-      },
-      {
-        "in": [
           "x",
           "y"
         ],
@@ -14865,6 +14844,28 @@
         "nargin": {
           "min": 0,
           "max": 2
+        },
+        "nargout": {
+          "min": 0,
+          "max": 1
+        }
+      },
+      {
+        "in": [
+          "x"
+        ],
+        "inTypes": [
+          "any"
+        ],
+        "out": [
+          "out"
+        ],
+        "outTypes": [
+          "any"
+        ],
+        "nargin": {
+          "min": 0,
+          "max": 1
         },
         "nargout": {
           "min": 0,


### PR DESCRIPTION
Fix website build errors by removing edge runtime from OG image routes and updating MDX link syntax.

The build was failing due to two main issues: incompatibility between `runtime = 'edge'` and `dynamic = 'force-static'` on OpenGraph image generation pages, and `next-mdx-remote` failing to compile MDX content that used angle-bracket autolinks. Removing the `runtime = 'edge'` export and converting angle-bracket links to standard Markdown links resolves these errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae7d1323-8c73-4aee-87a4-b24a1515b37e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae7d1323-8c73-4aee-87a4-b24a1515b37e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

