### PR TITLE
fixed clear/variable display issue

### DIFF
--- a/crates/runmat-core/tests/command_controls.rs
+++ b/crates/runmat-core/tests/command_controls.rs
@@ -91,13 +91,18 @@ fn clear_followed_by_assignments_shows_vars_in_workspace() {
     // Variables assigned after clear() in the same execution block must appear
     // in the workspace snapshot – the bug was that StoreVar did not re-register
     // names into ws.idx_to_name after workspace_clear() wiped the map.
-    let result = block_on(engine.execute(
-        "clear();\nXRange = -2:0.02:2;\nYRange = -2:0.02:2;\ndisp(YRange);",
-    ))
+    let result = block_on(
+        engine.execute("clear();\nXRange = -2:0.02:2;\nYRange = -2:0.02:2;\ndisp(YRange);"),
+    )
     .unwrap();
 
     assert!(result.error.is_none());
-    let names: Vec<&str> = result.workspace.values.iter().map(|e| e.name.as_str()).collect();
+    let names: Vec<&str> = result
+        .workspace
+        .values
+        .iter()
+        .map(|e| e.name.as_str())
+        .collect();
     assert!(
         names.contains(&"XRange"),
         "XRange should be in workspace after clear(); XRange = ...; got: {names:?}"

--- a/crates/runmat-core/tests/command_controls.rs
+++ b/crates/runmat-core/tests/command_controls.rs
@@ -85,6 +85,30 @@ fn clear_multiple_named_variables_accepts_multiple_inputs() {
 }
 
 #[test]
+fn clear_followed_by_assignments_shows_vars_in_workspace() {
+    let mut engine = gc_test_context(RunMatSession::new).unwrap();
+
+    // Variables assigned after clear() in the same execution block must appear
+    // in the workspace snapshot – the bug was that StoreVar did not re-register
+    // names into ws.idx_to_name after workspace_clear() wiped the map.
+    let result = block_on(engine.execute(
+        "clear();\nXRange = -2:0.02:2;\nYRange = -2:0.02:2;\ndisp(YRange);",
+    ))
+    .unwrap();
+
+    assert!(result.error.is_none());
+    let names: Vec<&str> = result.workspace.values.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        names.contains(&"XRange"),
+        "XRange should be in workspace after clear(); XRange = ...; got: {names:?}"
+    );
+    assert!(
+        names.contains(&"YRange"),
+        "YRange should be in workspace after clear(); YRange = ...; got: {names:?}"
+    );
+}
+
+#[test]
 fn clc_emits_clear_screen_control_stream() {
     let mut engine = gc_test_context(RunMatSession::new).unwrap();
 

--- a/crates/runmat-ignition/src/vm.rs
+++ b/crates/runmat-ignition/src/vm.rs
@@ -2766,8 +2766,19 @@ async fn run_interpreter_inner(
                 vars[i] = val;
                 WORKSPACE_STATE.with(|state| {
                     if let Some(ws) = state.borrow_mut().as_mut() {
-                        if let Some(name) = ws.idx_to_name.get(&i) {
-                            ws.assigned.insert(name.clone());
+                        let name = ws.idx_to_name.get(&i).cloned().or_else(|| {
+                            // After clear() the idx_to_name map is wiped, but the compiled
+                            // bytecode still uses the same slot indices.  Re-register the
+                            // name→idx mapping from the static bytecode var_names table so
+                            // that post-clear assignments are visible in the workspace.
+                            bytecode.var_names.get(&i).map(|n| {
+                                ws.names.entry(n.clone()).or_insert(i);
+                                ws.idx_to_name.entry(i).or_insert_with(|| n.clone());
+                                n.clone()
+                            })
+                        });
+                        if let Some(name) = name {
+                            ws.assigned.insert(name);
                         }
                     }
                 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches VM `StoreVar`/workspace bookkeeping so post-`clear()` assignments re-populate name↔index mappings; mistakes could cause incorrect workspace snapshots or variable tracking regressions.
> 
> **Overview**
> Fixes a workspace snapshot bug where variables assigned after `clear()` within the same execution block were missing from the reported workspace.
> 
> `StoreVar` now re-registers missing slot names into `ws.names`/`ws.idx_to_name` from `bytecode.var_names` when the maps were wiped by `workspace_clear()`, and a new regression test asserts `XRange`/`YRange` appear after `clear(); ...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9514d52c2d72617b3085c70505710a7093dd0807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->