### PR TITLE
- Introduced a new `breadcrumbItems` array to streamline the creation…

### DIFF
--- a/website/app/docs/[...slug]/page.tsx
+++ b/website/app/docs/[...slug]/page.tsx
@@ -161,26 +161,31 @@ export default async function DocPage({ params }: { params: Promise<{ slug?: str
   };
   const pageJsonLdString = JSON.stringify(pageJsonLd).replace(/<\//g, "<\\/");
   const crumbs = findPathBySlug(slug) ?? [];
+  const breadcrumbItems = crumbs
+    .filter((c) => c.title)
+    .map((c) => {
+      const item = c.slug
+        ? `${baseUrl}/docs/${c.slug.join("/")}`
+        : c.externalHref
+          ? `${baseUrl}${c.externalHref}`
+          : undefined;
+      if (!item) return undefined;
+      return {
+        "@type": "ListItem" as const,
+        name: c.title,
+        item,
+      };
+    })
+    .filter((entry): entry is { "@type": "ListItem"; name: string; item: string } => Boolean(entry?.item));
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
       { "@type": "ListItem", position: 1, name: "Docs", item: `${baseUrl}/docs` },
-      ...crumbs
-        .filter((c) => c.title)
-        .map((c, i) => {
-          const item = c.slug
-            ? `${baseUrl}/docs/${c.slug.join("/")}`
-            : c.externalHref
-              ? `${baseUrl}${c.externalHref}`
-              : undefined;
-          return {
-            "@type": "ListItem" as const,
-            position: i + 2,
-            name: c.title,
-            ...(item ? { item } : {}),
-          };
-        }),
+      ...breadcrumbItems.map((entry, i) => ({
+        ...entry,
+        position: i + 2,
+      })),
     ],
   };
   const breadcrumbJsonLdString = JSON.stringify(breadcrumbJsonLd).replace(/<\//g, "<\\/");


### PR DESCRIPTION
… of breadcrumb list items.

- Replaced the previous inline mapping logic with a more structured approach, enhancing readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to docs breadcrumb JSON-LD construction; main behavior change is that breadcrumbs without a resolvable URL are now omitted instead of emitting items without `item`.
> 
> **Overview**
> Refactors docs page breadcrumb JSON-LD generation by introducing a `breadcrumbItems` precomputed array and reusing it when building the `BreadcrumbList`.
> 
> Behaviorally, breadcrumb entries that don’t resolve to a URL (`slug`/`externalHref`) are now filtered out entirely rather than being included without an `item` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c13046196afecbf4cea10d7bcfcd00e0cc56573d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->