### PR TITLE
posthog analytics change revert

### DIFF
--- a/website/components/GoogleAnalytics.tsx
+++ b/website/components/GoogleAnalytics.tsx
@@ -64,7 +64,11 @@ export const trackWebsiteEvent = (event: string, properties: WebsiteEventPropert
     window.gtag('event', canonicalEvent, payload);
   }
   if (typeof window !== 'undefined') {
-    posthog.capture(canonicalEvent, payload);
+    try {
+      posthog.capture(canonicalEvent, payload);
+    } catch {
+      // PostHog may not be initialized (e.g. missing POSTHOG_KEY) — never break callers
+    }
   }
 };
 

--- a/website/components/GoogleAnalytics.tsx
+++ b/website/components/GoogleAnalytics.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Script from 'next/script';
+import posthog from 'posthog-js';
 
 // Google Analytics Measurement ID
 // You'll need to replace this with your actual GA4 Measurement ID
@@ -52,7 +53,7 @@ export type WebsiteEventProperties = {
   [key: string]: unknown;
 };
 
-export const trackWebsiteEvent = async (event: string, properties: WebsiteEventProperties = {}) => {
+export const trackWebsiteEvent = (event: string, properties: WebsiteEventProperties = {}) => {
   const canonicalEvent = toCanonicalWebsiteEvent(event);
   const payload = {
     ...properties,
@@ -63,12 +64,7 @@ export const trackWebsiteEvent = async (event: string, properties: WebsiteEventP
     window.gtag('event', canonicalEvent, payload);
   }
   if (typeof window !== 'undefined') {
-    try {
-      const { default: posthog } = await import('posthog-js');
-      posthog.capture(canonicalEvent, payload);
-    } catch {
-      // PostHog unavailable — analytics event lost, not user-facing
-    }
+    posthog.capture(canonicalEvent, payload);
   }
 };
 

--- a/website/components/GoogleAnalytics.tsx
+++ b/website/components/GoogleAnalytics.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Script from 'next/script';
-import posthog from 'posthog-js';
 
 // Google Analytics Measurement ID
 // You'll need to replace this with your actual GA4 Measurement ID
@@ -64,11 +63,9 @@ export const trackWebsiteEvent = (event: string, properties: WebsiteEventPropert
     window.gtag('event', canonicalEvent, payload);
   }
   if (typeof window !== 'undefined') {
-    try {
+    import('posthog-js').then(({ default: posthog }) => {
       posthog.capture(canonicalEvent, payload);
-    } catch {
-      // PostHog may not be initialized (e.g. missing POSTHOG_KEY) — never break callers
-    }
+    }).catch(() => {});
   }
 };
 


### PR DESCRIPTION
…nt tracking, enhancing error handling and simplifying the code structure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how PostHog is loaded by switching from a dynamic import to a static module import, which can affect client bundle size and runtime initialization behavior. Tracking calls are now synchronous (non-`async`), so any downstream code relying on a Promise resolution could behave differently.
> 
> **Overview**
> Simplifies website analytics event tracking by **removing the async/dynamic import path for PostHog** and using a static `posthog-js` import instead.
> 
> `trackWebsiteEvent` is now synchronous and keeps failures non-fatal with a broader catch/comment indicating PostHog may not be initialized (e.g., missing key).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa9b645bf09619529e2ce91c5e3704ebf108d341. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->