### PR TITLE
Doc macro fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ bindings/ts/node_modules/
 bindings/ts/pkg/
 bindings/ts/pkg-web/
 bindings/ts/dist/
+
+.idea

--- a/crates/runmat-runtime/src/bin/export_builtins.rs
+++ b/crates/runmat-runtime/src/bin/export_builtins.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use runmat_builtins::{builtin_docs, builtin_functions, BuiltinFunction, Type, Value};
-use runmat_runtime as _;
 use serde::Serialize;
 use serde_yaml::Value as YamlValue;
 use std::collections::HashMap;

--- a/crates/runmat-runtime/src/builtins/math/linalg/ops/ctranspose.rs
+++ b/crates/runmat-runtime/src/builtins/math/linalg/ops/ctranspose.rs
@@ -21,7 +21,13 @@ use runmat_macros::runtime_builtin;
 
 const NAME: &str = "ctranspose";
 
-#[cfg_attr(feature = "doc_export", runmat_macros::register_doc_text(name = NAME))]
+#[cfg_attr(
+    feature = "doc_export",
+    runmat_macros::register_doc_text(
+        name = NAME,
+        builtin_path = "crate::builtins::math::linalg::ops::ctranspose"
+    )
+)]
 #[cfg_attr(not(feature = "doc_export"), allow(dead_code))]
 pub const DOC_MD: &str = r#"---
 title: "ctranspose"

--- a/crates/runmat-runtime/src/builtins/math/linalg/ops/trace.rs
+++ b/crates/runmat-runtime/src/builtins/math/linalg/ops/trace.rs
@@ -13,7 +13,13 @@ use crate::builtins::common::tensor;
 
 const NAME: &str = "trace";
 
-#[cfg_attr(feature = "doc_export", runmat_macros::register_doc_text(name = NAME))]
+#[cfg_attr(
+    feature = "doc_export",
+    runmat_macros::register_doc_text(
+        name = NAME,
+        builtin_path = "crate::builtins::math::linalg::ops::trace"
+    )
+)]
 #[cfg_attr(not(feature = "doc_export"), allow(dead_code))]
 pub const DOC_MD: &str = r#"---
 title: "trace"

--- a/crates/runmat-runtime/src/builtins/math/linalg/ops/transpose.rs
+++ b/crates/runmat-runtime/src/builtins/math/linalg/ops/transpose.rs
@@ -21,7 +21,13 @@ use runmat_macros::runtime_builtin;
 
 const NAME: &str = "transpose";
 
-#[cfg_attr(feature = "doc_export", runmat_macros::register_doc_text(name = NAME))]
+#[cfg_attr(
+    feature = "doc_export",
+    runmat_macros::register_doc_text(
+        name = NAME,
+        builtin_path = "crate::builtins::math::linalg::ops::transpose"
+    )
+)]
 #[cfg_attr(not(feature = "doc_export"), allow(dead_code))]
 pub const DOC_MD: &str = r#"---
 title: "transpose"

--- a/crates/runmat-runtime/src/builtins/math/linalg/solve/cond.rs
+++ b/crates/runmat-runtime/src/builtins/math/linalg/solve/cond.rs
@@ -16,7 +16,13 @@ use crate::builtins::common::tensor;
 
 const NAME: &str = "cond";
 
-#[cfg_attr(feature = "doc_export", runmat_macros::register_doc_text(name = NAME))]
+#[cfg_attr(
+    feature = "doc_export",
+    runmat_macros::register_doc_text(
+        name = NAME,
+        builtin_path = "crate::builtins::math::linalg::solve::cond"
+    )
+)]
 #[cfg_attr(not(feature = "doc_export"), allow(dead_code))]
 pub const DOC_MD: &str = r#"---
 title: "cond"

--- a/crates/runmat-runtime/src/builtins/math/linalg/solve/det.rs
+++ b/crates/runmat-runtime/src/builtins/math/linalg/solve/det.rs
@@ -14,7 +14,13 @@ use crate::builtins::common::{gpu_helpers, tensor};
 
 const NAME: &str = "det";
 
-#[cfg_attr(feature = "doc_export", runmat_macros::register_doc_text(name = NAME))]
+#[cfg_attr(
+    feature = "doc_export",
+    runmat_macros::register_doc_text(
+        name = NAME,
+        builtin_path = "crate::builtins::math::linalg::solve::det"
+    )
+)]
 #[cfg_attr(not(feature = "doc_export"), allow(dead_code))]
 pub const DOC_MD: &str = r#"---
 title: "det"

