### PR TITLE
Support MATLAB-style leading-dot float literals

### DIFF
--- a/crates/runmat-ignition/tests/ranges.rs
+++ b/crates/runmat-ignition/tests/ranges.rs
@@ -43,3 +43,15 @@ fn descending_range() {
         panic!("expected tensor");
     }
 }
+
+#[test]
+fn leading_dot_step_range_executes() {
+    let ast = parse("x = 0:.1:.3").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    if let Value::Tensor(t) = &vars[0] {
+        assert_eq!(t.data, vec![0.0, 0.1, 0.2, 0.3]);
+    } else {
+        panic!("expected tensor");
+    }
+}

--- a/crates/runmat-lexer/src/lib.rs
+++ b/crates/runmat-lexer/src/lib.rs
@@ -211,12 +211,30 @@ pub fn tokenize_detailed(input: &str) -> Vec<SpannedToken> {
     while let Some(res) = lex.next() {
         match res {
             Ok(tok) => {
+                let span = lex.span();
+
+                if matches!(tok, Token::Dot) && can_start_leading_dot_float(out.last(), span.start)
+                {
+                    if let Some(float_suffix_len) = leading_dot_float_suffix_len(lex.remainder()) {
+                        let float_lexeme = format!(".{}", &lex.remainder()[..float_suffix_len]);
+                        lex.bump(float_suffix_len);
+                        lex.extras.last_was_value = true;
+                        lex.extras.line_start = false;
+                        out.push(SpannedToken {
+                            token: Token::Float,
+                            lexeme: float_lexeme.replace('_', ""),
+                            start: span.start,
+                            end: span.end + float_suffix_len,
+                        });
+                        continue;
+                    }
+                }
+
                 let mut s = lex.slice().to_string();
                 // Normalize numeric literals: remove underscores in integers/floats
                 if matches!(tok, Token::Float | Token::Integer) {
                     s.retain(|c| c != '_');
                 }
-                let span = lex.span();
 
                 // Handle contextual apostrophe before normal push logic
                 if matches!(tok, Token::Apostrophe) {
@@ -542,6 +560,60 @@ fn last_is_value_token(tok: &Token) -> bool {
             | Token::RBrace
             | Token::Str
     )
+}
+
+fn can_start_leading_dot_float(prev: Option<&SpannedToken>, dot_start: usize) -> bool {
+    match prev {
+        Some(token)
+            if token.end == dot_start
+                && (matches!(token.token, Token::Transpose | Token::Dot)
+                    || last_is_value_token(&token.token)) =>
+        {
+            false
+        }
+        _ => true,
+    }
+}
+
+fn leading_dot_float_suffix_len(remainder: &str) -> Option<usize> {
+    let bytes = remainder.as_bytes();
+    let mut idx = scan_decimal_digits(bytes, 0)?;
+
+    if let Some(exp_idx) = scan_float_exponent(bytes, idx) {
+        idx = exp_idx;
+    }
+
+    Some(idx)
+}
+
+fn scan_decimal_digits(bytes: &[u8], start: usize) -> Option<usize> {
+    if start >= bytes.len() || !bytes[start].is_ascii_digit() {
+        return None;
+    }
+
+    let mut idx = start + 1;
+    while idx < bytes.len() {
+        match bytes[idx] {
+            b'0'..=b'9' => idx += 1,
+            b'_' if idx + 1 < bytes.len() && bytes[idx + 1].is_ascii_digit() => idx += 2,
+            _ => break,
+        }
+    }
+
+    Some(idx)
+}
+
+fn scan_float_exponent(bytes: &[u8], start: usize) -> Option<usize> {
+    if start >= bytes.len() || !matches!(bytes[start], b'e' | b'E') {
+        return None;
+    }
+
+    let mut idx = start + 1;
+    if idx < bytes.len() && matches!(bytes[idx], b'+' | b'-') {
+        idx += 1;
+    }
+
+    scan_decimal_digits(bytes, idx)
 }
 
 fn double_quoted_string_emit(lexer: &mut Lexer<Token>) -> Filter<()> {

--- a/crates/runmat-lexer/tests/lexer.rs
+++ b/crates/runmat-lexer/tests/lexer.rs
@@ -32,6 +32,36 @@ fn identifiers_and_numbers() {
 }
 
 #[test]
+fn leading_dot_float_literals_tokenize_as_float() {
+    let src = ".1 .25e-2 .3_5";
+    let tokens = tokenize(src);
+    assert_eq!(tokens, vec![Token::Float, Token::Float, Token::Float]);
+}
+
+#[test]
+fn leading_dot_float_after_range_colon_tokenizes_as_float() {
+    let src = "0:.1:10";
+    let tokens = tokenize(src);
+    assert_eq!(
+        tokens,
+        vec![
+            Token::Integer,
+            Token::Colon,
+            Token::Float,
+            Token::Colon,
+            Token::Integer,
+        ]
+    );
+}
+
+#[test]
+fn property_access_dot_is_not_rewritten_as_float() {
+    let src = "obj.field";
+    let tokens = tokenize(src);
+    assert_eq!(tokens, vec![Token::Ident, Token::Dot, Token::Ident]);
+}
+
+#[test]
 fn string_literal() {
     let src = "'hello world'";
     let tokens = tokenize(src);

--- a/crates/runmat-parser/tests/range_parsing.rs
+++ b/crates/runmat-parser/tests/range_parsing.rs
@@ -27,3 +27,34 @@ fn parse_range_with_negative_start_and_step() {
         other => panic!("unexpected statement: {other:?}"),
     }
 }
+
+#[test]
+fn parse_range_with_leading_dot_step() {
+    let program = parse("a = 0:.1:1;").unwrap();
+    assert_eq!(program.body.len(), 1);
+    match &program.body[0] {
+        Stmt::Assign(name, Expr::Range(start, step, end, _), true, _) => {
+            assert_eq!(name, "a");
+            assert!(matches!(**start, Expr::Number(ref text, _) if text == "0"));
+            assert!(matches!(
+                step,
+                Some(step) if matches!(**step, Expr::Number(ref text, _) if text == ".1")
+            ));
+            assert!(matches!(**end, Expr::Number(ref text, _) if text == "1"));
+        }
+        other => panic!("unexpected statement: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_assignment_with_leading_dot_float() {
+    let program = parse("a = .1;").unwrap();
+    assert_eq!(program.body.len(), 1);
+    match &program.body[0] {
+        Stmt::Assign(name, Expr::Number(text, _), true, _) => {
+            assert_eq!(name, "a");
+            assert_eq!(text, ".1");
+        }
+        other => panic!("unexpected statement: {other:?}"),
+    }
+}


### PR DESCRIPTION
### Motivation

- The lexer currently rejects MATLAB-style numeric literals that omit the leading zero (e.g., `.1`), causing parsing failures in normal scripts and range expressions like `0:.1:10`.
- The fix must be done in the tokenization layer to be robust and avoid brittle downstream hacks while preserving existing dot-based syntax (`obj.field`, `1..3`, `.*`, etc.).

### Description

- Teach `tokenize_detailed()` in `crates/runmat-lexer/src/lib.rs` to contextually merge a standalone `.` into a `Token::Float` when it is followed by a valid fractional/exponent suffix, by detecting `Token::Dot` and scanning the remainder for a fractional/exponent sequence and underscores as digit separators.
- Add helpers `can_start_leading_dot_float`, `leading_dot_float_suffix_len`, `scan_decimal_digits`, and `scan_float_exponent` to safely identify valid leading-dot float suffixes and ensure the dot is not being used for adjacent member/transpose-style syntax.
- Preserve existing behavior for dot-based operators and property access (e.g., `obj.field`, `.*`, `1..3`) and normalize underscore-separated digits in the emitted float lexeme consistently with other numeric tokens.
- Add regression tests: lexer tests in `crates/runmat-lexer/tests/lexer.rs`, parser tests in `crates/runmat-parser/tests/range_parsing.rs`, and runtime/ignition test in `crates/runmat-ignition/tests/ranges.rs` to cover standalone leading-dot literals, range-step forms like `0:.1:1`, and ensure property-access dots are unchanged.

### Testing

- Ran `cargo fmt` to ensure formatting completed successfully.
- Ran `cargo test -p runmat-lexer --test lexer` and all lexer tests (including new leading-dot tests) passed.
- Ran `cargo test -p runmat-parser --test range_parsing` and parser range tests (including leading-dot forms) passed.
- Ran `cargo test -p runmat-ignition --test ranges` and runtime/ignition range tests (including a leading-dot step execution test) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c1bd349b388329a7c02f05592f078f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core lexing behavior by rewriting `.` into `Float` in specific contexts, which could subtly affect dot-based syntax (property access/operators) if the heuristics are wrong; changes are guarded and covered by new tests.
> 
> **Overview**
> Adds MATLAB-style leading-dot float support (e.g., `.1`, `.25e-2`, `.3_5`) by teaching `tokenize_detailed()` to *contextually* merge a standalone `Token::Dot` plus a following digit/exponent sequence into a single `Token::Float` (with underscore normalization), while avoiding rewrites when the dot is adjacent to a prior value/transpose.
> 
> Extends test coverage across lexer, parser, and runtime execution to ensure leading-dot floats work in assignments and range steps (e.g., `0:.1:1`) and that `obj.field`-style property access remains tokenized as `Ident Dot Ident`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee12f680b1c084f826b4a209f1ee4a09e9c897d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->