### PR TITLE
fixed gpu-backed selector indexing bug

### DIFF
--- a/crates/runmat-ignition/src/vm.rs
+++ b/crates/runmat-ignition/src/vm.rs
@@ -721,6 +721,15 @@ async fn index_scalar_from_value(value: &Value) -> VmResult<Option<i64>> {
     Ok(index_scalar_from_host_value(value))
 }
 
+async fn materialize_index_value(value: &Value) -> VmResult<Value> {
+    if matches!(value, Value::GpuTensor(_)) {
+        return gather_if_needed_async(value)
+            .await
+            .map_err(|e| mex("IndexGather", &format!("Failed to gather index value: {e}")));
+    }
+    Ok(value.clone())
+}
+
 async fn indices_from_value_linear(value: &Value, total_len: usize) -> VmResult<Vec<usize>> {
     if let Value::Bool(b) = value {
         return Ok(if *b { vec![1] } else { Vec::new() });
@@ -736,6 +745,13 @@ async fn indices_from_value_linear(value: &Value, total_len: usize) -> VmResult<
         }
         return Ok(vec![idx_val as usize]);
     }
+    let materialized;
+    let value = if matches!(value, Value::GpuTensor(_)) {
+        materialized = materialize_index_value(value).await?;
+        &materialized
+    } else {
+        value
+    };
     match value {
         Value::Tensor(idx_t) => {
             let len = idx_t.shape.iter().product::<usize>();
@@ -792,6 +808,13 @@ async fn selector_from_value_dim(value: &Value, dim_len: usize) -> VmResult<Slic
         }
         return Ok(SliceSelector::Scalar(idx_val as usize));
     }
+    let materialized;
+    let value = if matches!(value, Value::GpuTensor(_)) {
+        materialized = materialize_index_value(value).await?;
+        &materialized
+    } else {
+        value
+    };
     match value {
         Value::Tensor(idx_t) => {
             let len = idx_t.shape.iter().product::<usize>();
@@ -851,7 +874,8 @@ async fn build_slice_selectors(
                 "missing numeric index for linear slice",
             )
         })?;
