### PR TITLE
removed attribution and api calls from contact forms

### DIFF
--- a/website/app/api/contact/route.ts
+++ b/website/app/api/contact/route.ts
@@ -6,26 +6,6 @@ export const revalidate = 0;
 
 const HUBSPOT_PORTAL_ID = process.env.HUBSPOT_PORTAL_ID;
 const HUBSPOT_CONTACT_FORM_ID = process.env.HUBSPOT_CONTACT_FORM_ID;
-const RUNMAT_SERVER_API_BASE_URL = process.env.RUNMAT_SERVER_API_BASE_URL || "https://api.runmat.com";
-
-type AttributionPayload = {
-  utmSource?: string;
-  utmMedium?: string;
-  utmCampaign?: string;
-  utmTerm?: string;
-  utmContent?: string;
-  gclid?: string;
-  gbraid?: string;
-  wbraid?: string;
-  msclkid?: string;
-  fbclid?: string;
-  ttclid?: string;
-  liFatId?: string;
-  landingPageUrl?: string;
-  pageReferrer?: string;
-  capturedAt?: string;
-  gaClientId?: string;
-};
 
 function isValidEmail(email: string): boolean {
   const trimmed = email.trim();
@@ -66,7 +46,7 @@ function isValidEmail(email: string): boolean {
 
 export async function POST(req: NextRequest) {
   try {
-    const { firstname, lastname, email, company, message, source, pageUri, pageName, attribution } =
+    const { firstname, lastname, email, company, message, source, pageUri, pageName } =
       (await req.json()) as {
         firstname?: string;
         lastname?: string;
@@ -76,7 +56,6 @@ export async function POST(req: NextRequest) {
         source?: string;
         pageUri?: string;
         pageName?: string;
-        attribution?: AttributionPayload;
       };
 
     if (!firstname || !firstname.trim()) {
@@ -130,38 +109,7 @@ export async function POST(req: NextRequest) {
     }
 
     if (resp.ok) {
-      const campaign = attribution?.utmCampaign?.trim() || undefined;
-      const intakePayload = {
-        kind: "contact",
-        email: email.trim().toLowerCase(),
-        source: source?.trim() || "website_contact_page",
-        campaign,
-        attribution: attribution
-          ? {
-              utmSource: attribution.utmSource,
-              utmMedium: attribution.utmMedium,
-              utmCampaign: attribution.utmCampaign,
-              utmTerm: attribution.utmTerm,
-              utmContent: attribution.utmContent,
-              gclid: attribution.gclid,
-              gbraid: attribution.gbraid,
-              wbraid: attribution.wbraid,
-              msclkid: attribution.msclkid,
-              fbclid: attribution.fbclid,
-              ttclid: attribution.ttclid,
-              liFatId: attribution.liFatId,
-              landingPageUrl: attribution.landingPageUrl,
-              pageReferrer: attribution.pageReferrer,
-              capturedAt: attribution.capturedAt,
-              gaClientId: attribution.gaClientId,
-            }
-          : undefined,
-      };
-      void fetch(`${RUNMAT_SERVER_API_BASE_URL.replace(/\/$/, "")}/v1/lifecycle/intake`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(intakePayload),
-      }).catch(() => undefined);
+
       return NextResponse.json({ ok: true }, { status: 200 });
     }
 

--- a/website/app/api/subscribe/route.ts
+++ b/website/app/api/subscribe/route.ts
@@ -8,7 +8,6 @@ export const revalidate = 0;
 const HUBSPOT_PORTAL_ID = process.env.HUBSPOT_PORTAL_ID;
 const HUBSPOT_NEWSLETTER_FORM_ID = process.env.HUBSPOT_NEWSLETTER_FORM_ID;
 const HUBSPOT_DESKTOP_FORM_ID = process.env.HUBSPOT_DESKTOP_FORM_ID;
-const RUNMAT_SERVER_API_BASE_URL = process.env.RUNMAT_SERVER_API_BASE_URL || "https://api.runmat.com";
 
 type AttributionPayload = {
   utmSource?: string;
@@ -106,39 +105,6 @@ export async function POST(req: NextRequest) {
 
     // HubSpot returns 200 OK or 204 No Content on success; treat other codes as soft-fail
     if (resp.ok) {
-      const intakeSource = source === "desktop" ? "website_desktop_request" : "website_newsletter";
-      const intakeKind = source === "desktop" ? "desktop_access" : "newsletter";
-      const intakePayload = {
-        kind: intakeKind,
-        email: email.trim().toLowerCase(),
-        source: intakeSource,
-        campaign: attribution?.utmCampaign?.trim() || undefined,
-        attribution: attribution
-          ? {
-              utmSource: attribution.utmSource,
-              utmMedium: attribution.utmMedium,
-              utmCampaign: attribution.utmCampaign,
-              utmTerm: attribution.utmTerm,
-              utmContent: attribution.utmContent,
-              gclid: attribution.gclid,
-              gbraid: attribution.gbraid,
-              wbraid: attribution.wbraid,
-              msclkid: attribution.msclkid,
-              fbclid: attribution.fbclid,
-              ttclid: attribution.ttclid,
-              liFatId: attribution.liFatId,
-              landingPageUrl: attribution.landingPageUrl,
-              pageReferrer: attribution.pageReferrer,
-              capturedAt: attribution.capturedAt,
-              gaClientId: attribution.gaClientId,
-            }
-          : undefined,
-      };
-      void fetch(`${RUNMAT_SERVER_API_BASE_URL.replace(/\/$/, "")}/v1/lifecycle/intake`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(intakePayload),
-      }).catch(() => undefined);
       return NextResponse.json({ ok: true }, { status: 200 });
     }
 

--- a/website/app/api/subscribe/route.ts
+++ b/website/app/api/subscribe/route.ts
@@ -9,25 +9,6 @@ const HUBSPOT_PORTAL_ID = process.env.HUBSPOT_PORTAL_ID;
 const HUBSPOT_NEWSLETTER_FORM_ID = process.env.HUBSPOT_NEWSLETTER_FORM_ID;
 const HUBSPOT_DESKTOP_FORM_ID = process.env.HUBSPOT_DESKTOP_FORM_ID;
 
-type AttributionPayload = {
-  utmSource?: string;
-  utmMedium?: string;
-  utmCampaign?: string;
-  utmTerm?: string;
-  utmContent?: string;
-  gclid?: string;
-  gbraid?: string;
-  wbraid?: string;
-  msclkid?: string;
-  fbclid?: string;
-  ttclid?: string;
-  liFatId?: string;
-  landingPageUrl?: string;
-  pageReferrer?: string;
-  capturedAt?: string;
-  gaClientId?: string;
-};
-
 function isValidEmail(email: string): boolean {
   const trimmed = email.trim();
   if (!trimmed || trimmed.length > 320) {
@@ -67,12 +48,11 @@ function isValidEmail(email: string): boolean {
 
 export async function POST(req: NextRequest) {
   try {
-    const { email, pageUri, pageName, source, attribution } = (await req.json()) as {
+    const { email, pageUri, pageName, source } = (await req.json()) as {
       email?: string;
       pageUri?: string;
       pageName?: string;
       source?: string;
-      attribution?: AttributionPayload;
     };
 
     if (!email || !isValidEmail(email)) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: removes a secondary analytics/intake POST and stops accepting `attribution` in request bodies; core HubSpot submission flow remains unchanged.
> 
> **Overview**
> Both `api/contact` and `api/subscribe` endpoints no longer accept an `attribution` payload and stop posting successful submissions to the internal lifecycle intake endpoint (`/v1/lifecycle/intake`).
> 
> The routes now only submit to HubSpot and return success on HubSpot OK responses, removing the `RUNMAT_SERVER_API_BASE_URL` dependency and associated attribution mapping logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f2107f85df712cb227562416831a603a7abfd42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->