### PR TITLE
Make_axis n=1 endpoint

### DIFF
--- a/crates/runmat-runtime/src/builtins/array/creation/peaks.rs
+++ b/crates/runmat-runtime/src/builtins/array/creation/peaks.rs
@@ -89,7 +89,7 @@ fn make_axis(n: usize) -> (Vec<f64>, Vec<f64>) {
         return (Vec::new(), Vec::new());
     }
     if n == 1 {
-        return (vec![0.0], vec![0.0]);
+        return (vec![3.0], vec![3.0]);
     }
     let axis: Vec<f64> = (0..n)
         .map(|i| -3.0 + 6.0 * (i as f64) / ((n - 1) as f64))
@@ -265,9 +265,9 @@ mod tests {
 
     #[test]
     fn peaks_one_is_scalar() {
-        // At n=1 the single grid point maps to (x=0, y=0).
+        // At n=1 the single grid point maps to the stop endpoint (x=3, y=3).
         // tensor_into_value may collapse a 1×1 tensor to Value::Num.
-        let expected = peaks_at(0.0, 0.0);
+        let expected = peaks_at(3.0, 3.0);
         let value = peaks_builtin(vec![Value::Num(1.0)]).expect("peaks");
         let got = match value {
             Value::Num(v) => v,


### PR DESCRIPTION
Fix `make_axis(1)` to return the stop endpoint (3.0) for MATLAB compatibility, aligning with `linspace` behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, isolated behavior change only affecting the `peaks(1)` edge case, with an updated unit test to lock in the new expectation.
> 
> **Overview**
> `peaks` now treats the `n=1` case as a single-point `linspace(-3,3,1)` and returns coordinates at the stop endpoint (`x=y=3`) instead of the midpoint (`0`).
> 
> The `peaks_one_is_scalar` test is updated to validate the new `peaks(1)` output value computed at `(3,3)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b862955bb2866e5b9226138e4cf8fa577b17f145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->