### PR TITLE
Fix MATLAB in-out parameter semantics when input and output share a name

### DIFF
--- a/crates/runmat-hir/src/lib.rs
+++ b/crates/runmat-hir/src/lib.rs
@@ -3268,6 +3268,12 @@ impl Ctx {
         None
     }
 
+    fn lookup_current_scope(&self, name: &str) -> Option<VarId> {
+        self.scopes
+            .last()
+            .and_then(|scope| scope.bindings.get(name).copied())
+    }
+
     fn is_constant(&self, name: &str) -> bool {
         // Check if name is a registered constant
         runmat_builtins::constants().iter().any(|c| c.name == name)
@@ -3491,8 +3497,13 @@ impl Ctx {
             } => {
                 self.push_scope();
                 let param_ids: Vec<VarId> = params.iter().map(|p| self.define(p.clone())).collect();
-                let output_ids: Vec<VarId> =
-                    outputs.iter().map(|o| self.define(o.clone())).collect();
+                let output_ids: Vec<VarId> = outputs
+                    .iter()
+                    .map(|o| {
+                        self.lookup_current_scope(o)
+                            .unwrap_or_else(|| self.define(o.clone()))
+                    })
+                    .collect();
                 let body_hir = self.lower_stmts(body)?;
                 self.pop_scope();
 

--- a/crates/runmat-hir/tests/coverage.rs
+++ b/crates/runmat-hir/tests/coverage.rs
@@ -246,3 +246,45 @@ end
         .iter()
         .any(|s| matches!(s, HirStmt::ClassDef { .. })));
 }
+
+#[test]
+fn function_output_reuses_param_binding_when_names_match() {
+    let src = r#"
+function [x, y] = f(x)
+  y = x;
+  x = x + 1;
+end
+"#;
+    let ast = parse(src).unwrap();
+    let lowered = runmat_hir::lower(&ast, &LoweringContext::empty()).unwrap();
+
+    let HirStmt::Function {
+        params,
+        outputs,
+        body,
+        ..
+    } = &lowered.hir.body[0]
+    else {
+        panic!("expected function");
+    };
+
+    assert_eq!(params.len(), 1);
+    assert_eq!(outputs.len(), 2);
+    assert_eq!(params[0], outputs[0]);
+
+    match &body[0] {
+        HirStmt::Assign(target, expr, _, _) => {
+            assert_eq!(*target, outputs[1]);
+            assert!(matches!(expr.kind, HirExprKind::Var(id) if id == params[0]));
+        }
+        _ => panic!("expected y = x assignment"),
+    }
+
+    match &body[1] {
+        HirStmt::Assign(target, expr, _, _) => {
+            assert_eq!(*target, params[0]);
+            assert!(matches!(expr.kind, HirExprKind::Binary(_, _, _)));
+        }
+        _ => panic!("expected x = x + 1 assignment"),
+    }
+}

--- a/crates/runmat-ignition/tests/functions.rs
+++ b/crates/runmat-ignition/tests/functions.rs
@@ -141,6 +141,40 @@ fn nested_function_calls() {
 }
 
 #[test]
+fn shared_input_output_name_behaves_like_in_out_parameter() {
+    let program = r#"
+        function x = bump(x)
+            x = x + 1;
+        end
+        r = bump(41);
+    "#;
+    let hir = lower(&parse(program).unwrap()).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert!(vars
+        .iter()
+        .any(|v| matches!(v, runmat_builtins::Value::Num(n) if (*n - 42.0).abs() < 1e-9)));
+}
+
+#[test]
+fn shared_input_output_name_preserves_input_value_for_other_outputs() {
+    let program = r#"
+        function [x, y] = bump_and_copy(x)
+            y = x;
+            x = x + 1;
+        end
+        [a, b] = bump_and_copy(5);
+    "#;
+    let hir = lower(&parse(program).unwrap()).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert!(vars
+        .iter()
+        .any(|v| matches!(v, runmat_builtins::Value::Num(n) if (*n - 6.0).abs() < 1e-9)));
+    assert!(vars
+        .iter()
+        .any(|v| matches!(v, runmat_builtins::Value::Num(n) if (*n - 5.0).abs() < 1e-9)));
+}
+
+#[test]
 fn member_get_set_and_method_call_skeleton() {
     let input = "obj = new_object('Point'); obj = setfield(obj, 'x', 3); ax = getfield(obj, 'x');";
     let ast = parse(input).unwrap();


### PR DESCRIPTION
### Motivation
- Function lowering currently defines outputs after parameters in the same scope which overwrites parameter bindings when an output shares an input name, breaking MATLAB in-out semantics.
- This causes body references to resolve to the output slot instead of the incoming argument, producing incorrect runtime behavior for common authoring patterns.

### Description
- Preserve the parameter binding when an output name matches an existing parameter by adding `fn lookup_current_scope(&self, name: &str) -> Option<VarId>` and reusing that `VarId` instead of defining a new one during `AstStmt::Function` lowering in `crates/runmat-hir/src/lib.rs`.
- Added a HIR-level regression test `function_output_reuses_param_binding_when_names_match` in `crates/runmat-hir/tests/coverage.rs` that asserts the output reuses the parameter `VarId` and that body references resolve to the shared binding.
- Added runtime regression tests `shared_input_output_name_behaves_like_in_out_parameter` and `shared_input_output_name_preserves_input_value_for_other_outputs` in `crates/runmat-ignition/tests/functions.rs` to verify single-output and multi-output shared-name behaviors at execution time.
- Updated lowering behavior so subsequent remapping and VM frame creation see a single VarId for shared input/output names, restoring MATLAB-compatible semantics.

### Testing
- Ran `cargo test -p runmat-hir function_output_reuses_param_binding_when_names_match -- --nocapture`, which passed.
- Ran `cargo test -p runmat-ignition shared_input_output_name -- --nocapture`, which passed both added runtime tests.
- Ran `cargo fmt --all` to format changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c1bdaac0448329ac52a4fd17b19b01)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core function-lowering symbol binding semantics, which can affect variable resolution across many functions; scope is small and covered by new HIR and runtime regression tests.
> 
> **Overview**
> Fixes MATLAB in/out parameter semantics during HIR lowering by **reusing the existing parameter `VarId`** when a function output name matches an already-defined binding in the current function scope (via new `lookup_current_scope`).
> 
> Adds regression coverage at both the HIR level (verifying shared param/output IDs and body variable resolution) and runtime level in `runmat-ignition` (verifying single- and multi-output shared-name behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa92e53078a21f7a157410bbb040f23506630f23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->