### PR TITLE
Wasm test fixes 2

### DIFF
--- a/crates/runmat-core/src/lib.rs
+++ b/crates/runmat-core/src/lib.rs
@@ -1687,8 +1687,8 @@ impl RunMatSession {
             self.populate_callstack(runtime_error);
         }
 
-        let suppress_public_value = is_expression_stmt
-            && matches!(final_stmt_emit, FinalStmtEmitDisposition::Suppressed);
+        let suppress_public_value =
+            is_expression_stmt && matches!(final_stmt_emit, FinalStmtEmitDisposition::Suppressed);
         let public_value = if is_semicolon_suppressed || suppress_public_value {
             None
         } else {

--- a/crates/runmat-core/src/lib.rs
+++ b/crates/runmat-core/src/lib.rs
@@ -1687,7 +1687,9 @@ impl RunMatSession {
             self.populate_callstack(runtime_error);
         }
 
-        let public_value = if is_semicolon_suppressed {
+        let suppress_public_value = is_expression_stmt
+            && matches!(final_stmt_emit, FinalStmtEmitDisposition::Suppressed);
+        let public_value = if is_semicolon_suppressed || suppress_public_value {
             None
         } else {
             result_value

--- a/crates/runmat-ignition/src/vm.rs
+++ b/crates/runmat-ignition/src/vm.rs
@@ -24,7 +24,7 @@ use runmat_runtime::{
     builtins::common::shape::is_scalar_shape,
     builtins::common::tensor,
     builtins::stats::random::stochastic_evolution::stochastic_evolution_host,
-    gather_if_needed,
+    gather_if_needed, user_functions,
     workspace::{self as runtime_workspace, WorkspaceResolver},
     CallFrame, RuntimeError,
 };
@@ -36,7 +36,6 @@ type Instant = ();
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
-#[cfg(feature = "native-accel")]
 use std::sync::Arc;
 use std::sync::Once;
 #[cfg(feature = "native-accel")]
@@ -1348,6 +1347,29 @@ runmat_thread_local! {
     };
 }
 
+runmat_thread_local! {
+    static USER_FUNCTION_VARS: RefCell<Option<*mut Vec<Value>>> = const { RefCell::new(None) };
+}
+
+struct UserFunctionVarsGuard {
+    previous: Option<*mut Vec<Value>>,
+}
+
+impl Drop for UserFunctionVarsGuard {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        USER_FUNCTION_VARS.with(|slot| {
+            *slot.borrow_mut() = previous;
+        });
+    }
+}
+
+fn install_user_function_vars(vars: &mut Vec<Value>) -> UserFunctionVarsGuard {
+    let vars_ptr = vars as *mut Vec<Value>;
+    let previous = USER_FUNCTION_VARS.with(|slot| slot.borrow_mut().replace(vars_ptr));
+    UserFunctionVarsGuard { previous }
+}
+
 #[derive(Debug)]
 pub enum InterpreterOutcome {
     Completed(Vec<Value>),
@@ -1512,6 +1534,25 @@ async fn run_interpreter_inner(
             fusion_plan: _,
         bytecode,
     } = state;
+    let functions = Arc::new(context.functions.clone());
+    let _user_function_vars_guard = install_user_function_vars(&mut vars);
+    let _user_function_guard = user_functions::install_user_function_invoker(Some(Arc::new(
+        move |name: &str, args: &[Value]| {
+            let name = name.to_string();
+            let args = args.to_vec();
+            let functions = Arc::clone(&functions);
+            Box::pin(async move {
+                let vars_ptr = USER_FUNCTION_VARS.with(|slot| *slot.borrow());
+                let Some(vars_ptr) = vars_ptr else {
+                    return Err(RuntimeError::new(
+                        "user function vars not installed".to_string(),
+                    ));
+                };
+                let vars = unsafe { &mut *vars_ptr };
+                invoke_user_function_value(&name, &args, &functions, vars).await
+            })
+        },
+    )));
     CALL_COUNTS.with(|cc| {
         *cc.borrow_mut() = call_counts.clone();
     });
@@ -1721,7 +1762,10 @@ async fn run_interpreter_inner(
                     // Gather GPU tensors so we display actual values, not internal handles
                     let host_value =
                         runmat_runtime::dispatcher::gather_if_needed_async(value).await?;
-                    runmat_runtime::console::record_value_output(label_text.as_deref(), &host_value);
+                    runmat_runtime::console::record_value_output(
+                        label_text.as_deref(),
+                        &host_value,
+                    );
                 }
             }
             Instr::EmitVar { var_index, label } => {
@@ -1730,7 +1774,10 @@ async fn run_interpreter_inner(
                     // Gather GPU tensors so we display actual values, not internal handles
                     let host_value =
                         runmat_runtime::dispatcher::gather_if_needed_async(value).await?;
-                    runmat_runtime::console::record_value_output(label_text.as_deref(), &host_value);
+                    runmat_runtime::console::record_value_output(
+                        label_text.as_deref(),
+                        &host_value,
+                    );
                 }
             }
             Instr::AndAnd(target) => {
@@ -12128,6 +12175,172 @@ pub async fn interpret(bytecode: &Bytecode) -> Result<Vec<Value>, RuntimeError> 
         Ok(InterpreterOutcome::Completed(values)) => Ok(values),
         Err(e) => Err(e),
     }
+}
+
+async fn invoke_user_function_value(
+    name: &str,
+    args: &[Value],
+    functions: &HashMap<String, UserFunction>,
+    vars: &mut [Value],
+) -> Result<Value, RuntimeError> {
+    let func: UserFunction = match functions.get(name) {
+        Some(f) => f.clone(),
+        None => {
+            return Err(mex(
+                "UndefinedFunction",
+                &format!("Undefined function: {name}"),
+            ))
+        }
+    };
+
+    let arg_count = args.len();
+    if !func.has_varargin {
+        if arg_count < func.params.len() {
+            return Err(mex(
+                "NotEnoughInputs",
+                &format!(
+                    "Function '{name}' expects {} inputs, got {arg_count}",
+                    func.params.len()
+                ),
+            ));
+        }
+        if arg_count > func.params.len() {
+            return Err(mex(
+                "TooManyInputs",
+                &format!(
+                    "Function '{name}' expects {} inputs, got {arg_count}",
+                    func.params.len()
+                ),
+            ));
+        }
+    } else if arg_count + 1 < func.params.len() {
+        return Err(mex(
+            "NotEnoughInputs",
+            &format!(
+                "Function '{name}' expects at least {} inputs, got {arg_count}",
+                func.params.len() - 1
+            ),
+        ));
+    }
+
+    let var_map = runmat_hir::remapping::create_complete_function_var_map(
+        &func.params,
+        &func.outputs,
+        &func.body,
+    );
+    let local_var_count = var_map.len();
+    let remapped_body = runmat_hir::remapping::remap_function_body(&func.body, &var_map);
+    let func_vars_count = local_var_count.max(func.params.len());
+    let mut func_vars = vec![Value::Num(0.0); func_vars_count];
+
+    if func.has_varargin {
+        let fixed = func.params.len().saturating_sub(1);
+        for i in 0..fixed {
+            if i < args.len() && i < func_vars.len() {
+                func_vars[i] = args[i].clone();
+            }
+        }
+        let mut rest: Vec<Value> = if args.len() > fixed {
+            args[fixed..].to_vec()
+        } else {
+            Vec::new()
+        };
+        let cell = runmat_builtins::CellArray::new(
+            std::mem::take(&mut rest),
+            1,
+            if args.len() > fixed {
+                args.len() - fixed
+            } else {
+                0
+            },
+        )
+        .map_err(|e| RuntimeError::new(format!("varargin: {e}")))?;
+        if fixed < func_vars.len() {
+            func_vars[fixed] = Value::Cell(cell);
+        }
+    } else {
+        for (i, _param_id) in func.params.iter().enumerate() {
+            if i < args.len() && i < func_vars.len() {
+                func_vars[i] = args[i].clone();
+            }
+        }
+    }
+
+    for (original_var_id, local_var_id) in &var_map {
+        let local_index = local_var_id.0;
+        let global_index = original_var_id.0;
+        if local_index < func_vars.len() && global_index < vars.len() {
+            let is_parameter = func
+                .params
+                .iter()
+                .any(|param_id| param_id == original_var_id);
+            if !is_parameter {
+                func_vars[local_index] = vars[global_index].clone();
+            }
+        }
+    }
+
+    if func.has_varargout {
+        if let Some(varargout_oid) = func.outputs.last() {
+            if let Some(local_id) = var_map.get(varargout_oid) {
+                if local_id.0 < func_vars.len() {
+                    let empty = runmat_builtins::CellArray::new(vec![], 1, 0)
+                        .map_err(|e| RuntimeError::new(format!("varargout init: {e}")))?;
+                    func_vars[local_id.0] = Value::Cell(empty);
+                }
+            }
+        }
+    }
+
+    let mut func_var_types = func.var_types.clone();
+    if func_var_types.len() < local_var_count {
+        func_var_types.resize(local_var_count, Type::Unknown);
+    }
+    let func_program = runmat_hir::HirProgram {
+        body: remapped_body,
+        var_types: func_var_types,
+    };
+    let func_bytecode = crate::compile(&func_program, functions)?;
+    let func_result_vars =
+        interpret_function_with_counts(&func_bytecode, func_vars, name, 1, arg_count).await?;
+
+    if func.outputs.is_empty() {
+        return Ok(Value::Num(0.0));
+    }
+
+    if func.has_varargout {
+        let total_named = func.outputs.len().saturating_sub(1);
+        if total_named > 0 {
+            if let Some(oid) = func.outputs.first() {
+                if let Some(local_id) = var_map.get(oid) {
+                    if let Some(value) = func_result_vars.get(local_id.0) {
+                        return Ok(value.clone());
+                    }
+                }
+            }
+        }
+        if let Some(varargout_oid) = func.outputs.last() {
+            if let Some(local_id) = var_map.get(varargout_oid) {
+                if let Some(Value::Cell(ca)) = func_result_vars.get(local_id.0) {
+                    if let Some(first) = ca.data.first() {
+                        return Ok((**first).clone());
+                    }
+                }
+            }
+        }
+        return Ok(Value::Num(0.0));
+    }
+
+    let Some(output_id) = func.outputs.first() else {
+        return Ok(Value::Num(0.0));
+    };
+    let Some(local_id) = var_map.get(output_id) else {
+        return Ok(Value::Num(0.0));
+    };
+    Ok(func_result_vars
+        .get(local_id.0)
+        .cloned()
+        .unwrap_or(Value::Num(0.0)))
 }
 
 pub async fn interpret_function(

--- a/crates/runmat-ignition/src/vm.rs
+++ b/crates/runmat-ignition/src/vm.rs
@@ -1718,13 +1718,19 @@ async fn run_interpreter_inner(
             Instr::EmitStackTop { label } => {
                 if let Some(value) = stack.last() {
                     let label_text = resolve_emit_label_text(&label, &bytecode.var_names);
-                    runmat_runtime::console::record_value_output(label_text.as_deref(), value);
+                    // Gather GPU tensors so we display actual values, not internal handles
+                    let host_value =
+                        runmat_runtime::dispatcher::gather_if_needed_async(value).await?;
+                    runmat_runtime::console::record_value_output(label_text.as_deref(), &host_value);
                 }
             }
             Instr::EmitVar { var_index, label } => {
                 if let Some(value) = vars.get(var_index) {
                     let label_text = resolve_emit_label_text(&label, &bytecode.var_names);
-                    runmat_runtime::console::record_value_output(label_text.as_deref(), value);
+                    // Gather GPU tensors so we display actual values, not internal handles
+                    let host_value =
+                        runmat_runtime::dispatcher::gather_if_needed_async(value).await?;
+                    runmat_runtime::console::record_value_output(label_text.as_deref(), &host_value);
                 }
             }
             Instr::AndAnd(target) => {

--- a/crates/runmat-runtime/src/builtins/array/creation/mod.rs
+++ b/crates/runmat-runtime/src/builtins/array/creation/mod.rs
@@ -10,4 +10,5 @@ pub(crate) mod randi;
 pub(crate) mod randn;
 pub(crate) mod randperm;
 pub(crate) mod range;
+pub(crate) mod true_false;
 pub(crate) mod zeros;

--- a/crates/runmat-runtime/src/builtins/array/creation/true_false.rs
+++ b/crates/runmat-runtime/src/builtins/array/creation/true_false.rs
@@ -1,0 +1,230 @@
+//! MATLAB-compatible `true`/`false` builtins for logical array creation.
+
+use runmat_builtins::{LogicalArray, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::{shape::normalize_scalar_shape, tensor};
+use crate::{build_runtime_error, BuiltinResult, RuntimeError};
+
+fn builtin_error(name: &str, message: impl Into<String>) -> RuntimeError {
+    build_runtime_error(message).with_builtin(name).build()
+}
+
+#[runtime_builtin(
+    name = "true",
+    category = "array/creation",
+    summary = "Create logical arrays filled with true values.",
+    keywords = "true,logical,array",
+    accel = "array_construct",
+    builtin_path = "crate::builtins::array::creation::true_false"
+)]
+async fn true_builtin(rest: Vec<Value>) -> BuiltinResult<Value> {
+    logical_fill(rest, true, "true").await
+}
+
+#[runtime_builtin(
+    name = "false",
+    category = "array/creation",
+    summary = "Create logical arrays filled with false values.",
+    keywords = "false,logical,array",
+    accel = "array_construct",
+    builtin_path = "crate::builtins::array::creation::true_false"
+)]
+async fn false_builtin(rest: Vec<Value>) -> BuiltinResult<Value> {
+    logical_fill(rest, false, "false").await
+}
+
+async fn logical_fill(args: Vec<Value>, value: bool, name: &str) -> BuiltinResult<Value> {
+    let parsed = ParsedLogical::parse(args, name).await?;
+    let len = tensor::element_count(&parsed.shape);
+    if len == 1 {
+        return Ok(Value::Bool(value));
+    }
+    let data = vec![if value { 1u8 } else { 0u8 }; len];
+    LogicalArray::new(data, parsed.shape)
+        .map(Value::LogicalArray)
+        .map_err(|e| builtin_error(name, format!("{name}: {e}")))
+}
+
+struct ParsedLogical {
+    shape: Vec<usize>,
+}
+
+impl ParsedLogical {
+    async fn parse(args: Vec<Value>, name: &str) -> BuiltinResult<Self> {
+        let mut dims: Vec<usize> = Vec::new();
+        let mut saw_dims_arg = false;
+        let mut shape_source: Option<Vec<usize>> = None;
+        let mut saw_like = false;
+
+        let mut idx = 0;
+        while idx < args.len() {
+            let arg = args[idx].clone();
+            if let Some(keyword) = keyword_of(&arg) {
+                match keyword.as_str() {
+                    "like" => {
+                        if saw_like {
+                            return Err(builtin_error(
+                                name,
+                                format!("{name}: multiple 'like' specifications are not supported"),
+                            ));
+                        }
+                        let Some(proto) = args.get(idx + 1).cloned() else {
+                            return Err(builtin_error(
+                                name,
+                                format!("{name}: expected prototype after 'like'"),
+                            ));
+                        };
+                        saw_like = true;
+                        if shape_source.is_none() && !saw_dims_arg {
+                            shape_source =
+                                Some(shape_from_value(&proto).map_err(|e| builtin_error(name, e))?);
+                        }
+                        idx += 2;
+                        continue;
+                    }
+                    "logical" => {
+                        idx += 1;
+                        continue;
+                    }
+                    other => {
+                        return Err(builtin_error(
+                            name,
+                            format!("{name}: unrecognised option '{other}'"),
+                        ));
+                    }
+                }
+            }
+
+            if let Some(parsed_dims) = extract_dims(&arg, name).await? {
+                saw_dims_arg = true;
+                if dims.is_empty() {
+                    dims = parsed_dims;
+                } else {
+                    dims.extend(parsed_dims);
+                }
+                idx += 1;
+                continue;
+            }
+
+            if shape_source.is_none() {
+                shape_source =
+                    Some(shape_from_value(&arg).map_err(|e| builtin_error(name, e))?);
+            }
+            idx += 1;
+        }
+
+        let shape = if saw_dims_arg {
+            if dims.is_empty() {
+                vec![0, 0]
+            } else if dims.len() == 1 {
+                vec![dims[0], dims[0]]
+            } else {
+                dims
+            }
+        } else if let Some(shape) = shape_source {
+            shape
+        } else {
+            vec![1, 1]
+        };
+
+        Ok(Self { shape })
+    }
+}
+
+fn keyword_of(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) => Some(s.to_ascii_lowercase()),
+        Value::StringArray(sa) if sa.data.len() == 1 => Some(sa.data[0].to_ascii_lowercase()),
+        Value::CharArray(ca) if ca.rows == 1 => {
+            let text: String = ca.data.iter().collect();
+            Some(text.to_ascii_lowercase())
+        }
+        _ => None,
+    }
+}
+
+async fn extract_dims(value: &Value, name: &str) -> BuiltinResult<Option<Vec<usize>>> {
+    if matches!(value, Value::LogicalArray(_)) {
+        return Ok(None);
+    }
+    let gpu_scalar = match value {
+        Value::GpuTensor(handle) => tensor::element_count(&handle.shape) == 1,
+        _ => false,
+    };
+    match tensor::dims_from_value_async(value).await {
+        Ok(dims) => Ok(dims),
+        Err(err) => {
+            if matches!(value, Value::Tensor(_))
+                || (matches!(value, Value::GpuTensor(_)) && !gpu_scalar)
+            {
+                Ok(None)
+            } else {
+                Err(builtin_error(name, format!("{name}: {err}")))
+            }
+        }
+    }
+}
+
+fn shape_from_value(value: &Value) -> Result<Vec<usize>, String> {
+    match value {
+        Value::Tensor(t) => Ok(t.shape.clone()),
+        Value::ComplexTensor(t) => Ok(t.shape.clone()),
+        Value::LogicalArray(l) => Ok(l.shape.clone()),
+        Value::GpuTensor(h) => Ok(normalize_scalar_shape(&h.shape)),
+        Value::CharArray(ca) => Ok(vec![ca.rows, ca.cols]),
+        Value::Cell(cell) => Ok(vec![cell.rows, cell.cols]),
+        Value::Num(_) | Value::Int(_) | Value::Bool(_) | Value::Complex(_, _) => Ok(vec![1, 1]),
+        other => Err(format!("unsupported prototype {other:?}")),
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::Tensor;
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn true_default_scalar() {
+        let result = block_on(true_builtin(Vec::new())).expect("true");
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn false_default_scalar() {
+        let result = block_on(false_builtin(Vec::new())).expect("false");
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn true_with_dims() {
+        let args = vec![Value::Num(2.0), Value::Num(1.0)];
+        let result = block_on(true_builtin(args)).expect("true");
+        match result {
+            Value::LogicalArray(logical) => {
+                assert_eq!(logical.shape, vec![2, 1]);
+                assert!(logical.data.iter().all(|&x| x == 1));
+            }
+            other => panic!("expected logical array, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn false_from_size_vector() {
+        let size_vec = Tensor::new(vec![2.0, 3.0], vec![2, 1]).unwrap();
+        let args = vec![Value::Tensor(size_vec)];
+        let result = block_on(false_builtin(args)).expect("false");
+        match result {
+            Value::LogicalArray(logical) => {
+                assert_eq!(logical.shape, vec![2, 3]);
+                assert!(logical.data.iter().all(|&x| x == 0));
+            }
+            other => panic!("expected logical array, got {other:?}"),
+        }
+    }
+}

--- a/crates/runmat-runtime/src/builtins/array/creation/zeros.rs
+++ b/crates/runmat-runtime/src/builtins/array/creation/zeros.rs
@@ -85,6 +85,8 @@ enum OutputTemplate {
     /// single precision when allocating on GPU via 'like' or provider hooks.
     Single,
     Logical,
+    /// GPU-resident zeros array request via 'gpuArray' keyword or gpuArray.zeros() static method
+    GpuArray,
     Like(Value),
 }
 
@@ -150,6 +152,16 @@ impl ParsedZeros {
                             ));
                         }
                         class_override = Some(OutputTemplate::Single);
+                        idx += 1;
+                        continue;
+                    }
+                    "gpuArray" | "gpuarray" => {
+                        if like_proto.is_some() {
+                            return Err(builtin_error(
+                                "zeros: cannot combine 'like' with 'gpuArray'",
+                            ));
+                        }
+                        class_override = Some(OutputTemplate::GpuArray);
                         idx += 1;
                         continue;
                     }
@@ -230,6 +242,7 @@ async fn build_output(parsed: ParsedZeros) -> crate::BuiltinResult<Value> {
         OutputTemplate::Double => zeros_double(&parsed.shape),
         OutputTemplate::Single => zeros_single(&parsed.shape),
         OutputTemplate::Logical => zeros_logical(&parsed.shape),
+        OutputTemplate::GpuArray => zeros_gpu(&parsed.shape).await,
         OutputTemplate::Like(proto) => zeros_like(&proto, &parsed.shape).await,
     }
 }
@@ -285,6 +298,36 @@ fn force_host_allocation(shape: &[usize]) -> bool {
 
 fn zeros_logical(shape: &[usize]) -> crate::BuiltinResult<Value> {
     Ok(Value::LogicalArray(LogicalArray::zeros(shape.to_vec())))
+}
+
+/// Create a GPU-resident zeros array. Falls back to host tensor if no GPU provider.
+async fn zeros_gpu(shape: &[usize]) -> crate::BuiltinResult<Value> {
+    // Try to allocate on GPU with default precision (usually F32)
+    if let Some(provider) = runmat_accelerate_api::provider() {
+        let precision = provider.precision();
+        let dtype = dtype_from_precision(precision);
+        match provider.zeros(shape) {
+            Ok(handle) => {
+                runmat_accelerate_api::set_handle_precision(&handle, precision);
+                return Ok(Value::GpuTensor(handle));
+            }
+            Err(err) => {
+                log::debug!("zeros_gpu: provider.zeros failed ({err}); falling back to host upload");
+            }
+        }
+        // Fallback: build a host tensor and upload
+        let host = tensor::zeros_with_dtype(shape, dtype)?;
+        let view = HostTensorView {
+            data: &host.data,
+            shape: &host.shape,
+        };
+        if let Ok(gpu) = provider.upload(&view) {
+            runmat_accelerate_api::set_handle_precision(&gpu, precision);
+            return Ok(Value::GpuTensor(gpu));
+        }
+    }
+    // No GPU provider: fall back to host double tensor
+    zeros_double(shape)
 }
 
 #[async_recursion::async_recursion(?Send)]

--- a/crates/runmat-runtime/src/builtins/builtins-json/arrayfun.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/arrayfun.json
@@ -61,7 +61,7 @@
     {
       "description": "Handling errors with a custom error handler",
       "input": "vals = [-1 0 1];\nhandler = @(err, x) err.identifier;\nsafe = arrayfun(@(x) sqrt(x), vals, 'ErrorHandler', handler, 'UniformOutput', false)",
-      "output": "safe =\n  1\u00d73 cell array\n    {'MATLAB:arrayfun:FunctionError'}    {[0]}    {[1]}"
+      "output": "safe =\n  1\u00d73 cell array\n    {[0+1i]}    {[0]}    {[1]}"
     },
     {
       "description": "Working with `gpuArray` inputs",

--- a/crates/runmat-runtime/src/builtins/builtins-json/cellfun.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/cellfun.json
@@ -71,7 +71,7 @@
     {
       "description": "Returning rich metadata in the error handler",
       "input": "cells = {1, 'two', 3};\neh = @(err, value) sprintf('%s @ %d', err.identifier, err.index);\nresults = cellfun(@(x) x + 1, cells, 'UniformOutput', false, 'ErrorHandler', eh)",
-      "output": "results =\n  1\u00d73 cell array\n    {[2]}    {'MATLAB:UndefinedFunction @ 2'}    {[4]}"
+      "output": "results =\n  1\u00d73 cell array\n    {[2]}    {[117 120 112]}    {[4]}"
     }
   ],
   "faqs": [

--- a/crates/runmat-runtime/src/builtins/builtins-json/false.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/false.json
@@ -1,0 +1,101 @@
+{
+  "title": "false",
+  "category": "array/creation",
+  "keywords": [
+    "false",
+    "logical",
+    "array",
+    "mask"
+  ],
+  "summary": "Create logical arrays filled with false values.",
+  "references": [],
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [],
+    "broadcasting": "none",
+    "notes": "Always constructs a host logical array; gpuArray inputs are used only for sizing."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 0,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::array::creation::true_false::tests",
+    "integration": null
+  },
+  "description": "`false` creates logical arrays filled with false values. RunMat mirrors MATLAB sizing semantics across scalar, vector, matrix, and N-D forms.",
+  "behaviors": [
+    "`false()` returns the scalar logical `false`.",
+    "`false(n)` returns an n x n logical array of false values.",
+    "`false(m, n, ...)` returns a logical array with the requested dimensions.",
+    "`false(sz)` accepts a size vector (row or column) and returns an array with prod(sz) elements arranged using MATLAB column-major ordering.",
+    "`false(A)` returns a logical array of false with the same size as `A`.",
+    "`false(___, 'like', prototype)` uses the prototype only for sizing; the result is still a host logical array.",
+    "`false(___, 'logical')` is accepted for MATLAB compatibility and has no effect."
+  ],
+  "examples": [
+    {
+      "description": "Creating a 2x3 logical array of false values",
+      "input": "mask = false(2, 3)",
+      "output": "mask = [0 0 0; 0 0 0];"
+    },
+    {
+      "description": "Creating a logical array from a size vector",
+      "input": "dims = [1 4 2];\nmask = false(dims)",
+      "output": "mask =\n  1x4x2 logical array\n     0     0     0     0\n     0     0     0     0"
+    },
+    {
+      "description": "Creating a false mask with the same size as an existing array",
+      "input": "A = rand(2, 2);\nmask = false(A)",
+      "output": "mask =\n  2x2 logical array\n     0     0\n     0     0"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What does `false()` return?",
+      "answer": "It returns the logical scalar `false`."
+    },
+    {
+      "question": "Does `false(n)` create a square array?",
+      "answer": "Yes. `false(n)` returns an n x n logical array of false values, matching MATLAB behavior."
+    },
+    {
+      "question": "How does `false(sz)` interpret a size vector?",
+      "answer": "A row or column vector is treated as the full set of dimensions, so `false([2 3 4])` yields a 2x3x4 logical array."
+    },
+    {
+      "question": "Does `false` keep results on the GPU?",
+      "answer": "No. The builtin always returns a host logical array. gpuArray inputs are only used to infer the output size."
+    },
+    {
+      "question": "Is the `'logical'` option required?",
+      "answer": "No. `false` always returns logical values; the `'logical'` option is accepted only for MATLAB compatibility."
+    }
+  ],
+  "links": [
+    {
+      "label": "true",
+      "url": "./true"
+    },
+    {
+      "label": "logical",
+      "url": "./logical"
+    },
+    {
+      "label": "islogical",
+      "url": "./islogical"
+    },
+    {
+      "label": "zeros",
+      "url": "./zeros"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/array/creation/true_false.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/array/creation/true_false.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/builtins-json/isequal.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/isequal.json
@@ -1,0 +1,124 @@
+{
+  "title": "isequal",
+  "category": "logical/rel",
+  "keywords": [
+    "isequal",
+    "equality",
+    "comparison",
+    "logical",
+    "array comparison"
+  ],
+  "summary": "Test arrays for equality in size, class, and content.",
+  "references": [],
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [],
+    "broadcasting": "none",
+    "notes": "GPU tensors are gathered to the host before comparison. Future versions may add native GPU comparison paths."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 0,
+    "constants": "none"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::logical::rel::isequal::tests",
+    "integration": null
+  },
+  "description": "`isequal` compares two or more arrays and returns `true` (logical 1) if they all have the same size, class, and content, and `false` (logical 0) otherwise. NaN values are NOT considered equal; use `isequaln` to treat NaN values as equal.",
+  "behaviors": [
+    "`isequal(A, B)` compares two values for equality.",
+    "`isequal(A, B, C, ...)` compares all inputs against each other; returns `true` only if all are equal.",
+    "Arrays must have identical shape (size) to be equal.",
+    "Arrays must have matching data types (class) to be equal.",
+    "All corresponding elements must be identical for arrays to be equal.",
+    "NaN values are NOT equal to each other (NaN ~= NaN).",
+    "Empty arrays `[]` are equal to other empty arrays with the same shape.",
+    "Cell arrays are compared element-by-element recursively.",
+    "Structs are compared field-by-field."
+  ],
+  "examples": [
+    {
+      "description": "Comparing two identical scalars",
+      "input": "isequal(5, 5)",
+      "output": "ans = logical\n     1"
+    },
+    {
+      "description": "Comparing two different scalars",
+      "input": "isequal(5, 6)",
+      "output": "ans = logical\n     0"
+    },
+    {
+      "description": "Comparing identical matrices",
+      "input": "A = [1 2; 3 4];\nB = [1 2; 3 4];\nisequal(A, B)",
+      "output": "ans = logical\n     1"
+    },
+    {
+      "description": "Comparing matrices with different shapes",
+      "input": "A = [1 2 3];\nB = [1; 2; 3];\nisequal(A, B)",
+      "output": "ans = logical\n     0"
+    },
+    {
+      "description": "Comparing multiple arrays at once",
+      "input": "isequal([1 2], [1 2], [1 2])",
+      "output": "ans = logical\n     1"
+    },
+    {
+      "description": "NaN values are not equal",
+      "input": "isequal(NaN, NaN)",
+      "output": "ans = logical\n     0"
+    },
+    {
+      "description": "Verifying that every cell starts with `[]`",
+      "input": "C = cell(2, 2);\nisequal(C{1,1}, [], C{2,2}, [])",
+      "output": "ans = logical\n     1"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How is `isequal` different from `==`?",
+      "answer": "`isequal` returns a single logical value indicating whether all inputs are completely identical. The `==` operator performs element-wise comparison and returns an array of the same size as the inputs."
+    },
+    {
+      "question": "How does `isequal` handle NaN values?",
+      "answer": "NaN values are NOT considered equal. `isequal(NaN, NaN)` returns `false`. Use `isequaln` if you want NaN values to be treated as equal."
+    },
+    {
+      "question": "Can I compare more than two arrays?",
+      "answer": "Yes. `isequal(A, B, C, ...)` accepts any number of inputs and returns `true` only if all inputs are equal to each other."
+    },
+    {
+      "question": "Are empty arrays equal?",
+      "answer": "Empty arrays with the same shape are equal. For example, `isequal([], [])` returns `true`, and `isequal(zeros(0,3), zeros(0,3))` returns `true`."
+    },
+    {
+      "question": "How are cell arrays compared?",
+      "answer": "Cell arrays are compared element-by-element. Each corresponding pair of cells must contain equal values for the cell arrays to be equal."
+    },
+    {
+      "question": "What happens with different data types?",
+      "answer": "Values of different classes are generally not equal. However, compatible numeric types (like `double` and `single`, or `double` and `logical`) may be compared after appropriate promotion."
+    }
+  ],
+  "links": [
+    {
+      "label": "eq",
+      "url": "./eq"
+    },
+    {
+      "label": "strcmp",
+      "url": "./strcmp"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/logical/rel/isequal.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/logical/rel/isequal.rs"
+  },
+  "gpu_residency": "None. `isequal` gathers GPU tensors to the host for comparison. The result is always a host logical scalar.",
+  "gpu_behavior": [
+    "When comparing gpuArray inputs, `isequal` gathers all tensors to the host before performing the comparison. The result is a scalar logical value on the host."
+  ]
+}

--- a/crates/runmat-runtime/src/builtins/builtins-json/true.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/true.json
@@ -1,0 +1,101 @@
+{
+  "title": "true",
+  "category": "array/creation",
+  "keywords": [
+    "true",
+    "logical",
+    "array",
+    "mask"
+  ],
+  "summary": "Create logical arrays filled with true values.",
+  "references": [],
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [],
+    "broadcasting": "none",
+    "notes": "Always constructs a host logical array; gpuArray inputs are used only for sizing."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 0,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::array::creation::true_false::tests",
+    "integration": null
+  },
+  "description": "`true` creates logical arrays filled with true values. RunMat mirrors MATLAB sizing semantics across scalar, vector, matrix, and N-D forms.",
+  "behaviors": [
+    "`true()` returns the scalar logical `true`.",
+    "`true(n)` returns an n x n logical array of true values.",
+    "`true(m, n, ...)` returns a logical array with the requested dimensions.",
+    "`true(sz)` accepts a size vector (row or column) and returns an array with prod(sz) elements arranged using MATLAB column-major ordering.",
+    "`true(A)` returns a logical array of true with the same size as `A`.",
+    "`true(___, 'like', prototype)` uses the prototype only for sizing; the result is still a host logical array.",
+    "`true(___, 'logical')` is accepted for MATLAB compatibility and has no effect."
+  ],
+  "examples": [
+    {
+      "description": "Creating a 2x3 logical array of true values",
+      "input": "mask = true(2, 3)",
+      "output": "mask = [1 1 1; 1 1 1];"
+    },
+    {
+      "description": "Creating a logical array from a size vector",
+      "input": "dims = [2 1 3];\nmask = true(dims)",
+      "output": "mask =\n  2x1x3 logical array\n     1\n     1\n     1\n     1\n     1\n     1"
+    },
+    {
+      "description": "Creating a true mask with the same size as an existing array",
+      "input": "A = rand(3, 2);\nmask = true(A)",
+      "output": "mask =\n  3x2 logical array\n     1     1\n     1     1\n     1     1"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What does `true()` return?",
+      "answer": "It returns the logical scalar `true`."
+    },
+    {
+      "question": "Does `true(n)` create a square array?",
+      "answer": "Yes. `true(n)` returns an n x n logical array of true values, matching MATLAB behavior."
+    },
+    {
+      "question": "How does `true(sz)` interpret a size vector?",
+      "answer": "A row or column vector is treated as the full set of dimensions, so `true([2 3 4])` yields a 2x3x4 logical array."
+    },
+    {
+      "question": "Does `true` keep results on the GPU?",
+      "answer": "No. The builtin always returns a host logical array. gpuArray inputs are only used to infer the output size."
+    },
+    {
+      "question": "Is the `'logical'` option required?",
+      "answer": "No. `true` always returns logical values; the `'logical'` option is accepted only for MATLAB compatibility."
+    }
+  ],
+  "links": [
+    {
+      "label": "false",
+      "url": "./false"
+    },
+    {
+      "label": "logical",
+      "url": "./logical"
+    },
+    {
+      "label": "islogical",
+      "url": "./islogical"
+    },
+    {
+      "label": "zeros",
+      "url": "./zeros"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/array/creation/true_false.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/array/creation/true_false.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/cells/core/cellfun.rs
+++ b/crates/runmat-runtime/src/builtins/cells/core/cellfun.rs
@@ -12,7 +12,7 @@ use crate::builtins::common::spec::{
 };
 use crate::{
     build_runtime_error, call_builtin_async, gather_if_needed_async, make_cell_with_shape,
-    BuiltinResult, RuntimeError,
+    user_functions, BuiltinResult, RuntimeError,
 };
 
 #[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::cells::core::cellfun")]
@@ -494,6 +494,11 @@ impl Callable {
             Callable::Closure(c) => {
                 let mut captures = c.captures.clone();
                 captures.extend_from_slice(args);
+                if let Some(result) =
+                    user_functions::try_call_user_function(&c.function_name, &captures).await
+                {
+                    return result;
+                }
                 call_builtin_async(&c.function_name, &captures).await
             }
             Callable::Special(special) => special.call(args).await,

--- a/crates/runmat-runtime/src/builtins/io/repl_fs/tempname.rs
+++ b/crates/runmat-runtime/src/builtins/io/repl_fs/tempname.rs
@@ -170,9 +170,20 @@ fn unique_token() -> String {
         .unwrap_or_default();
     let secs = now.as_secs();
     let nanos = now.subsec_nanos();
-    let pid = std::process::id() as u64;
+    let pid = process_id();
     let counter = UNIQUE_COUNTER.fetch_add(1, Ordering::Relaxed);
     format!("tp{:016x}{:08x}{:08x}{:016x}", secs, nanos, pid, counter)
+}
+
+fn process_id() -> u64 {
+    #[cfg(target_arch = "wasm32")]
+    {
+        0
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::process::id() as u64
+    }
 }
 
 fn path_to_value(path: &Path) -> Value {

--- a/crates/runmat-runtime/src/builtins/logical/rel/isequal.rs
+++ b/crates/runmat-runtime/src/builtins/logical/rel/isequal.rs
@@ -1,0 +1,377 @@
+//! MATLAB-compatible `isequal` builtin for RunMat.
+//!
+//! Tests whether all input arrays have the same size, class, and content.
+
+use runmat_builtins::{CharArray, ComplexTensor, LogicalArray, StringArray, Tensor, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::gpu_helpers;
+use crate::{build_runtime_error, RuntimeError};
+
+const BUILTIN_NAME: &str = "isequal";
+const IDENT_NOT_ENOUGH_INPUTS: &str = "MATLAB:isequal:NotEnoughInputs";
+
+fn isequal_error(message: impl Into<String>, identifier: &'static str) -> RuntimeError {
+    build_runtime_error(message)
+        .with_builtin(BUILTIN_NAME)
+        .with_identifier(identifier)
+        .build()
+}
+
+/// Compares all input values for equality.
+///
+/// Returns `true` if all inputs have the same size, class, and content.
+/// Returns `false` otherwise. NaN values are NOT considered equal.
+#[runtime_builtin(
+    name = "isequal",
+    category = "logical/rel",
+    summary = "Test arrays for equality in size, class, and content.",
+    keywords = "isequal,equality,comparison,logical",
+    accel = "cpu",
+    builtin_path = "crate::builtins::logical::rel::isequal"
+)]
+async fn isequal_builtin(args: Vec<Value>) -> crate::BuiltinResult<Value> {
+    if args.len() < 2 {
+        return Err(isequal_error(
+            "isequal: requires at least two input arguments",
+            IDENT_NOT_ENOUGH_INPUTS,
+        ));
+    }
+
+    // Gather all values to host if needed
+    let mut gathered = Vec::with_capacity(args.len());
+    for arg in args {
+        gathered.push(gather_value(arg).await?);
+    }
+
+    // Compare first value against all others
+    let first = &gathered[0];
+    for other in gathered.iter().skip(1) {
+        if !values_equal(first, other) {
+            return Ok(Value::Bool(false));
+        }
+    }
+
+    Ok(Value::Bool(true))
+}
+
+async fn gather_value(value: Value) -> crate::BuiltinResult<Value> {
+    match value {
+        Value::GpuTensor(handle) => {
+            let tensor = gpu_helpers::gather_tensor_async(&handle)
+                .await
+                .map_err(|err| isequal_error(format!("{BUILTIN_NAME}: {err}"), IDENT_NOT_ENOUGH_INPUTS))?;
+            Ok(Value::Tensor(tensor))
+        }
+        other => Ok(other),
+    }
+}
+
+/// Compare two values for equality (same size, class, and content).
+/// NaN values are NOT considered equal.
+fn values_equal(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        // Numeric scalars
+        (Value::Num(x), Value::Num(y)) => x == y,
+        (Value::Bool(x), Value::Bool(y)) => x == y,
+        (Value::Int(x), Value::Int(y)) => x == y,
+
+        // Promote scalar to match types
+        (Value::Num(x), Value::Bool(y)) => *x == if *y { 1.0 } else { 0.0 },
+        (Value::Bool(x), Value::Num(y)) => (if *x { 1.0 } else { 0.0 }) == *y,
+        (Value::Num(x), Value::Int(y)) => *x == y.to_f64(),
+        (Value::Int(x), Value::Num(y)) => x.to_f64() == *y,
+        (Value::Bool(x), Value::Int(y)) => (if *x { 1 } else { 0 }) == y.as_i64(),
+        (Value::Int(x), Value::Bool(y)) => x.as_i64() == if *y { 1 } else { 0 },
+
+        // Complex scalars
+        (Value::Complex(ar, ai), Value::Complex(br, bi)) => ar == br && ai == bi,
+        (Value::Num(x), Value::Complex(br, bi)) => *x == *br && *bi == 0.0,
+        (Value::Complex(ar, ai), Value::Num(y)) => *ar == *y && *ai == 0.0,
+
+        // Tensors
+        (Value::Tensor(a), Value::Tensor(b)) => tensors_equal(a, b),
+        (Value::Tensor(t), Value::Num(n)) => scalar_tensor_equal(t, *n),
+        (Value::Num(n), Value::Tensor(t)) => scalar_tensor_equal(t, *n),
+
+        // Complex tensors
+        (Value::ComplexTensor(a), Value::ComplexTensor(b)) => complex_tensors_equal(a, b),
+
+        // Logical arrays
+        (Value::LogicalArray(a), Value::LogicalArray(b)) => logical_arrays_equal(a, b),
+        (Value::Bool(x), Value::LogicalArray(a)) => scalar_logical_equal(a, *x),
+        (Value::LogicalArray(a), Value::Bool(x)) => scalar_logical_equal(a, *x),
+
+        // Character arrays
+        (Value::CharArray(a), Value::CharArray(b)) => char_arrays_equal(a, b),
+
+        // Strings
+        (Value::String(a), Value::String(b)) => a == b,
+        (Value::StringArray(a), Value::StringArray(b)) => string_arrays_equal(a, b),
+        (Value::String(a), Value::StringArray(b)) => {
+            b.shape == vec![1, 1] && b.data.len() == 1 && b.data[0] == *a
+        }
+        (Value::StringArray(a), Value::String(b)) => {
+            a.shape == vec![1, 1] && a.data.len() == 1 && a.data[0] == *b
+        }
+
+        // Cells
+        (Value::Cell(a), Value::Cell(b)) => cells_equal(a, b),
+
+        // Cell arrays with shape
+        (Value::CellArray(a), Value::CellArray(b)) => {
+            a.shape == b.shape && cells_equal(&a.data, &b.data)
+        }
+
+        // Structs
+        (Value::Struct(a), Value::Struct(b)) => structs_equal(a, b),
+
+        // Empty arrays - check shape compatibility
+        (Value::Empty, Value::Empty) => true,
+        (Value::Empty, Value::Tensor(t)) => t.data.is_empty(),
+        (Value::Tensor(t), Value::Empty) => t.data.is_empty(),
+        (Value::Empty, Value::LogicalArray(a)) => a.data.is_empty(),
+        (Value::LogicalArray(a), Value::Empty) => a.data.is_empty(),
+        (Value::Empty, Value::Cell(c)) => c.is_empty(),
+        (Value::Cell(c), Value::Empty) => c.is_empty(),
+
+        // Different types are not equal
+        _ => false,
+    }
+}
+
+fn tensors_equal(a: &Tensor, b: &Tensor) -> bool {
+    if a.shape != b.shape {
+        return false;
+    }
+    if a.data.len() != b.data.len() {
+        return false;
+    }
+    // NaN != NaN in isequal (use isequaln for NaN equality)
+    a.data.iter().zip(b.data.iter()).all(|(x, y)| x == y)
+}
+
+fn scalar_tensor_equal(t: &Tensor, n: f64) -> bool {
+    if t.data.len() != 1 {
+        return false;
+    }
+    t.data[0] == n
+}
+
+fn complex_tensors_equal(a: &ComplexTensor, b: &ComplexTensor) -> bool {
+    if a.shape != b.shape {
+        return false;
+    }
+    if a.data.len() != b.data.len() {
+        return false;
+    }
+    a.data
+        .iter()
+        .zip(b.data.iter())
+        .all(|((ar, ai), (br, bi))| ar == br && ai == bi)
+}
+
+fn logical_arrays_equal(a: &LogicalArray, b: &LogicalArray) -> bool {
+    if a.shape != b.shape {
+        return false;
+    }
+    a.data == b.data
+}
+
+fn scalar_logical_equal(a: &LogicalArray, x: bool) -> bool {
+    if a.data.len() != 1 {
+        return false;
+    }
+    (a.data[0] != 0) == x
+}
+
+fn char_arrays_equal(a: &CharArray, b: &CharArray) -> bool {
+    a.rows == b.rows && a.cols == b.cols && a.data == b.data
+}
+
+fn string_arrays_equal(a: &StringArray, b: &StringArray) -> bool {
+    if a.shape != b.shape {
+        return false;
+    }
+    a.data == b.data
+}
+
+fn cells_equal(a: &[Value], b: &[Value]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b.iter()).all(|(x, y)| values_equal(x, y))
+}
+
+fn structs_equal(
+    a: &std::collections::HashMap<String, Value>,
+    b: &std::collections::HashMap<String, Value>,
+) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    for (key, val_a) in a {
+        match b.get(key) {
+            Some(val_b) => {
+                if !values_equal(val_a, val_b) {
+                    return false;
+                }
+            }
+            None => return false,
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::CellArray;
+
+    fn run_isequal(args: Vec<Value>) -> crate::BuiltinResult<Value> {
+        block_on(isequal_builtin(args))
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_two_scalars_equal() {
+        let result = run_isequal(vec![Value::Num(5.0), Value::Num(5.0)]).expect("isequal");
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_two_scalars_not_equal() {
+        let result = run_isequal(vec![Value::Num(5.0), Value::Num(4.0)]).expect("isequal");
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_three_args_all_equal() {
+        let result =
+            run_isequal(vec![Value::Num(3.0), Value::Num(3.0), Value::Num(3.0)]).expect("isequal");
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_three_args_one_different() {
+        let result =
+            run_isequal(vec![Value::Num(3.0), Value::Num(3.0), Value::Num(4.0)]).expect("isequal");
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_tensors_equal() {
+        let t1 = Tensor::new(vec![1.0, 2.0, 3.0], vec![1, 3]).unwrap();
+        let t2 = Tensor::new(vec![1.0, 2.0, 3.0], vec![1, 3]).unwrap();
+        let result = run_isequal(vec![Value::Tensor(t1), Value::Tensor(t2)]).expect("isequal");
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_tensors_different_shape() {
+        let t1 = Tensor::new(vec![1.0, 2.0, 3.0], vec![1, 3]).unwrap();
+        let t2 = Tensor::new(vec![1.0, 2.0, 3.0], vec![3, 1]).unwrap();
+        let result = run_isequal(vec![Value::Tensor(t1), Value::Tensor(t2)]).expect("isequal");
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_tensors_different_values() {
+        let t1 = Tensor::new(vec![1.0, 2.0, 3.0], vec![1, 3]).unwrap();
+        let t2 = Tensor::new(vec![1.0, 2.0, 4.0], vec![1, 3]).unwrap();
+        let result = run_isequal(vec![Value::Tensor(t1), Value::Tensor(t2)]).expect("isequal");
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_empty_arrays() {
+        // Test that empty arrays are equal
+        let result = run_isequal(vec![Value::Empty, Value::Empty]).expect("isequal");
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_empty_cell_arrays() {
+        // Test the cell example from the failing test: cell(2,2) elements should be []
+        let c1 = CellArray::new(vec![Value::Empty; 4], vec![2, 2]).unwrap();
+        let c2 = CellArray::new(vec![Value::Empty; 4], vec![2, 2]).unwrap();
+        let result =
+            run_isequal(vec![Value::CellArray(c1), Value::CellArray(c2)]).expect("isequal");
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_cell_element_with_empty() {
+        // Test isequal(C{1,1}, [], C{2,2}, []) pattern
+        let result = run_isequal(vec![
+            Value::Empty,
+            Value::Empty,
+            Value::Empty,
+            Value::Empty,
+        ])
+        .expect("isequal");
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_nan_not_equal() {
+        // In isequal, NaN != NaN (use isequaln for NaN equality)
+        let result = run_isequal(vec![Value::Num(f64::NAN), Value::Num(f64::NAN)]).expect("isequal");
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_strings() {
+        let result = run_isequal(vec![
+            Value::String("hello".into()),
+            Value::String("hello".into()),
+        ])
+        .expect("isequal");
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_different_types() {
+        let result = run_isequal(vec![Value::Num(5.0), Value::String("5".into())]).expect("isequal");
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_not_enough_args() {
+        let err = run_isequal(vec![Value::Num(5.0)]).unwrap_err();
+        assert!(err.message().contains("at least two"));
+        assert_eq!(err.identifier(), Some(IDENT_NOT_ENOUGH_INPUTS));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_bool_and_num() {
+        let result = run_isequal(vec![Value::Bool(true), Value::Num(1.0)]).expect("isequal");
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn isequal_complex() {
+        let result = run_isequal(vec![
+            Value::Complex(1.0, 2.0),
+            Value::Complex(1.0, 2.0),
+        ])
+        .expect("isequal");
+        assert_eq!(result, Value::Bool(true));
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/trigonometry/acos.rs
+++ b/crates/runmat-runtime/src/builtins/math/trigonometry/acos.rs
@@ -168,9 +168,9 @@ fn acos_tensor_real(tensor: Tensor) -> BuiltinResult<Value> {
     let mut complex_data = Vec::with_capacity(len);
 
     for &v in &tensor.data {
-        let result = Complex64::new(v, 0.0).acos();
-        let re = zero_small(result.re);
-        let im = zero_small(result.im);
+        let (re, im) = acos_real_matlab(v);
+        let re = zero_small(re);
+        let im = zero_small(im);
         if im.abs() > ZERO_EPS {
             requires_complex = true;
         }
@@ -191,6 +191,30 @@ fn acos_tensor_real(tensor: Tensor) -> BuiltinResult<Value> {
         let tensor = Tensor::new(real_data, tensor.shape.clone())
             .map_err(|e| runtime_error_for(format!("acos: {e}")))?;
         Ok(tensor::tensor_into_value(tensor))
+    }
+}
+
+/// MATLAB-compatible acos for real values.
+///
+/// For values within `[-1, 1]`, returns the standard real acos.
+/// For values outside this range, MATLAB's principal branch is:
+/// - `x > 1`:  `acos(x) = -i * acosh(x)`  → `(0, -acosh(x))`
+/// - `x < -1`: `acos(x) = π - i * acosh(-x)` → `(π, -acosh(-x))`
+///
+/// This differs from `num_complex::Complex64::acos()` which uses a different branch cut.
+fn acos_real_matlab(x: f64) -> (f64, f64) {
+    if x.is_nan() {
+        return (f64::NAN, 0.0);
+    }
+    if (-1.0..=1.0).contains(&x) {
+        // Within domain: real result
+        (x.acos(), 0.0)
+    } else if x > 1.0 {
+        // x > 1: acos(x) = -i * acosh(x)
+        (0.0, -x.acosh())
+    } else {
+        // x < -1: acos(x) = π - i * acosh(-x)
+        (std::f64::consts::PI, -(-x).acosh())
     }
 }
 
@@ -266,14 +290,69 @@ pub(crate) mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn acos_scalar_outside_domain_returns_complex() {
+        // For x > 1, MATLAB returns acos(x) = -i * acosh(x)
         let result = acos_builtin(Value::Num(1.2)).expect("acos");
         match result {
             Value::Complex(re, im) => {
-                let expected = Complex64::new(1.2, 0.0).acos();
-                assert!((re - expected.re).abs() < 1e-10);
-                assert!((im - expected.im).abs() < 1e-10);
+                // MATLAB: acos(1.2) = 0 - 0.6224i
+                assert!(re.abs() < 1e-10, "real part should be ~0, got {}", re);
+                let expected_im = -1.2f64.acosh(); // negative imaginary
+                assert!(
+                    (im - expected_im).abs() < 1e-10,
+                    "expected im={}, got im={}",
+                    expected_im,
+                    im
+                );
             }
             other => panic!("unexpected result {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn acos_of_two_matches_matlab() {
+        // MATLAB: acos(2) = 0 - 1.3170i
+        // This is the principal branch: acos(x) = -i * acosh(x) for x > 1
+        let result = acos_builtin(Value::Num(2.0)).expect("acos(2)");
+        match result {
+            Value::Complex(re, im) => {
+                assert!(re.abs() < 1e-10, "expected re=0, got {}", re);
+                // acosh(2) ≈ 1.3169578969248166
+                let expected_im = -2.0f64.acosh();
+                assert!(
+                    (im - expected_im).abs() < 1e-10,
+                    "expected im≈{:.4}, got im≈{:.4}",
+                    expected_im,
+                    im
+                );
+                // Verify the sign is negative (MATLAB convention)
+                assert!(im < 0.0, "imaginary part should be negative, got {}", im);
+            }
+            other => panic!("expected complex result, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn acos_negative_outside_domain() {
+        // MATLAB: acos(-2) = π - i * acosh(2) ≈ 3.1416 - 1.3170i
+        let result = acos_builtin(Value::Num(-2.0)).expect("acos(-2)");
+        match result {
+            Value::Complex(re, im) => {
+                assert!(
+                    (re - std::f64::consts::PI).abs() < 1e-10,
+                    "expected re=π, got {}",
+                    re
+                );
+                let expected_im = -2.0f64.acosh();
+                assert!(
+                    (im - expected_im).abs() < 1e-10,
+                    "expected im≈{:.4}, got im≈{:.4}",
+                    expected_im,
+                    im
+                );
+            }
+            other => panic!("expected complex result, got {other:?}"),
         }
     }
 
@@ -317,16 +396,34 @@ pub(crate) mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
     fn acos_char_array_complex_promotion() {
+        // 'B' has ASCII code 66, which is > 1, so complex promotion is required.
+        // MATLAB: acos(66) = 0 - i * acosh(66)
         let chars = CharArray::new("B".chars().collect(), 1, 1).expect("char");
         let result = acos_builtin(Value::CharArray(chars)).expect("acos char");
         match result {
             Value::Complex(re, im) => {
-                let expected = Complex64::new('B' as u32 as f64, 0.0).acos();
-                assert!((re - expected.re).abs() < 1e-10);
-                assert!((im - expected.im).abs() < 1e-10);
+                let x = 'B' as u32 as f64; // 66.0
+                assert!(re.abs() < 1e-10, "expected re=0, got {}", re);
+                let expected_im = -x.acosh();
+                assert!(
+                    (im - expected_im).abs() < 1e-10,
+                    "expected im={}, got {}",
+                    expected_im,
+                    im
+                );
             }
             Value::ComplexTensor(ct) => {
                 assert_eq!(ct.data.len(), 1);
+                let (re, im) = ct.data[0];
+                let x = 'B' as u32 as f64;
+                assert!(re.abs() < 1e-10, "expected re=0, got {}", re);
+                let expected_im = -x.acosh();
+                assert!(
+                    (im - expected_im).abs() < 1e-10,
+                    "expected im={}, got {}",
+                    expected_im,
+                    im
+                );
             }
             other => panic!("unexpected result {other:?}"),
         }

--- a/crates/runmat-runtime/src/lib.rs
+++ b/crates/runmat-runtime/src/lib.rs
@@ -32,6 +32,7 @@ pub mod indexing;
 pub mod matrix;
 pub mod plotting_hooks;
 pub mod runtime_error;
+pub mod user_functions;
 pub mod warning_store;
 pub mod workspace;
 

--- a/crates/runmat-runtime/src/user_functions.rs
+++ b/crates/runmat-runtime/src/user_functions.rs
@@ -1,0 +1,45 @@
+use crate::RuntimeError;
+use runmat_builtins::Value;
+use runmat_thread_local::runmat_thread_local;
+use std::cell::RefCell;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+pub type UserFunctionFuture = Pin<Box<dyn Future<Output = Result<Value, RuntimeError>>>>;
+pub type UserFunctionInvoker = dyn Fn(&str, &[Value]) -> UserFunctionFuture + Send + Sync;
+
+runmat_thread_local! {
+    static USER_FUNCTION_INVOKER: RefCell<Option<Arc<UserFunctionInvoker>>> =
+        const { RefCell::new(None) };
+}
+
+pub struct UserFunctionInvokerGuard {
+    previous: Option<Arc<UserFunctionInvoker>>,
+}
+
+impl Drop for UserFunctionInvokerGuard {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        USER_FUNCTION_INVOKER.with(|slot| {
+            *slot.borrow_mut() = previous;
+        });
+    }
+}
+
+pub fn install_user_function_invoker(
+    invoker: Option<Arc<UserFunctionInvoker>>,
+) -> UserFunctionInvokerGuard {
+    let previous =
+        USER_FUNCTION_INVOKER.with(|slot| std::mem::replace(&mut *slot.borrow_mut(), invoker));
+    UserFunctionInvokerGuard { previous }
+}
+
+pub async fn try_call_user_function(
+    name: &str,
+    args: &[Value],
+) -> Option<Result<Value, RuntimeError>> {
+    let invoker = USER_FUNCTION_INVOKER.with(|slot| slot.borrow().clone());
+    let invoker = invoker?;
+    Some(invoker(name, args).await)
+}

--- a/scripts/verify-example-outputs.mjs
+++ b/scripts/verify-example-outputs.mjs
@@ -394,7 +394,7 @@ function createRunnerHtml(timeoutMs, concurrency, logIntervalMs) {
         "      } catch (err) {}",
         "      const execResult = await Promise.resolve(session.execute(testCase.input));",
         "      if (execResult && Array.isArray(execResult.stdout)) {",
-        "        stdoutText = execResult.stdout.map((entry) => entry.text || \"\").join(\"\");",
+        "        stdoutText = execResult.stdout.map((entry) => entry.text || \"\").join(\"\\n\");",
         "      }",
         "      if (execResult && typeof execResult.valueText === \"string\") {",
         "        valueText = execResult.valueText;",

--- a/scripts/verify-example-outputs.mjs
+++ b/scripts/verify-example-outputs.mjs
@@ -145,6 +145,9 @@ function collectCases(dir) {
             if (!example || typeof example.output !== "string") {
                 continue;
             }
+            if (is_comment_only_output(example.output)) {
+                continue;
+            }
             const description = typeof example.description === "string" && example.description.trim().length > 0
                 ? example.description.trim()
                 : `${parsed.title ?? basename(file, ".json")} example ${i + 1}`;
@@ -161,6 +164,27 @@ function collectCases(dir) {
     }
 
     return cases;
+}
+
+/**
+ * Treat examples with only comment lines as documentation-only.
+ * @param {string} output
+ */
+function is_comment_only_output(output) {
+    const lines = output.split(/\r?\n/);
+    let saw_comment = false;
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+            continue;
+        }
+        if (trimmed.startsWith("%")) {
+            saw_comment = true;
+            continue;
+        }
+        return false;
+    }
+    return saw_comment;
 }
 
 function createRunnerHtml(timeoutMs, concurrency, logIntervalMs) {

--- a/scripts/verify-example-outputs.mjs
+++ b/scripts/verify-example-outputs.mjs
@@ -802,6 +802,7 @@ function normalizeOutput(text) {
     const lines = text.replace(/\r\n/g, "\n").split("\n");
     const stripped = lines.map((line) =>
         line.replace(/^\s*\d+(?:\s*[x×]\s*\d+)+\s+\w+(?:\s+\w+)*(?:\s+array)?\s*$/i, "")
+            .replace(/^\s*\d+(?:\s*[x×]\s*\d+)+\s*$/i, "")
             .replace(/^\s*[A-Za-z_]\w*(?:\([^)]*\))?\s*=\s*/, "")
     );
     const joined = stripped.join(" ");

--- a/scripts/verify-example-outputs.mjs
+++ b/scripts/verify-example-outputs.mjs
@@ -811,7 +811,11 @@ function normalizeOutput(text) {
         /\b[A-Za-z_]\w*(?:\([^)]*\))?\s*=\s*/g,
         ""
     );
-    const withoutHeaders = withoutAssignments.replace(
+    const withoutInlineDims = withoutAssignments.replace(
+        /(^|\s)\d+\s*[x×]\s*\d+(?:\s*[x×]\s*\d+)*\s+(?=(?:[-+]?(?:\d|\.\d)|NaN|Inf|-Inf))/gi,
+        "$1"
+    );
+    const withoutHeaders = withoutInlineDims.replace(
         /\b\d+\s*[x×]\s*\d+(?:\s*[x×]\s*\d+)*\s+(?:gpuArray\s*)?(?:sparse\s+)?(?:complex\s+)?(?:logical\s+)?(?:logical|double|single|char|string|cell|struct|table|categorical|datetime|duration)(?:\s+array)?\b/gi,
         " "
     );

--- a/scripts/verify-example-outputs.mjs
+++ b/scripts/verify-example-outputs.mjs
@@ -889,8 +889,20 @@ function formatWasmOutput(result) {
     if (result.stdoutText && result.valueText) {
         const normalizedStdout = normalizeOutput(result.stdoutText);
         const normalizedValue = normalizeOutput(result.valueText);
+        if (!normalizedValue) {
+            return result.stdoutText;
+        }
         if (normalizedStdout && normalizedStdout === normalizedValue) {
             return result.valueText;
+        }
+        if (normalizedStdout) {
+            const suffixIndex = normalizedStdout.lastIndexOf(normalizedValue);
+            const isSuffix = suffixIndex >= 0
+                && suffixIndex + normalizedValue.length === normalizedStdout.length
+                && (suffixIndex === 0 || normalizedStdout[suffixIndex - 1] === " ");
+            if (isSuffix) {
+                return result.stdoutText;
+            }
         }
         return `${result.stdoutText}\n${result.valueText}`;
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core runtime execution paths (function invocation, output capture, VM emission) and numeric compatibility branches, which could subtly change behavior across many builtins; changes are covered by new/updated tests and example fixtures but remain broadly impactful.
> 
> **Overview**
> Fixes REPL/wasm output behavior by additionally suppressing the public return value when the final expression is *semantically suppressed* (not just semicolon-terminated).
> 
> Expands MATLAB compatibility and callback execution: adds thread-local user-function invocation plumbing so `feval`, `cellfun`, and `arrayfun` can execute user-defined functions and closures; switches function handles to `Value::FunctionHandle`; and extends `arrayfun` to support string inputs.
> 
> Improves class/type ergonomics and GPU output: lowers `double.zeros(...)`/`gpuArray.zeros(...)`-style static calls by treating certain identifiers as class references, adds VM fallback that appends the class name argument for type-class static methods, enables `zeros(...,'gpuArray')` GPU allocation, and gathers GPU tensors before `Emit*` console display.
> 
> Adds new builtins `true`, `false`, and `isequal` (with GPU gather for comparisons), adjusts `acos` and `atanh` real-branch behavior to match MATLAB conventions, and updates builtins JSON examples plus the example-output verifier to better handle comment-only outputs and stdout/valueText normalization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cbe7c5ac66ffd48662cd0d8c6604075f888cfa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>8cbe7c5</u></sup><!-- /BUGBOT_STATUS -->