--- a/crates/runmat-runtime/src/builtins/math/linalg/solve/inv.rs
+++ b/crates/runmat-runtime/src/builtins/math/linalg/solve/inv.rs
@@ -14,7 +14,13 @@ use crate::builtins::common::{gpu_helpers, tensor};
 
 const NAME: &str = "inv";
 
-#[cfg_attr(feature = "doc_export", runmat_macros::register_doc_text(name = NAME))]
+#[cfg_attr(
+    feature = "doc_export",
+    runmat_macros::register_doc_text(
+        name = NAME,
+        builtin_path = "crate::builtins::math::linalg::solve::inv"
+    )
+)]
 #[cfg_attr(not(feature = "doc_export"), allow(dead_code))]
 pub const DOC_MD: &str = r#"---
 title: "inv"

--- a/crates/runmat-runtime/src/builtins/math/linalg/solve/norm.rs
+++ b/crates/runmat-runtime/src/builtins/math/linalg/solve/norm.rs
@@ -14,7 +14,13 @@ use crate::builtins::common::{gpu_helpers, tensor};
 
 const NAME: &str = "norm";
 
-#[cfg_attr(feature = "doc_export", runmat_macros::register_doc_text(name = NAME))]
+#[cfg_attr(
+    feature = "doc_export",
+    runmat_macros::register_doc_text(
+        name = NAME,
+        builtin_path = "crate::builtins::math::linalg::solve::norm"
+    )
+)]
 #[cfg_attr(not(feature = "doc_export"), allow(dead_code))]
 pub const DOC_MD: &str = r#"---
 title: "norm"

--- a/crates/runmat-runtime/src/builtins/math/linalg/solve/rank.rs
+++ b/crates/runmat-runtime/src/builtins/math/linalg/solve/rank.rs
@@ -17,7 +17,13 @@ use crate::builtins::common::{gpu_helpers, tensor};
 
 const NAME: &str = "rank";
 
-#[cfg_attr(feature = "doc_export", runmat_macros::register_doc_text(name = NAME))]
+#[cfg_attr(
+    feature = "doc_export",
+    runmat_macros::register_doc_text(
+        name = NAME,
+        builtin_path = "crate::builtins::math::linalg::solve::rank"
+    )
+)]
 #[cfg_attr(not(feature = "doc_export"), allow(dead_code))]
 pub const DOC_MD: &str = r#"---
 title: "rank"

--- a/crates/runmat-runtime/src/builtins/math/linalg/solve/rcond.rs
+++ b/crates/runmat-runtime/src/builtins/math/linalg/solve/rcond.rs
@@ -15,7 +15,13 @@ use crate::builtins::common::{gpu_helpers, tensor};
 
 const NAME: &str = "rcond";
 
-#[cfg_attr(feature = "doc_export", runmat_macros::register_doc_text(name = NAME))]
+#[cfg_attr(
+    feature = "doc_export",
+    runmat_macros::register_doc_text(
+        name = NAME,
+        builtin_path = "crate::builtins::math::linalg::solve::rcond"
+    )
+)]
 #[cfg_attr(not(feature = "doc_export"), allow(dead_code))]
 pub const DOC_MD: &str = r#"---
 title: "rcond"

--- a/crates/runmat-runtime/src/builtins/strings/core/strings.rs
+++ b/crates/runmat-runtime/src/builtins/strings/core/strings.rs
@@ -17,7 +17,13 @@ const SIZE_FINITE_ERR: &str = "size inputs must be finite";
 const SIZE_NUMERIC_ERR: &str = "size arguments must be numeric scalars or vectors";
 const SIZE_SCALAR_ERR: &str = "size inputs must be scalar";
 
-#[cfg_attr(feature = "doc_export", runmat_macros::register_doc_text(name = FN_NAME))]
+#[cfg_attr(
+    feature = "doc_export",
+    runmat_macros::register_doc_text(
+        name = FN_NAME,
+        builtin_path = "crate::builtins::strings::core::strings"
+    )
+)]
 #[cfg_attr(not(feature = "doc_export"), allow(dead_code))]
 pub const DOC_MD: &str = r#"---
 title: "strings"


### PR DESCRIPTION
This PR adds `builtin_path` to the `register_doc_text` macro, where required.