-        if let Value::Tensor(idx_t) = value {
+        let materialized = materialize_index_value(value).await?;
+        if let Value::Tensor(idx_t) = &materialized {
             let len = idx_t.shape.iter().product::<usize>();
             let mut indices = Vec::with_capacity(len);
             for &val in &idx_t.data {
@@ -866,7 +890,7 @@ async fn build_slice_selectors(
                 output_shape: idx_t.shape.clone(),
             });
         } else {
-            let idxs = indices_from_value_linear(value, total_len).await?;
+            let idxs = indices_from_value_linear(&materialized, total_len).await?;
             selectors.push(SliceSelector::Indices(idxs));
         }
         return Ok(selectors);
@@ -5650,13 +5674,14 @@ async fn run_interpreter_inner(
                             } else if is_end {
                                 idxs = vec![total];
                             } else if let Some(v) = numeric.first() {
-                                if let Some(i) = index_scalar_from_value(v).await? {
+                                let materialized = materialize_index_value(v).await?;
+                                if let Some(i) = index_scalar_from_value(&materialized).await? {
                                     if i < 1 {
                                         vm_bail!(mex("IndexOutOfBounds", "Index out of bounds"));
                                     }
                                     idxs = vec![i as usize];
                                 } else {
-                                    match v {
+                                    match &materialized {
                                         Value::Tensor(idx_t) => {
                                             idx_shape = Some(idx_t.shape.clone());
                                             for &val in &idx_t.data {
@@ -5739,7 +5764,10 @@ async fn run_interpreter_inner(
                                         "missing numeric index",
                                     ))?;
                                     num_iter += 1;
-                                    if let Some(idx) = index_scalar_from_value(v).await? {
+                                    let materialized = materialize_index_value(v).await?;
+                                    if let Some(idx) =
+                                        index_scalar_from_value(&materialized).await?
+                                    {
                                         if idx < 1 {
                                             return Err(mex(
                                                 "IndexOutOfBounds",
@@ -5748,7 +5776,7 @@ async fn run_interpreter_inner(
                                         }
                                         selectors.push(Sel::Scalar(idx as usize));
                                     } else {
-                                        match v {
+                                        match &materialized {
                                             Value::Tensor(idx_t) => {
                                                 let dim_len = *t.shape.get(d).unwrap_or(&1);
                                                 let len = idx_t.shape.iter().product::<usize>();
@@ -6079,13 +6107,14 @@ async fn run_interpreter_inner(
                             } else if is_end {
                                 idxs = vec![total];
                             } else if let Some(v) = numeric.first() {
-                                if let Some(i) = index_scalar_from_value(v).await? {
+                                let materialized = materialize_index_value(v).await?;
+                                if let Some(i) = index_scalar_from_value(&materialized).await? {
                                     if i < 1 {
                                         vm_bail!(mex("IndexOutOfBounds", "Index out of bounds"));
                                     }
                                     idxs = vec![i as usize];
                                 } else {
-                                    match v {
+                                    match &materialized {
                                         Value::Tensor(idx_t) => {
                                             let len = idx_t.shape.iter().product::<usize>();
                                             if len == total {
@@ -6147,7 +6176,10 @@ async fn run_interpreter_inner(
                                         "missing numeric index",
                                     ))?;
                                     num_iter += 1;
-                                    if let Some(idx) = index_scalar_from_value(v).await? {
+                                    let materialized = materialize_index_value(v).await?;
+                                    if let Some(idx) =
+                                        index_scalar_from_value(&materialized).await?
+                                    {
                                         if idx < 1 {
                                             return Err(mex(
                                                 "IndexOutOfBounds",
@@ -6156,7 +6188,7 @@ async fn run_interpreter_inner(
                                         }
                                         selectors.push(Sel::Scalar(idx as usize));
                                     } else {
-                                        match v {
+                                        match &materialized {
                                             Value::Tensor(idx_t) => {
                                                 let dim_len = *sa.shape.get(d).unwrap_or(&1);
                                                 let len = idx_t.shape.iter().product::<usize>();

--- a/crates/runmat-ignition/tests/basics.rs
+++ b/crates/runmat-ignition/tests/basics.rs
@@ -332,6 +332,29 @@ fn fft2_output_supports_two_dimensional_indexing() {
 }
 
 #[test]
+fn fft_output_accepts_gpu_backed_range_selector() {
+    let input = r#"
+        fs = 1000;
+        t = (0:fs-1)'/fs;
+        x = 0.8*sin(2*pi*120*t) + 0.35*sin(2*pi*260*t);
+        N = 2^nextpow2(length(x));
+        X = fft(x, N);
+        k = floor(N/2) + 1;
+        Y = X(1:k);
+        ok = (numel(Y) == 513);
+    "#;
+    let ast = parse(input).expect("parse fft gpu-backed range script");
+    let hir = lower(&ast).expect("lower fft gpu-backed range script");
+    let vars = execute(&hir).expect("fft gpu-backed range indexing should execute");
+    assert!(
+        vars.iter().any(|v| {
+            matches!(v, Value::Bool(true)) || matches!(v, Value::Num(n) if (*n - 1.0).abs() < 1e-12)
+        }),
+        "expected true/equivalent marker in vars, got {vars:?}"
+    );
+}
+
+#[test]
 fn fft_output_supports_scalar_end_div_indexing() {
     let input = r#"
         x = [1 2 3 4 5 6 7 8];

--- a/crates/runmat-ignition/tests/indexing.rs
+++ b/crates/runmat-ignition/tests/indexing.rs
@@ -65,3 +65,16 @@ fn logical_mask_linear_indexing_matrix_mask_returns_column() {
         panic!("v");
     }
 }
+
+#[test]
+fn host_linear_indexing_accepts_gpu_backed_range_selector() {
+    let ast = parse("a=length(1:10); k=floor(a/2)+1; x=(1:10)'; y=x(1:k);").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    if let Value::Tensor(v) = &vars[3] {
+        assert_eq!(v.shape, vec![1, 6]);
+        assert_eq!(v.data, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    } else {
+        panic!("y");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core VM indexing/slicing paths and changes how GPU-backed selectors are materialized, which could affect a broad set of indexing behaviors despite being a targeted fix.
> 
> **Overview**
> Fixes a bug where **GPU-backed index selectors** (e.g., range/array indices produced on the GPU) were not reliably usable for slicing, by introducing `materialize_index_value` to gather `Value::GpuTensor` selectors onto the host before interpreting them as scalars, tensors, or logical masks.
> 
> Applies this materialization consistently across linear slicing and per-dimension selector handling (including `build_slice_selectors` and `IndexSliceExpr` execution paths), and adds regression tests covering FFT and host linear indexing with GPU-backed range selectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64c31a30e6ad8c1dc294dfe5bee585b96ca6ea7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->