### PR TITLE
fixed broken links reported by Google

### DIFF
--- a/crates/runmat-runtime/src/builtins/builtins-json/bandwidth.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/bandwidth.json
@@ -129,10 +129,6 @@
       "url": "./triu"
     },
     {
-      "label": "spdiags",
-      "url": "./spdiags"
-    },
-    {
       "label": "issymmetric",
       "url": "./issymmetric"
     },

--- a/crates/runmat-runtime/src/builtins/builtins-json/cell.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/cell.json
@@ -103,10 +103,6 @@
   ],
   "links": [
     {
-      "label": "num2cell",
-      "url": "./num2cell"
-    },
-    {
       "label": "cellfun",
       "url": "./cellfun"
     },

--- a/crates/runmat-runtime/src/builtins/builtins-json/cell2mat.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/cell2mat.json
@@ -113,10 +113,6 @@
       "url": "./mat2cell"
     },
     {
-      "label": "num2cell",
-      "url": "./num2cell"
-    },
-    {
       "label": "cellfun",
       "url": "./cellfun"
     }

--- a/crates/runmat-runtime/src/builtins/builtins-json/class.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/class.json
@@ -111,10 +111,6 @@
       "url": "./isnumeric"
     },
     {
-      "label": "classref",
-      "url": "./classref"
-    },
-    {
       "label": "gpuArray",
       "url": "./gpuarray"
     },

--- a/crates/runmat-runtime/src/builtins/builtins-json/containers.Map.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/containers.Map.json
@@ -110,22 +110,6 @@
   ],
   "links": [
     {
-      "label": "keys",
-      "url": "./containers.Map.keys"
-    },
-    {
-      "label": "values",
-      "url": "./containers.Map.values"
-    },
-    {
-      "label": "isKey",
-      "url": "./containers.Map.isKey"
-    },
-    {
-      "label": "remove",
-      "url": "./containers.Map.remove"
-    },
-    {
       "label": "length",
       "url": "./length"
     }

--- a/crates/runmat-runtime/src/builtins/builtins-json/dir.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/dir.json
@@ -125,10 +125,6 @@
     {
       "label": "cd",
       "url": "./cd"
-    },
-    {
-      "label": "fullfile",
-      "url": "./fullfile"
     }
   ],
   "source": {

--- a/crates/runmat-runtime/src/builtins/builtins-json/histcounts2.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/histcounts2.json
@@ -107,10 +107,6 @@
       "url": "./histcounts"
     },
     {
-      "label": "accumarray",
-      "url": "./accumarray"
-    },
-    {
       "label": "sum",
       "url": "./sum"
     },

--- a/crates/runmat-runtime/src/builtins/builtins-json/isfield.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/isfield.json
@@ -103,10 +103,6 @@
       "url": "./struct"
     },
     {
-      "label": "isprop",
-      "url": "./isprop"
-    },
-    {
       "label": "getfield",
       "url": "./getfield"
     },

--- a/crates/runmat-runtime/src/builtins/builtins-json/isstring.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/isstring.json
@@ -117,10 +117,6 @@
       "url": "./string"
     },
     {
-      "label": "convertStringsToChars",
-      "url": "./convertStringsToChars"
-    },
-    {
       "label": "gpuArray",
       "url": "./gpuarray"
     }

--- a/crates/runmat-runtime/src/builtins/builtins-json/join.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/join.json
@@ -112,10 +112,6 @@
   ],
   "links": [
     {
-      "label": "strjoin",
-      "url": "./strjoin"
-    },
-    {
       "label": "split",
       "url": "./split"
     },

--- a/crates/runmat-runtime/src/builtins/builtins-json/kron.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/kron.json
@@ -118,10 +118,6 @@
       "url": "./sum"
     },
     {
-      "label": "matmul",
-      "url": "./matmul"
-    },
-    {
       "label": "gpuArray",
       "url": "./gpuarray"
     },

--- a/crates/runmat-runtime/src/builtins/builtins-json/lu.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/lu.json
@@ -129,10 +129,6 @@
       "url": "./qr"
     },
     {
-      "label": "solve",
-      "url": "./backslash"
-    },
-    {
       "label": "gpuArray",
       "url": "./gpuarray"
     }

--- a/crates/runmat-runtime/src/builtins/builtins-json/mat2cell.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/mat2cell.json
@@ -101,10 +101,6 @@
       "url": "./cell2mat"
     },
     {
-      "label": "num2cell",
-      "url": "./num2cell"
-    },
-    {
       "label": "gpuArray",
       "url": "./gpuarray"
     },

