### PR TITLE
updated CI to use GCP windows VM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         include:
           - runner: ["self-hosted", "linux", "gpu"]
             name: linux-x86_64
-          - runner: ["self-hosted", "windows", "gpu"]
+          - runner: ["self-hosted", "windows", "gpu", "GCP"]
             name: windows-x86_64
           - runner: macos-latest
             name: macos-universal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,12 @@ jobs:
         run: |
           brew update
           brew install zeromq
+      - name: Install Chocolatey
+        shell: pwsh
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+          iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
       - name: Install Windows dependencies (ZMQ, vcpkg + OpenBLAS)
         if: runner.os == 'Windows'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI behavior changes for Windows by targeting a different self-hosted runner label and bootstrapping Chocolatey; failures are likely if the new runner image/permissions differ or if Chocolatey install is blocked.
> 
> **Overview**
> Updates the CI `build-and-test` matrix to run Windows jobs on a self-hosted runner labeled `GCP`.
> 
> Adds an explicit Chocolatey bootstrap step so subsequent Windows dependency installs (e.g., `pkgconfiglite`) work reliably on the new runner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16a2e43eacee087b197ac1e7b1cc6c65a12e31d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->