### PR TITLE
Update GTM script loading to lazyOnload

### DIFF
--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -433,6 +433,21 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
           dangerouslySetInnerHTML={{ __html: jsonLdString }}
         />
       )}
+      
+      {/* If there's a frontmatter image and we're on a specific blog post, render it early as a hero to improve LCP */}
+      {post.frontmatter.image && (
+        <div className="mb-10 w-full rounded-xl overflow-hidden shadow-md">
+          <Image 
+            src={post.frontmatter.image} 
+            alt={post.frontmatter.imageAlt || post.frontmatter.title}
+            width={1200}
+            height={630}
+            className="w-full h-auto object-cover"
+            priority={true}
+          />
+        </div>
+      )}
+
       <MarkdownRenderer source={post.content} />
 
       {relatedPosts.length > 0 && (

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import { ThemeProvider } from "@/components/ThemeProvider";
-
+import { GoogleAnalytics } from "@/components/GoogleAnalytics";
 import { GoogleTagManager } from "@/components/GoogleTagManager";
 import AnalyticsBootstrapClient from "@/components/AnalyticsBootstrapClient";
 
@@ -182,7 +182,7 @@ export default function RootLayout({
             }
           `}</style>
         ) : null}
-
+        <GoogleAnalytics />
       </head>
       <body className={`${inter.className} antialiased`} suppressHydrationWarning>
         <GoogleTagManager />

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import { ThemeProvider } from "@/components/ThemeProvider";
-import { GoogleAnalytics } from "@/components/GoogleAnalytics";
+
 import { GoogleTagManager } from "@/components/GoogleTagManager";
 import AnalyticsBootstrapClient from "@/components/AnalyticsBootstrapClient";
 
@@ -182,7 +182,7 @@ export default function RootLayout({
             }
           `}</style>
         ) : null}
-        <GoogleAnalytics />
+
       </head>
       <body className={`${inter.className} antialiased`} suppressHydrationWarning>
         <GoogleTagManager />

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -73,11 +73,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <link
-          rel="preload"
-          as="image"
-          href="https://web.runmatstatic.com/video/posters/runmat-wave-simulation.webp"
-        />
+        {/* We moved the poster preload out of root layout because it hurts LCP on non-homepage routes (like blogs) */}
         <link rel="icon" href="/favicon.ico" sizes="32x32" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/website/app/matlab-online/page.tsx
+++ b/website/app/matlab-online/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import dynamic from "next/dynamic";
+import LazyVideo from "@/components/LazyVideo";
 
 const MatlabInlineCodeBlock = dynamic(() => import("@/components/MatlabInlineCodeBlock"), {
   loading: () => <div className="w-full h-[60px] rounded-md bg-muted/40 animate-pulse" />,
@@ -336,18 +337,16 @@ export default function MatlabOnlinePage() {
               </div>
             </div>
             <div className="rounded-xl border border-border bg-muted/40 p-2 bg-[radial-gradient(ellipse_at_top,_rgba(124,58,237,0.25),_transparent_60%)]">
-              <video
-                className="w-full h-auto rounded-lg"
-                autoPlay
+              <LazyVideo
+                className="w-full h-auto rounded-lg shadow-sm"
                 muted
                 loop
                 playsInline
-                preload="none"
                 poster={heroPosterSrc}
                 aria-label="RunMat MATLAB-style code example demo"
               >
                 <source src={heroVideoSrc} type="video/mp4" />
-              </video>
+              </LazyVideo>
             </div>
           </div>
         </section>

--- a/website/components/GoogleTagManager.tsx
+++ b/website/components/GoogleTagManager.tsx
@@ -14,7 +14,7 @@ export function GoogleTagManager() {
 
   return (
     <>
-      <Script id="gtm-init" strategy="afterInteractive">
+      <Script id="gtm-init" strategy="lazyOnload">
         {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;

--- a/website/components/MarkdownRenderer.tsx
+++ b/website/components/MarkdownRenderer.tsx
@@ -318,15 +318,24 @@ export async function MarkdownRenderer({ source, components = {} }: MarkdownRend
       const inlineClassName = mergeClassNames("markdown-inline-code", className);
       return <code className={inlineClassName} {...props}>{children}</code>;
     },
-    img: ({ src, alt, ...props }: { src?: string; alt?: string } & Record<string, unknown>) => (
-      <img 
-        src={src} 
-        alt={alt} 
-        className="my-6 max-w-full h-auto rounded-lg" 
-        loading="lazy"
-        {...props} 
-      />
-    ),
+    img: ({ src, alt, ...props }: { src?: string; alt?: string } & Record<string, unknown>) => {
+      // Next.js Image component handles lazy loading better by default, 
+      // but for markdown we'll use a standard img tag with better attributes
+      // The hero image or first image should usually be eager loaded
+      const isFirstImage = src?.includes('free-matlab-alternatives-2026') || false; // Hacky way to detect hero
+      
+      return (
+        <img 
+          src={src} 
+          alt={alt} 
+          className="my-6 max-w-full h-auto rounded-lg shadow-sm" 
+          loading={isFirstImage ? "eager" : "lazy"}
+          fetchPriority={isFirstImage ? "high" : "auto"}
+          decoding="async"
+          {...props} 
+        />
+      );
+    },
     MermaidDiagram: (props: { chart?: string } & Record<string, unknown>) => (
       <div className="my-12 flex justify-center">
         <div className="max-w-full overflow-x-auto">

--- a/website/content/blog/matlab-alternatives.md
+++ b/website/content/blog/matlab-alternatives.md
@@ -128,9 +128,6 @@ jsonLd:
             text: "RunMat ships as a single static binary with no external dependencies or license server, making it straightforward to deploy on air-gapped networks. MATLAB requires a FlexLM license server, and Python requires pre-staging all package dependencies."
 ---
 
-
-![Matlab Alternatives in 2026](https://web.runmatstatic.com/free-matlab-alternatives-2026.png)
-
 *This article was originally published in September 2025 and has been updated for 2026 with new sections on Browser-Based Computing, GPU Acceleration, Version Control, Large File Handling, and Airgap Deployment.*
 
 ## Why are engineers searching for MATLAB alternatives?


### PR DESCRIPTION
…

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tweaks load priority for images, videos, and GTM, which can change perceived performance and analytics firing timing across key pages. Main risk is unintended regressions in above-the-fold rendering or missing/late tracking on production.
> 
> **Overview**
> Improves perceived performance by adjusting what loads eagerly vs lazily across the site.
> 
> Blog posts now render the frontmatter `image` as an early, `priority` Next `Image` hero (and removes the duplicated in-body markdown image in `matlab-alternatives.md`) to boost LCP. Markdown image rendering is updated to set `loading`/`fetchPriority`/`decoding` attributes (with a special-case to eagerly load the first/hero image).
> 
> Moves the global homepage poster preload out of `RootLayout` to avoid hurting LCP on non-home routes, swaps the `matlab-online` hero from a plain `<video autoPlay>` to `LazyVideo` to defer video loading until in-view, and changes `GoogleTagManager` script loading from `afterInteractive` to `lazyOnload`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50802dd716601f89f3809e624fd23e5b28373651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->