### PR TITLE
Page speed

### DIFF
--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -73,6 +73,11 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <link
+          rel="preload"
+          as="image"
+          href="https://web.runmatstatic.com/video/posters/runmat-wave-simulation.webp"
+        />
         <link rel="icon" href="/favicon.ico" sizes="32x32" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -10,7 +10,6 @@ import dynamic from "next/dynamic";
 import Hero from "@/components/Hero";
 
 const MatlabCodeCard = dynamic(() => import("@/components/MatlabCodeCard"), {
-  ssr: false,
   loading: () => <div className="w-full max-w-3xl h-[120px] rounded-3xl bg-muted/40 animate-pulse" />,
 });
 

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -6,9 +6,18 @@ import { Card, CardContent } from "@/components/ui/card";
 import { SiGithub } from "react-icons/si";
 import { Users, GitBranch, Camera, Lock, Shield, Eye, ClipboardCheck, Cpu, Monitor, HardDrive } from "lucide-react";
 
-import MatlabCodeCard from "@/components/MatlabCodeCard";
+import dynamic from "next/dynamic";
 import Hero from "@/components/Hero";
-import BenchmarkShowcaseBlock from "@/components/benchmarks/BenchmarkShowcaseBlock";
+
+const MatlabCodeCard = dynamic(() => import("@/components/MatlabCodeCard"), {
+  ssr: false,
+  loading: () => <div className="w-full max-w-3xl h-[120px] rounded-3xl bg-muted/40 animate-pulse" />,
+});
+
+const BenchmarkShowcaseBlock = dynamic(
+  () => import("@/components/benchmarks/BenchmarkShowcaseBlock"),
+  { loading: () => <div className="w-full h-[300px] rounded-xl bg-muted/40 animate-pulse" /> },
+);
 
 const jsonLd = {
   "@context": "https://schema.org",
@@ -101,7 +110,7 @@ const jsonLd = {
       "@id": "https://runmat.com/#hero-video",
       "name": "RunMat wave interference simulation",
       "description": "GPU-accelerated wave interference simulation rendered in real time using RunMat's surf() function.",
-      "thumbnailUrl": "https://web.runmatstatic.com/video/posters/runmat-wave-simulation.png",
+      "thumbnailUrl": "https://web.runmatstatic.com/video/posters/runmat-wave-simulation.webp",
       "contentUrl": "https://web.runmatstatic.com/video/runmat-wave-simulation.mp4",
       "uploadDate": "2026-03-03T00:00:00Z",
       "duration": "PT10S"
@@ -210,7 +219,8 @@ export default function HomePage() {
                   muted
                   loop
                   playsInline
-                  poster="https://web.runmatstatic.com/video/posters/3d-interactive-plotting-runmat.png"
+                  preload="none"
+                  poster="https://web.runmatstatic.com/video/posters/3d-interactive-plotting-runmat.webp"
                   aria-label="RunMat 3D interactive plotting demo"
                 >
                   <source src="https://web.runmatstatic.com/video/3d-interactive-plotting-runmat.mp4" type="video/mp4" />
@@ -314,7 +324,8 @@ export default function HomePage() {
                   muted
                   loop
                   playsInline
-                  poster="https://web.runmatstatic.com/video/posters/runmat-shape-tracking.png"
+                  preload="none"
+                  poster="https://web.runmatstatic.com/video/posters/runmat-shape-tracking.webp"
                   aria-label="RunMat shape tracking and type system demo"
                 >
                   <source src="https://web.runmatstatic.com/video/runmat-shape-tracking.mp4" type="video/mp4" />
@@ -347,7 +358,8 @@ export default function HomePage() {
                 muted
                 loop
                 playsInline
-                poster="https://web.runmatstatic.com/video/posters/runmat-versioning.png"
+                preload="none"
+                poster="https://web.runmatstatic.com/video/posters/runmat-versioning.webp"
                 aria-label="RunMat versioning demo"
               >
                 <source src="https://web.runmatstatic.com/video/runmat-versioning.mp4" type="video/mp4" />

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -8,6 +8,7 @@ import { Users, GitBranch, Camera, Lock, Shield, Eye, ClipboardCheck, Cpu, Monit
 
 import dynamic from "next/dynamic";
 import Hero from "@/components/Hero";
+import LazyVideo from "@/components/LazyVideo";
 
 const MatlabCodeCard = dynamic(() => import("@/components/MatlabCodeCard"), {
   loading: () => <div className="w-full max-w-3xl h-[120px] rounded-3xl bg-muted/40 animate-pulse" />,
@@ -212,18 +213,16 @@ export default function HomePage() {
           <div className="mx-auto max-w-3xl">
             <div className="rounded-xl border border-border overflow-hidden elevated-panel">
               <Link href="/sandbox" className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-b-none rounded-t-xl overflow-hidden">
-                <video
+                <LazyVideo
                   className="w-full h-auto"
-                  autoPlay
                   muted
                   loop
                   playsInline
-                  preload="none"
                   poster="https://web.runmatstatic.com/video/posters/3d-interactive-plotting-runmat.webp"
                   aria-label="RunMat 3D interactive plotting demo"
                 >
                   <source src="https://web.runmatstatic.com/video/3d-interactive-plotting-runmat.mp4" type="video/mp4" />
-                </video>
+                </LazyVideo>
               </Link>
             </div>
           </div>
@@ -317,18 +316,16 @@ export default function HomePage() {
           <div className="mx-auto max-w-3xl">
             <div className="rounded-xl border border-border overflow-hidden elevated-panel">
               <Link href="/sandbox" className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-b-none rounded-t-xl overflow-hidden">
-                <video
+                <LazyVideo
                   className="w-full h-auto"
-                  autoPlay
                   muted
                   loop
                   playsInline
-                  preload="none"
                   poster="https://web.runmatstatic.com/video/posters/runmat-shape-tracking.webp"
                   aria-label="RunMat shape tracking and type system demo"
                 >
                   <source src="https://web.runmatstatic.com/video/runmat-shape-tracking.mp4" type="video/mp4" />
-                </video>
+                </LazyVideo>
               </Link>
             </div>
           </div>
@@ -351,18 +348,16 @@ export default function HomePage() {
               href="/sandbox"
               className="rounded-2xl border border-border overflow-hidden min-h-[380px] md:row-span-3 bg-muted/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
-              <video
+              <LazyVideo
                 className="w-full h-full min-h-[380px] object-cover object-left-top"
-                autoPlay
                 muted
                 loop
                 playsInline
-                preload="none"
                 poster="https://web.runmatstatic.com/video/posters/runmat-versioning.webp"
                 aria-label="RunMat versioning demo"
               >
                 <source src="https://web.runmatstatic.com/video/runmat-versioning.mp4" type="video/mp4" />
-              </video>
+              </LazyVideo>
             </Link>
             <div className="rounded-2xl border border-purple-500/30 bg-gradient-to-br from-purple-500/10 to-[#0E1421] p-6">
               <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-purple-500/30 bg-purple-500/10 text-gray-400 mb-3">

--- a/website/components/GoogleAnalytics.tsx
+++ b/website/components/GoogleAnalytics.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Script from 'next/script';
-import posthog from 'posthog-js';
 
 // Google Analytics Measurement ID
 // You'll need to replace this with your actual GA4 Measurement ID
@@ -53,7 +52,7 @@ export type WebsiteEventProperties = {
   [key: string]: unknown;
 };
 
-export const trackWebsiteEvent = (event: string, properties: WebsiteEventProperties = {}) => {
+export const trackWebsiteEvent = async (event: string, properties: WebsiteEventProperties = {}) => {
   const canonicalEvent = toCanonicalWebsiteEvent(event);
   const payload = {
     ...properties,
@@ -64,7 +63,12 @@ export const trackWebsiteEvent = (event: string, properties: WebsiteEventPropert
     window.gtag('event', canonicalEvent, payload);
   }
   if (typeof window !== 'undefined') {
-    posthog.capture(canonicalEvent, payload);
+    try {
+      const { default: posthog } = await import('posthog-js');
+      posthog.capture(canonicalEvent, payload);
+    } catch {
+      // PostHog unavailable — analytics event lost, not user-facing
+    }
   }
 };
 

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -37,7 +37,6 @@ export default function Hero() {
               muted
               loop
               playsInline
-              fetchPriority="high"
               poster="https://web.runmatstatic.com/video/posters/runmat-wave-simulation.webp"
               aria-label="RunMat wave simulation demo"
             >

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -37,7 +37,8 @@ export default function Hero() {
               muted
               loop
               playsInline
-              poster="https://web.runmatstatic.com/video/posters/runmat-wave-simulation.png"
+              fetchPriority="high"
+              poster="https://web.runmatstatic.com/video/posters/runmat-wave-simulation.webp"
               aria-label="RunMat wave simulation demo"
             >
               <source src="https://web.runmatstatic.com/video/runmat-wave-simulation.mp4" type="video/mp4" />

--- a/website/components/LazyVideo.tsx
+++ b/website/components/LazyVideo.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useRef, type ComponentProps } from "react";
+
+type VideoProps = Omit<ComponentProps<"video">, "autoPlay" | "preload">;
+
+/**
+ * A video element that defers loading until it scrolls into view.
+ *
+ * Unlike a plain `<video autoPlay preload="none">`, where `autoplay`
+ * overrides `preload` and forces an immediate download, this component
+ * keeps `preload="none"` effective by only calling `.play()` once the
+ * element enters the viewport via Intersection Observer.
+ */
+export default function LazyVideo(props: VideoProps) {
+  const ref = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          el.play().catch(() => {});
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return <video ref={ref} preload="none" {...props} />;
+}

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -2,8 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   // Allow API routes to run on Vercel (no static export)
-  images: { 
-    unoptimized: true,
+  images: {
     remotePatterns: [
       {
         protocol: 'https',
@@ -12,7 +11,7 @@ const nextConfig: NextConfig = {
     ],
   },
   experimental: {
-    optimizePackageImports: ["lucide-react"],
+    optimizePackageImports: ["lucide-react", "react-icons"],
   },
   // Ensure Markdown files living outside the website/ dir are traced for SSG/SSR on Vercel
   outputFileTracingIncludes: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes homepage rendering/loading behavior (videos, dynamic imports) and makes `trackWebsiteEvent` async, which could subtly affect callers and analytics delivery.
> 
> **Overview**
> Improves homepage page speed by **deferring heavy client work**: `MatlabCodeCard` and `BenchmarkShowcaseBlock` are now loaded via `next/dynamic` with skeleton placeholders.
> 
> Introduces `LazyVideo`, replacing several autoplaying `<video>` elements on the homepage so videos only start (and download) when near the viewport, and switches multiple video posters/JSON-LD thumbnails from `.png` to `.webp` (with a preload hint for the hero poster in `layout.tsx`).
> 
> Reduces initial analytics bundle cost by **lazy-importing `posthog-js`** inside `trackWebsiteEvent` (now `async`), and expands Next’s `optimizePackageImports` to include `react-icons`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 157bafad408ca540c0d6976e1f4ea7712fbaa09d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->