### PR TITLE
Cursor BB PR Feedback Suggestions

### DIFF
--- a/crates/runmat-accelerate/src/backend/wgpu/provider_impl/fft.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/provider_impl/fft.rs
@@ -431,6 +431,21 @@ impl WgpuProvider {
                             digits,
                         );
                     }
+                    return self.try_fft_dim_exec_native_mixed(
+                        entry.buffer,
+                        shape,
+                        dim,
+                        origin_rank,
+                        current_len,
+                        copy_len,
+                        target_len,
+                        inner_stride,
+                        total_out,
+                        out_scalar_len,
+                        complex_axis,
+                        inverse,
+                        &factors,
+                    );
                 } else if has_5 && !has_3 {
                     if let Some(digits) = fft_log5_pow5(target_len) {
                         return self.try_fft_dim_exec_native_radix5(
@@ -449,6 +464,21 @@ impl WgpuProvider {
                             digits,
                         );
                     }
+                    return self.try_fft_dim_exec_native_mixed(
+                        entry.buffer,
+                        shape,
+                        dim,
+                        origin_rank,
+                        current_len,
+                        copy_len,
+                        target_len,
+                        inner_stride,
+                        total_out,
+                        out_scalar_len,
+                        complex_axis,
+                        inverse,
+                        &factors,
+                    );
                 } else {
                     return self.try_fft_dim_exec_native_mixed(
                         entry.buffer,

--- a/crates/runmat-accelerate/src/backend/wgpu/shaders/fft.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/shaders/fft.rs
@@ -16,8 +16,7 @@ struct Params {
 
 @group(0) @binding(0) var<storage, read> Input: Tensor;
 @group(0) @binding(1) var<storage, read_write> Output: Tensor;
-@group(0) @binding(2) var<storage, read> Twiddles: Tensor;
-@group(0) @binding(3) var<uniform> params: Params;
+@group(0) @binding(2) var<uniform> params: Params;
 
 @compute @workgroup_size(@WG@)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
@@ -426,8 +425,7 @@ struct Params {
 
 @group(0) @binding(0) var<storage, read> Input: Tensor;
 @group(0) @binding(1) var<storage, read_write> Output: Tensor;
-@group(0) @binding(2) var<storage, read> Twiddles: Tensor;
-@group(0) @binding(3) var<storage, read> params: Params;
+@group(0) @binding(2) var<uniform> params: Params;
 
 fn load_complex(data: ptr<storage, array<f64>, read>, index: u32) -> vec2<f64> {
     let base = index * 2u;


### PR DESCRIPTION
Fixes WGPU shader binding mismatches for F64 FFT initialization and direct shaders, and improves FFT routing for mixed-radix smooth numbers to avoid inefficient Bluestein fallback.

The original FFT routing logic for smooth-235 numbers incorrectly directed numbers with mixed factors of 2 and only one of 3 or 5 (e.g., 6, 10, 12) to the slower Bluestein algorithm. The fix ensures these numbers now utilize the more efficient mixed-radix decomposition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GPU shader bind group layouts for F64 FFT kernels and alters FFT plan selection logic, which could break GPU execution or produce incorrect results if bindings/dispatch assumptions are wrong. Scope is limited to FFT paths but impacts correctness/performance for affected sizes.
> 
> **Overview**
> Fixes WGPU FFT correctness/perf issues by **aligning F64 shader bindings** and improving **native FFT routing**.
> 
> The F64 `fft_init` and `fft_direct` shaders drop an unused `Twiddles` binding and treat `params` as a `uniform` at `@binding(2)`, eliminating bind group mismatches.
> 
> FFT dimension selection now routes smooth-235 sizes with mixed factors (e.g., 2×3 or 2×5 compositions) through the native `mixed` radix path instead of falling back to slower Bluestein when the length isn’t a pure power of 3 or 5.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bece37c0584c5e48a9c161135b1f02b581149c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->