### PR TITLE
resolved clippy build issues; work on resolving CI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,7 @@ jobs:
         uses: nanasess/setup-chromedriver@v2
 
       - name: Install npm dependencies
+        working-directory: bindings/ts
         run: npm ci
 
       - name: Build wasm32 target
@@ -385,7 +386,9 @@ jobs:
         run: scripts/test-wasm-headless.sh
 
       - name: Build bindings package
-        run: npm run build --workspace bindings/ts
+        working-directory: bindings/ts
+        run: npm run build
 
       - name: Lint bindings package
-        run: npm run lint --workspace bindings/ts
+        working-directory: bindings/ts
+        run: npm run lint

--- a/crates/runmat-ignition/src/compiler.rs
+++ b/crates/runmat-ignition/src/compiler.rs
@@ -147,13 +147,11 @@ impl Compiler {
     }
 
     fn emit_multiassign_outputs(&mut self, vars: &[Option<runmat_hir::VarId>]) {
-        for var in vars {
-            if let Some(v) = var {
-                self.emit(Instr::EmitVar {
-                    var_index: v.0,
-                    label: EmitLabel::Var(v.0),
-                });
-            }
+        for v in vars.iter().flatten() {
+            self.emit(Instr::EmitVar {
+                var_index: v.0,
+                label: EmitLabel::Var(v.0),
+            });
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures wasm bindings CI steps run in the correct package and simplifies a small compiler routine.
> 
> - **CI (wasm-bindings job):** add `working-directory: bindings/ts` for `npm ci`, `npm run build`, and `npm run lint`; drop workspace flags and run commands directly in the package
> - **Compiler:** simplify `emit_multiassign_outputs` to iterate `vars.iter().flatten()` and emit `Instr::EmitVar` for present variables
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63ac79fc88c2c4b15fc93a344bef16aae3ccc347. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->