--- a/crates/runmat-runtime/src/builtins/builtins-json/num2str.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/num2str.json
@@ -112,10 +112,6 @@
       "url": "./string"
     },
     {
-      "label": "mat2str",
-      "url": "./mat2str"
-    },
-    {
       "label": "str2double",
       "url": "./str2double"
     }

--- a/crates/runmat-runtime/src/builtins/builtins-json/polyfit.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/polyfit.json
@@ -101,10 +101,6 @@
       "url": "./polyval"
     },
     {
-      "label": "poly",
-      "url": "./poly"
-    },
-    {
       "label": "roots",
       "url": "./roots"
     },

--- a/crates/runmat-runtime/src/builtins/builtins-json/polyval.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/polyval.json
@@ -125,10 +125,6 @@
       "url": "./deconv"
     },
     {
-      "label": "poly",
-      "url": "./poly"
-    },
-    {
       "label": "polyder",
       "url": "./polyder"
     },

--- a/crates/runmat-runtime/src/builtins/builtins-json/rank.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/rank.json
@@ -135,10 +135,6 @@
       "url": "./det"
     },
     {
-      "label": "null",
-      "url": "./null"
-    },
-    {
       "label": "gpuArray",
       "url": "./gpuarray"
     },

--- a/crates/runmat-runtime/src/builtins/builtins-json/roots.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/roots.json
@@ -103,10 +103,6 @@
       "url": "./polyfit"
     },
     {
-      "label": "residue",
-      "url": "./residue"
-    },
-    {
       "label": "roots documentation (MathWorks)",
       "url": "https://www.mathworks.com/help/matlab/ref/roots.html"
     }

--- a/crates/runmat-runtime/src/builtins/builtins-json/single.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/single.json
@@ -126,10 +126,6 @@
       "url": "./gather"
     },
     {
-      "label": "logical",
-      "url": "./ops"
-    },
-    {
       "label": "single (MathWorks)",
       "url": "https://www.mathworks.com/help/matlab/ref/single.html"
     }

--- a/crates/runmat-runtime/src/builtins/builtins-json/split.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/split.json
@@ -109,10 +109,6 @@
   ],
   "links": [
     {
-      "label": "strsplit",
-      "url": "./strsplit"
-    },
-    {
       "label": "replace",
       "url": "./replace"
     },

--- a/crates/runmat-runtime/src/builtins/builtins-json/startsWith.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/startsWith.json
@@ -120,7 +120,7 @@
     },
     {
       "label": "`endsWith`",
-      "url": "./endsWith"
+      "url": "./endswith"
     },
     {
       "label": "`regexp`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/str2double.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/str2double.json
@@ -117,20 +117,12 @@
   ],
   "links": [
     {
-      "label": "str2num",
-      "url": "./str2num"
-    },
-    {
       "label": "double",
       "url": "./double"
     },
     {
       "label": "string",
       "url": "./string"
-    },
-    {
-      "label": "str2int",
-      "url": "./str2int"
     }
   ],
   "source": {

--- a/crates/runmat-runtime/src/builtins/builtins-json/tic.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/tic.json
@@ -88,10 +88,6 @@
     {
       "label": "timeit",
       "url": "./timeit"
-    },
-    {
-      "label": "profile",
-      "url": "./profile"
     }
   ],
   "source": {

--- a/crates/runmat-runtime/src/builtins/builtins-json/timeit.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/timeit.json
@@ -111,10 +111,6 @@
     {
       "label": "toc",
       "url": "./toc"
-    },
-    {
-      "label": "feval",
-      "url": "./feval"
     }
   ],
   "source": {

--- a/crates/runmat-runtime/src/builtins/builtins-json/writematrix.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/writematrix.json
@@ -112,10 +112,6 @@
       "url": "./readmatrix"
     },
     {
-      "label": "writecell",
-      "url": "./writecell"
-    },
-    {
       "label": "fprintf",
       "url": "./fprintf"
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Cleans up documentation links across builtin reference JSON files to remove broken targets and correct URLs.
> 
> - Prunes invalid cross-references in multiple docs (e.g., `num2cell`, `classref`, `accumarray`, `strsplit`, `poly`, `writecell`, method links under `containers.Map`, etc.)
> - Corrects `startsWith` link URL from `./endsWith` to `./endswith`
> - No code or behavior changes; updates only affect docs/help rendering and SEO
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da348aa41f0ef019b564a4a7afdf162a4b8b4eec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->