### PR TITLE
Enable input() expression parsing and preserve WASM input handler

### DIFF
--- a/crates/runmat-core/Cargo.toml
+++ b/crates/runmat-core/Cargo.toml
@@ -38,6 +38,7 @@ jit = ["dep:runmat-turbine"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 runmat-runtime = { workspace = true, features = ["plot-core"] }
 runmat-snapshot = { workspace = true, features = ["compression-native", "validation"] }
+futures = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 runmat-runtime = { workspace = true, features = ["plot-web"] }

--- a/crates/runmat-core/src/lib.rs
+++ b/crates/runmat-core/src/lib.rs
@@ -1264,14 +1264,12 @@ impl RunMatSession {
                 move |expr: String| -> runmat_runtime::interaction::EvalHookFuture {
                     Box::pin(async move {
                         let wrapped = format!("__runmat_input_result__ = ({expr});");
-                        let ast =
-                            parse_with_options(&wrapped, ParserOptions::new(compat)).map_err(
-                                |e| {
-                                    build_runtime_error(format!("input: parse error: {e}"))
-                                        .with_identifier("RunMat:input:ParseError")
-                                        .build()
-                                },
-                            )?;
+                        let ast = parse_with_options(&wrapped, ParserOptions::new(compat))
+                            .map_err(|e| {
+                                build_runtime_error(format!("input: parse error: {e}"))
+                                    .with_identifier("RunMat:input:ParseError")
+                                    .build()
+                            })?;
                         let lowering = runmat_hir::lower(
                             &ast,
                             &LoweringContext::new(&HashMap::new(), &HashMap::new()),
@@ -1282,10 +1280,7 @@ impl RunMatSession {
                                 .build()
                         })?;
                         // lowering.variables maps variable name → slot index.
-                        let result_idx = lowering
-                            .variables
-                            .get("__runmat_input_result__")
-                            .copied();
+                        let result_idx = lowering.variables.get("__runmat_input_result__").copied();
                         let bc = runmat_ignition::compile(&lowering.hir, &HashMap::new())
                             .map_err(RuntimeError::from)?;
                         // interpret() returns the final variable slot array.

--- a/crates/runmat-core/src/lib.rs
+++ b/crates/runmat-core/src/lib.rs
@@ -1319,13 +1319,20 @@ impl RunMatSession {
                         // blocking on recv() is safe here because the native executor
                         // (futures::executor::block_on) is itself synchronous.
                         let (tx, rx) = std::sync::mpsc::sync_channel(1);
-                        let _ = std::thread::Builder::new()
+                        let spawn_result = std::thread::Builder::new()
                             .stack_size(16 * 1024 * 1024)
                             .spawn(move || {
                                 let result = futures::executor::block_on(eval_expr(expr, compat));
                                 let _ = tx.send(result);
                             });
                         Box::pin(async move {
+                            spawn_result.map_err(|err| {
+                                build_runtime_error(format!(
+                                    "input: failed to spawn eval thread: {err}"
+                                ))
+                                .with_identifier("RunMat:input:EvalThreadSpawnFailed")
+                                .build()
+                            })?;
                             rx.recv().unwrap_or_else(|_| {
                                 Err(build_runtime_error("input: eval thread panicked")
                                     .with_identifier("RunMat:input:EvalThreadPanic")

--- a/crates/runmat-core/src/lib.rs
+++ b/crates/runmat-core/src/lib.rs
@@ -1251,18 +1251,29 @@ impl RunMatSession {
             runmat_runtime::interaction::replace_async_handler(Some(runtime_async_handler));
 
         // Install a stateless expression evaluator for `input()` numeric parsing.
-        // The closure uses parse → lower → compile → interpret on an empty scope so
-        // that users can type expressions like `[1 2 3]`, `pi`, `42`, `[1 2; 3 4]`
-        // at an `input()` prompt and have them evaluated correctly.
         //
-        // We wrap the user expression in an explicit assignment so that we can
-        // reliably extract the result from the returned variable array by index.
-        // `lowering.variables` maps name → var index, which is exactly what we need.
+        // The hook runs the full parse → lower → compile → interpret pipeline so
+        // that users can type arbitrary MATLAB expressions at an input() prompt:
+        // `sqrt(2)`, `pi/2`, `ones(3)`, `[1 2; 3 4]`, etc.
+        //
+        // Stack-overflow hazard: the hook calls runmat_ignition::interpret() while
+        // the outer interpret() is already on the call stack. On WASM the JS event
+        // loop drives both as async state-machines and the WASM linear stack is
+        // large, so nesting is safe. On native the default thread stack is too
+        // small for two nested interpret() invocations, so we instead run the inner
+        // interpret() on a dedicated thread that has its own 16 MB stack and block
+        // the calling future synchronously on the result (safe because the native
+        // executor — futures::executor::block_on — is already synchronous).
         let compat = self.compat_mode;
         let _eval_hook_guard =
             runmat_runtime::interaction::replace_eval_hook(Some(std::sync::Arc::new(
                 move |expr: String| -> runmat_runtime::interaction::EvalHookFuture {
-                    Box::pin(async move {
+                    // Shared eval logic, used by both the WASM async path and the
+                    // native thread path below.
+                    async fn eval_expr(
+                        expr: String,
+                        compat: runmat_parser::CompatMode,
+                    ) -> Result<Value, RuntimeError> {
                         let wrapped = format!("__runmat_input_result__ = ({expr});");
                         let ast = parse_with_options(&wrapped, ParserOptions::new(compat))
                             .map_err(|e| {
@@ -1279,11 +1290,9 @@ impl RunMatSession {
                                 .with_identifier("RunMat:input:LowerError")
                                 .build()
                         })?;
-                        // lowering.variables maps variable name → slot index.
                         let result_idx = lowering.variables.get("__runmat_input_result__").copied();
                         let bc = runmat_ignition::compile(&lowering.hir, &HashMap::new())
                             .map_err(RuntimeError::from)?;
-                        // interpret() returns the final variable slot array.
                         let vars = runmat_ignition::interpret(&bc).await?;
                         result_idx
                             .and_then(|idx| vars.get(idx).cloned())
@@ -1292,7 +1301,38 @@ impl RunMatSession {
                                     .with_identifier("RunMat:input:NoValue")
                                     .build()
                             })
-                    })
+                    }
+
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        // On WASM: await the inner interpret() directly. The JS async
+                        // runtime handles both futures as cooperative state-machines and
+                        // the WASM linear stack is large enough for the extra frames.
+                        Box::pin(eval_expr(expr, compat))
+                    }
+
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        // On native: run interpret() on a dedicated thread so it gets
+                        // its own 16 MB stack, fully isolated from the outer interpret()
+                        // call stack. The result is sent back via a synchronous channel;
+                        // blocking on recv() is safe here because the native executor
+                        // (futures::executor::block_on) is itself synchronous.
+                        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+                        let _ = std::thread::Builder::new()
+                            .stack_size(16 * 1024 * 1024)
+                            .spawn(move || {
+                                let result = futures::executor::block_on(eval_expr(expr, compat));
+                                let _ = tx.send(result);
+                            });
+                        Box::pin(async move {
+                            rx.recv().unwrap_or_else(|_| {
+                                Err(build_runtime_error("input: eval thread panicked")
+                                    .with_identifier("RunMat:input:EvalThreadPanic")
+                                    .build())
+                            })
+                        })
+                    }
                 },
             )));
 

--- a/crates/runmat-core/src/lib.rs
+++ b/crates/runmat-core/src/lib.rs
@@ -1250,6 +1250,57 @@ impl RunMatSession {
         let _async_input_guard =
             runmat_runtime::interaction::replace_async_handler(Some(runtime_async_handler));
 
+        // Install a stateless expression evaluator for `input()` numeric parsing.
+        // The closure uses parse → lower → compile → interpret on an empty scope so
+        // that users can type expressions like `[1 2 3]`, `pi`, `42`, `[1 2; 3 4]`
+        // at an `input()` prompt and have them evaluated correctly.
+        //
+        // We wrap the user expression in an explicit assignment so that we can
+        // reliably extract the result from the returned variable array by index.
+        // `lowering.variables` maps name → var index, which is exactly what we need.
+        let compat = self.compat_mode;
+        let _eval_hook_guard =
+            runmat_runtime::interaction::replace_eval_hook(Some(std::sync::Arc::new(
+                move |expr: String| -> runmat_runtime::interaction::EvalHookFuture {
+                    Box::pin(async move {
+                        let wrapped = format!("__runmat_input_result__ = ({expr});");
+                        let ast =
+                            parse_with_options(&wrapped, ParserOptions::new(compat)).map_err(
+                                |e| {
+                                    build_runtime_error(format!("input: parse error: {e}"))
+                                        .with_identifier("RunMat:input:ParseError")
+                                        .build()
+                                },
+                            )?;
+                        let lowering = runmat_hir::lower(
+                            &ast,
+                            &LoweringContext::new(&HashMap::new(), &HashMap::new()),
+                        )
+                        .map_err(|e| {
+                            build_runtime_error(format!("input: lowering error: {e}"))
+                                .with_identifier("RunMat:input:LowerError")
+                                .build()
+                        })?;
+                        // lowering.variables maps variable name → slot index.
+                        let result_idx = lowering
+                            .variables
+                            .get("__runmat_input_result__")
+                            .copied();
+                        let bc = runmat_ignition::compile(&lowering.hir, &HashMap::new())
+                            .map_err(RuntimeError::from)?;
+                        // interpret() returns the final variable slot array.
+                        let vars = runmat_ignition::interpret(&bc).await?;
+                        result_idx
+                            .and_then(|idx| vars.get(idx).cloned())
+                            .ok_or_else(|| {
+                                build_runtime_error("input: expression produced no value")
+                                    .with_identifier("RunMat:input:NoValue")
+                                    .build()
+                            })
+                    })
+                },
+            )));
+
         if self.verbose {
             debug!("Executing: {}", input.trim());
         }

--- a/crates/runmat-runtime/src/builtins/constants/mod.rs
+++ b/crates/runmat-runtime/src/builtins/constants/mod.rs
@@ -12,12 +12,6 @@ register_constant!(
 );
 
 register_constant!(
-    "e",
-    Value::Num(std::f64::consts::E),
-    "crate::builtins::constants"
-);
-
-register_constant!(
     "eps",
     Value::Num(f64::EPSILON),
     "crate::builtins::constants"

--- a/crates/runmat-runtime/src/builtins/io/input.rs
+++ b/crates/runmat-runtime/src/builtins/io/input.rs
@@ -167,6 +167,19 @@ async fn parse_numeric_response(line: &str) -> Result<Value, RuntimeError> {
     if trimmed.is_empty() || trimmed == "[]" {
         return Ok(Value::Tensor(Tensor::zeros(vec![0, 0])));
     }
+    // Use the eval hook installed by runmat-core if available. This lets users
+    // type full MATLAB expressions: `[1 2 3]`, `pi`, `3+4`, `ones(3)`, etc.
+    if let Some(hook) = interaction::current_eval_hook() {
+        return hook(trimmed.to_string()).await.map_err(|err| {
+            let message = err.message().to_string();
+            build_runtime_error(format!("input: invalid expression ({message})"))
+                .with_identifier("RunMat:input:EvalFailed")
+                .with_source(err)
+                .with_builtin("input")
+                .build()
+        });
+    }
+    // Fallback when no eval hook is installed (e.g. in unit tests or native REPL).
     call_builtin_async("str2double", &[Value::String(trimmed.to_string())])
         .await
         .map_err(|err| {
@@ -210,6 +223,22 @@ pub(crate) mod tests {
         match value {
             Value::Tensor(t) => assert!(t.data.is_empty()),
             other => panic!("expected empty tensor, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn matrix_input_falls_through_to_str2double_without_hook() {
+        // Without the eval hook (unit-test context), `[1 2 3]` is not a scalar
+        // so str2double returns NaN. This test documents that the hook path is
+        // needed for matrix literals and that the fallback returns NaN (not an error).
+        push_queued_response(Ok(InteractionResponse::Line("[1 2 3]".into())));
+        let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
+        // str2double("[1 2 3]") returns NaN — the eval hook is required for the
+        // real result; this test just confirms no panic or hard error occurs.
+        match value {
+            Value::Num(f) => assert!(f.is_nan()),
+            other => panic!("expected NaN scalar, got {other:?}"),
         }
     }
 

--- a/crates/runmat-runtime/src/builtins/io/input.rs
+++ b/crates/runmat-runtime/src/builtins/io/input.rs
@@ -1,6 +1,6 @@
 //! MATLAB-compatible `input` builtin for line-oriented console interaction.
 
-use runmat_builtins::{CharArray, Tensor, Value};
+use runmat_builtins::{CharArray, LogicalArray, Tensor, Value};
 use runmat_macros::runtime_builtin;
 
 use crate::builtins::common::spec::{
@@ -168,13 +168,13 @@ async fn parse_numeric_response(line: &str) -> Result<Value, RuntimeError> {
         return Ok(Value::Tensor(Tensor::zeros(vec![0, 0])));
     }
 
-    // Fast path 1: scalar literals and named constants.
+    // Fast path 1: scalar literals, named constants, and logical keywords.
     // Handles the vast majority of input() use cases without touching the VM.
-    if let Some(f) = parse_scalar_token(trimmed) {
-        return Ok(Value::Num(f));
+    if let Some(v) = parse_scalar_value(trimmed) {
+        return Ok(v);
     }
 
-    // Fast path 2: matrix/vector literals like `[1 2 3]`, `[1;2;3]`, `[1 2;3 4]`.
+    // Fast path 2: matrix/vector literals like `[1 2 3]`, `[1;2;3]`, `[true false]`.
     // Avoids recursive interpret() calls for this common case.
     if trimmed.starts_with('[') && trimmed.ends_with(']') {
         if let Some(v) = parse_matrix_literal(trimmed) {
@@ -210,19 +210,21 @@ async fn parse_numeric_response(line: &str) -> Result<Value, RuntimeError> {
         })
 }
 
-/// Parse a single token that represents a MATLAB numeric scalar or named constant.
-/// Returns `None` if the token is not a recognisable scalar (e.g. it contains
-/// brackets, commas, or looks like a function call).
-fn parse_scalar_token(s: &str) -> Option<f64> {
-    // Named constants (case-insensitive to match MATLAB behaviour).
+/// Parse a single MATLAB scalar token into a [`Value`].
+///
+/// Returns [`Value::Bool`] for `true`/`false` (case-insensitive), [`Value::Num`]
+/// for numeric literals and named constants (`pi`, `inf`, `nan`, `e`), and
+/// `None` for anything that looks like a matrix, function call, or unknown
+/// identifier.
+fn parse_scalar_value(s: &str) -> Option<Value> {
     match s.to_ascii_lowercase().as_str() {
-        "pi" => return Some(std::f64::consts::PI),
-        "inf" | "+inf" | "infinity" | "+infinity" => return Some(f64::INFINITY),
-        "-inf" | "-infinity" => return Some(f64::NEG_INFINITY),
-        "nan" => return Some(f64::NAN),
-        "e" => return Some(std::f64::consts::E),
-        "true" => return Some(1.0),
-        "false" => return Some(0.0),
+        "true" => return Some(Value::Bool(true)),
+        "false" => return Some(Value::Bool(false)),
+        "pi" => return Some(Value::Num(std::f64::consts::PI)),
+        "inf" | "+inf" | "infinity" | "+infinity" => return Some(Value::Num(f64::INFINITY)),
+        "-inf" | "-infinity" => return Some(Value::Num(f64::NEG_INFINITY)),
+        "nan" => return Some(Value::Num(f64::NAN)),
+        "e" => return Some(Value::Num(std::f64::consts::E)),
         _ => {}
     }
     // Plain numeric literals: integers, decimals, scientific notation, optional sign.
@@ -235,14 +237,18 @@ fn parse_scalar_token(s: &str) -> Option<f64> {
     if has_non_numeric {
         return None;
     }
-    s.parse::<f64>().ok()
+    s.parse::<f64>().ok().map(Value::Num)
 }
 
 /// Parse a MATLAB matrix literal of the form `[elements]`.
 ///
 /// Rows are separated by `;` and elements within a row by whitespace and/or `,`.
-/// Every element must be a token accepted by [`parse_scalar_token`].
+/// Every element must be a token accepted by [`parse_scalar_value`].
 /// Returns `None` if the literal is malformed or contains non-scalar elements.
+///
+/// Output type mirrors MATLAB semantics:
+/// - All-logical elements → [`Value::LogicalArray`]
+/// - Any numeric element  → [`Value::Tensor`] (logical elements coerced to `f64`)
 fn parse_matrix_literal(s: &str) -> Option<Value> {
     let inner = s.strip_prefix('[')?.strip_suffix(']')?;
     let inner = inner.trim();
@@ -251,7 +257,7 @@ fn parse_matrix_literal(s: &str) -> Option<Value> {
     }
 
     let row_strs: Vec<&str> = inner.split(';').collect();
-    let mut data: Vec<f64> = Vec::new();
+    let mut values: Vec<Value> = Vec::new();
     let mut nrows = 0usize;
     let mut ncols: Option<usize> = None;
 
@@ -269,7 +275,7 @@ fn parse_matrix_literal(s: &str) -> Option<Value> {
             _ => {}
         }
         for token in &tokens {
-            data.push(parse_scalar_token(token)?);
+            values.push(parse_scalar_value(token)?);
         }
         nrows += 1;
     }
@@ -278,10 +284,35 @@ fn parse_matrix_literal(s: &str) -> Option<Value> {
     if nrows == 0 || ncols == 0 {
         return Some(Value::Tensor(Tensor::zeros(vec![0, 0])));
     }
+    // Scalar: preserve the exact type (Bool or Num) rather than always wrapping in Tensor.
     if nrows == 1 && ncols == 1 {
-        return Some(Value::Num(data[0]));
+        return Some(values.remove(0));
     }
-    Tensor::new_2d(data, nrows, ncols).ok().map(Value::Tensor)
+
+    // All-logical → LogicalArray; any numeric element → Tensor (bools coerced to f64).
+    let all_logical = values.iter().all(|v| matches!(v, Value::Bool(_)));
+    if all_logical {
+        let data: Vec<u8> = values
+            .iter()
+            .map(|v| match v {
+                Value::Bool(b) => u8::from(*b),
+                _ => unreachable!(),
+            })
+            .collect();
+        LogicalArray::new(data, vec![nrows, ncols])
+            .ok()
+            .map(Value::LogicalArray)
+    } else {
+        let data: Vec<f64> = values
+            .iter()
+            .map(|v| match v {
+                Value::Num(f) => *f,
+                Value::Bool(b) => f64::from(u8::from(*b)),
+                _ => unreachable!(),
+            })
+            .collect();
+        Tensor::new_2d(data, nrows, ncols).ok().map(Value::Tensor)
+    }
 }
 
 #[cfg(test)]
@@ -345,6 +376,30 @@ pub(crate) mod tests {
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
+    fn true_input_returns_logical_not_double() {
+        push_queued_response(Ok(InteractionResponse::Line("true".into())));
+        let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
+        assert_eq!(value, Value::Bool(true));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn false_input_returns_logical_not_double() {
+        push_queued_response(Ok(InteractionResponse::Line("false".into())));
+        let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
+        assert_eq!(value, Value::Bool(false));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn bool_input_is_case_insensitive() {
+        push_queued_response(Ok(InteractionResponse::Line("TRUE".into())));
+        let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
+        assert_eq!(value, Value::Bool(true));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
     fn column_vector_parses_without_eval_hook() {
         push_queued_response(Ok(InteractionResponse::Line("[1;2;3]".into())));
         let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
@@ -355,6 +410,49 @@ pub(crate) mod tests {
                 assert_eq!(t.data, vec![1.0, 2.0, 3.0]);
             }
             other => panic!("expected 3×1 tensor, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn logical_row_vector_parses_as_logical_array() {
+        push_queued_response(Ok(InteractionResponse::Line("[true false]".into())));
+        let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
+        match value {
+            Value::LogicalArray(la) => {
+                assert_eq!(la.shape, vec![1, 2]);
+                assert_eq!(la.data, vec![1, 0]);
+            }
+            other => panic!("expected LogicalArray, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn logical_column_vector_parses_as_logical_array() {
+        push_queued_response(Ok(InteractionResponse::Line("[true; false]".into())));
+        let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
+        match value {
+            Value::LogicalArray(la) => {
+                assert_eq!(la.shape, vec![2, 1]);
+                assert_eq!(la.data, vec![1, 0]);
+            }
+            other => panic!("expected LogicalArray, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn mixed_logical_and_numeric_coerces_to_double_tensor() {
+        push_queued_response(Ok(InteractionResponse::Line("[true 2.0]".into())));
+        let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
+        match value {
+            Value::Tensor(t) => {
+                assert_eq!(t.rows, 1);
+                assert_eq!(t.cols, 2);
+                assert_eq!(t.data, vec![1.0, 2.0]);
+            }
+            other => panic!("expected Tensor, got {other:?}"),
         }
     }
 

--- a/crates/runmat-runtime/src/builtins/io/input.rs
+++ b/crates/runmat-runtime/src/builtins/io/input.rs
@@ -167,8 +167,25 @@ async fn parse_numeric_response(line: &str) -> Result<Value, RuntimeError> {
     if trimmed.is_empty() || trimmed == "[]" {
         return Ok(Value::Tensor(Tensor::zeros(vec![0, 0])));
     }
-    // Use the eval hook installed by runmat-core if available. This lets users
-    // type full MATLAB expressions: `[1 2 3]`, `pi`, `3+4`, `ones(3)`, etc.
+
+    // Fast path 1: scalar literals and named constants.
+    // Handles the vast majority of input() use cases without touching the VM.
+    if let Some(f) = parse_scalar_token(trimmed) {
+        return Ok(Value::Num(f));
+    }
+
+    // Fast path 2: matrix/vector literals like `[1 2 3]`, `[1;2;3]`, `[1 2;3 4]`.
+    // Avoids recursive interpret() calls for this common case.
+    if trimmed.starts_with('[') && trimmed.ends_with(']') {
+        if let Some(v) = parse_matrix_literal(trimmed) {
+            return Ok(v);
+        }
+    }
+
+    // Full eval path for complex expressions (`sqrt(2)`, `pi/2`, `ones(3)`, etc.).
+    // The eval hook is only safe to call when the executor can handle re-entrant
+    // polls (e.g. the WASM async runtime). On native the fast paths above cover
+    // the common cases; truly complex expressions fall back to str2double here.
     if let Some(hook) = interaction::current_eval_hook() {
         return hook(trimmed.to_string()).await.map_err(|err| {
             let message = err.message().to_string();
@@ -179,7 +196,8 @@ async fn parse_numeric_response(line: &str) -> Result<Value, RuntimeError> {
                 .build()
         });
     }
-    // Fallback when no eval hook is installed (e.g. in unit tests or native REPL).
+
+    // Fallback when no eval hook is installed (unit tests, native REPL).
     call_builtin_async("str2double", &[Value::String(trimmed.to_string())])
         .await
         .map_err(|err| {
@@ -190,6 +208,80 @@ async fn parse_numeric_response(line: &str) -> Result<Value, RuntimeError> {
                 .with_builtin("input")
                 .build()
         })
+}
+
+/// Parse a single token that represents a MATLAB numeric scalar or named constant.
+/// Returns `None` if the token is not a recognisable scalar (e.g. it contains
+/// brackets, commas, or looks like a function call).
+fn parse_scalar_token(s: &str) -> Option<f64> {
+    // Named constants (case-insensitive to match MATLAB behaviour).
+    match s.to_ascii_lowercase().as_str() {
+        "pi" => return Some(std::f64::consts::PI),
+        "inf" | "+inf" | "infinity" | "+infinity" => return Some(f64::INFINITY),
+        "-inf" | "-infinity" => return Some(f64::NEG_INFINITY),
+        "nan" => return Some(f64::NAN),
+        "e" => return Some(std::f64::consts::E),
+        "true" => return Some(1.0),
+        "false" => return Some(0.0),
+        _ => {}
+    }
+    // Plain numeric literals: integers, decimals, scientific notation, optional sign.
+    // We reject anything containing brackets, commas, spaces (which would indicate a
+    // matrix or an expression), or letters other than 'e'/'E' for exponent notation.
+    let has_non_numeric = s.chars().any(|c| {
+        matches!(c, '[' | ']' | ',' | ';' | '(' | ')' | ' ' | '\t')
+            || (c.is_ascii_alphabetic() && c != 'e' && c != 'E' && c != 'i' && c != 'j')
+    });
+    if has_non_numeric {
+        return None;
+    }
+    s.parse::<f64>().ok()
+}
+
+/// Parse a MATLAB matrix literal of the form `[elements]`.
+///
+/// Rows are separated by `;` and elements within a row by whitespace and/or `,`.
+/// Every element must be a token accepted by [`parse_scalar_token`].
+/// Returns `None` if the literal is malformed or contains non-scalar elements.
+fn parse_matrix_literal(s: &str) -> Option<Value> {
+    let inner = s.strip_prefix('[')?.strip_suffix(']')?;
+    let inner = inner.trim();
+    if inner.is_empty() {
+        return Some(Value::Tensor(Tensor::zeros(vec![0, 0])));
+    }
+
+    let row_strs: Vec<&str> = inner.split(';').collect();
+    let mut data: Vec<f64> = Vec::new();
+    let mut nrows = 0usize;
+    let mut ncols: Option<usize> = None;
+
+    for row_str in &row_strs {
+        let tokens: Vec<&str> = row_str
+            .split(|c: char| c == ',' || c.is_ascii_whitespace())
+            .filter(|t| !t.is_empty())
+            .collect();
+        if tokens.is_empty() {
+            continue;
+        }
+        match ncols {
+            None => ncols = Some(tokens.len()),
+            Some(expected) if tokens.len() != expected => return None,
+            _ => {}
+        }
+        for token in &tokens {
+            data.push(parse_scalar_token(token)?);
+        }
+        nrows += 1;
+    }
+
+    let ncols = ncols.unwrap_or(0);
+    if nrows == 0 || ncols == 0 {
+        return Some(Value::Tensor(Tensor::zeros(vec![0, 0])));
+    }
+    if nrows == 1 && ncols == 1 {
+        return Some(Value::Num(data[0]));
+    }
+    Tensor::new_2d(data, nrows, ncols).ok().map(Value::Tensor)
 }
 
 #[cfg(test)]
@@ -228,17 +320,41 @@ pub(crate) mod tests {
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
-    fn matrix_input_falls_through_to_str2double_without_hook() {
-        // Without the eval hook (unit-test context), `[1 2 3]` is not a scalar
-        // so str2double returns NaN. This test documents that the hook path is
-        // needed for matrix literals and that the fallback returns NaN (not an error).
+    fn matrix_literal_parses_without_eval_hook() {
+        // The fast-path parser handles `[1 2 3]` directly, so no eval hook (and
+        // therefore no recursive interpret() call) is needed.
         push_queued_response(Ok(InteractionResponse::Line("[1 2 3]".into())));
         let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
-        // str2double("[1 2 3]") returns NaN — the eval hook is required for the
-        // real result; this test just confirms no panic or hard error occurs.
         match value {
-            Value::Num(f) => assert!(f.is_nan()),
-            other => panic!("expected NaN scalar, got {other:?}"),
+            Value::Tensor(t) => {
+                assert_eq!(t.rows, 1);
+                assert_eq!(t.cols, 3);
+                assert_eq!(t.data, vec![1.0, 2.0, 3.0]);
+            }
+            other => panic!("expected 1×3 tensor, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn named_constants_parse_without_eval_hook() {
+        push_queued_response(Ok(InteractionResponse::Line("pi".into())));
+        let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
+        assert_eq!(value, Value::Num(std::f64::consts::PI));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn column_vector_parses_without_eval_hook() {
+        push_queued_response(Ok(InteractionResponse::Line("[1;2;3]".into())));
+        let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
+        match value {
+            Value::Tensor(t) => {
+                assert_eq!(t.rows, 3);
+                assert_eq!(t.cols, 1);
+                assert_eq!(t.data, vec![1.0, 2.0, 3.0]);
+            }
+            other => panic!("expected 3×1 tensor, got {other:?}"),
         }
     }
 

--- a/crates/runmat-runtime/src/builtins/io/input.rs
+++ b/crates/runmat-runtime/src/builtins/io/input.rs
@@ -213,9 +213,14 @@ async fn parse_numeric_response(line: &str) -> Result<Value, RuntimeError> {
 /// Parse a single MATLAB scalar token into a [`Value`].
 ///
 /// Returns [`Value::Bool`] for `true`/`false` (case-insensitive), [`Value::Num`]
-/// for numeric literals and named constants (`pi`, `inf`, `nan`, `e`), and
+/// for numeric literals and named constants (`pi`, `inf`, `nan`), and
 /// `None` for anything that looks like a matrix, function call, or unknown
 /// identifier.
+///
+/// Note: `e` is intentionally **not** handled here. It is not a MATLAB built-in
+/// constant; typing `e` at an `input()` prompt would perform a variable lookup in
+/// MATLAB and error if `e` is undefined. Unknown identifiers fall through to the
+/// eval hook or `str2double`, which produce the correct error.
 fn parse_scalar_value(s: &str) -> Option<Value> {
     match s.to_ascii_lowercase().as_str() {
         "true" => return Some(Value::Bool(true)),
@@ -224,7 +229,6 @@ fn parse_scalar_value(s: &str) -> Option<Value> {
         "inf" | "+inf" | "infinity" | "+infinity" => return Some(Value::Num(f64::INFINITY)),
         "-inf" | "-infinity" => return Some(Value::Num(f64::NEG_INFINITY)),
         "nan" => return Some(Value::Num(f64::NAN)),
-        "e" => return Some(Value::Num(std::f64::consts::E)),
         _ => {}
     }
     // Plain numeric literals: integers, decimals, scientific notation, optional sign.
@@ -290,27 +294,38 @@ fn parse_matrix_literal(s: &str) -> Option<Value> {
     }
 
     // All-logical → LogicalArray; any numeric element → Tensor (bools coerced to f64).
+    // `values` is in row-major order (row 0 left-to-right, then row 1, …), but both
+    // Tensor and LogicalArray store data in column-major order (data[r + c*rows]).
+    // Reorder so that column-major index maps to the correct element.
     let all_logical = values.iter().all(|v| matches!(v, Value::Bool(_)));
     if all_logical {
-        let data: Vec<u8> = values
-            .iter()
-            .map(|v| match v {
-                Value::Bool(b) => u8::from(*b),
-                _ => unreachable!(),
-            })
-            .collect();
+        let mut data: Vec<u8> = vec![0u8; nrows * ncols];
+        for r in 0..nrows {
+            for c in 0..ncols {
+                let row_major_idx = r * ncols + c;
+                let col_major_idx = r + c * nrows;
+                data[col_major_idx] = match &values[row_major_idx] {
+                    Value::Bool(b) => u8::from(*b),
+                    _ => unreachable!(),
+                };
+            }
+        }
         LogicalArray::new(data, vec![nrows, ncols])
             .ok()
             .map(Value::LogicalArray)
     } else {
-        let data: Vec<f64> = values
-            .iter()
-            .map(|v| match v {
-                Value::Num(f) => *f,
-                Value::Bool(b) => f64::from(u8::from(*b)),
-                _ => unreachable!(),
-            })
-            .collect();
+        let mut data: Vec<f64> = vec![0f64; nrows * ncols];
+        for r in 0..nrows {
+            for c in 0..ncols {
+                let row_major_idx = r * ncols + c;
+                let col_major_idx = r + c * nrows;
+                data[col_major_idx] = match &values[row_major_idx] {
+                    Value::Num(f) => *f,
+                    Value::Bool(b) => f64::from(u8::from(*b)),
+                    _ => unreachable!(),
+                };
+            }
+        }
         Tensor::new_2d(data, nrows, ncols).ok().map(Value::Tensor)
     }
 }
@@ -372,6 +387,23 @@ pub(crate) mod tests {
         push_queued_response(Ok(InteractionResponse::Line("pi".into())));
         let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
         assert_eq!(value, Value::Num(std::f64::consts::PI));
+    }
+
+    /// `e` is not a MATLAB built-in constant. The fast-path parser must not map
+    /// it to Euler's number; it should fall through so the eval hook or
+    /// `str2double` can handle it (which will NaN or error on an unknown identifier).
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn bare_e_is_not_eulers_number() {
+        assert_eq!(parse_scalar_value("e"), None);
+        assert_eq!(parse_scalar_value("E"), None);
+    }
+
+    /// `[1 e 3]` must not silently produce `[1.0, 2.718…, 3.0]`.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn matrix_with_bare_e_does_not_parse() {
+        assert_eq!(parse_matrix_literal("[1 e 3]"), None);
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -453,6 +485,44 @@ pub(crate) mod tests {
                 assert_eq!(t.data, vec![1.0, 2.0]);
             }
             other => panic!("expected Tensor, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn matrix_2x2_column_major_layout() {
+        // [1 2; 3 4] → get2(r,c) must return element at row r, col c, not the transpose.
+        // Column-major storage: data = [1, 3, 2, 4] (not the row-major [1, 2, 3, 4]).
+        push_queued_response(Ok(InteractionResponse::Line("[1 2; 3 4]".into())));
+        let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
+        match value {
+            Value::Tensor(t) => {
+                assert_eq!(t.rows, 2);
+                assert_eq!(t.cols, 2);
+                assert_eq!(t.get2(0, 0).unwrap(), 1.0, "(0,0) should be 1");
+                assert_eq!(t.get2(0, 1).unwrap(), 2.0, "(0,1) should be 2");
+                assert_eq!(t.get2(1, 0).unwrap(), 3.0, "(1,0) should be 3");
+                assert_eq!(t.get2(1, 1).unwrap(), 4.0, "(1,1) should be 4");
+            }
+            other => panic!("expected 2×2 tensor, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn logical_matrix_2x2_column_major_layout() {
+        // [true false; false true] → column-major data = [1, 0, 0, 1].
+        push_queued_response(Ok(InteractionResponse::Line(
+            "[true false; false true]".into(),
+        )));
+        let value = futures::executor::block_on(input_builtin(vec![])).expect("input");
+        match value {
+            Value::LogicalArray(la) => {
+                assert_eq!(la.shape, vec![2, 2]);
+                // column-major: col 0 first ([true, false]), then col 1 ([false, true])
+                assert_eq!(la.data, vec![1, 0, 0, 1]);
+            }
+            other => panic!("expected 2×2 LogicalArray, got {other:?}"),
         }
     }
 

--- a/crates/runmat-runtime/src/interaction.rs
+++ b/crates/runmat-runtime/src/interaction.rs
@@ -1,4 +1,5 @@
 use once_cell::sync::OnceCell;
+use runmat_builtins::Value;
 use runmat_thread_local::runmat_thread_local;
 use std::cell::RefCell;
 use std::future::Future;
@@ -230,3 +231,51 @@ pub fn push_queued_response(response: Result<InteractionResponse, String>) {
 }
 
 // NOTE: The old suspend/resume control flow has been removed.
+
+// ---------------------------------------------------------------------------
+// Eval hook – lets runmat-core install a stateless expression evaluator so
+// that `input()` can parse numeric responses through the full MATLAB pipeline
+// instead of falling back to `str2double` (which cannot handle matrix literals,
+// named constants like `pi`, arithmetic, etc.).
+// ---------------------------------------------------------------------------
+
+/// Future returned by the eval hook.
+pub type EvalHookFuture = Pin<Box<dyn Future<Output = Result<Value, RuntimeError>> + 'static>>;
+
+/// Function signature for the eval hook.
+pub type EvalHookFn = dyn Fn(String) -> EvalHookFuture + Send + Sync;
+
+static EVAL_HOOK: OnceCell<RwLock<Option<Arc<EvalHookFn>>>> = OnceCell::new();
+
+fn eval_hook_slot() -> &'static RwLock<Option<Arc<EvalHookFn>>> {
+    EVAL_HOOK.get_or_init(|| RwLock::new(None))
+}
+
+/// RAII guard that restores the previous eval hook on drop.
+pub struct EvalHookGuard {
+    previous: Option<Arc<EvalHookFn>>,
+}
+
+impl Drop for EvalHookGuard {
+    fn drop(&mut self) {
+        let mut slot = eval_hook_slot()
+            .write()
+            .unwrap_or_else(|_| panic!("interaction eval hook lock poisoned"));
+        *slot = self.previous.take();
+    }
+}
+
+/// Replace the global eval hook for the duration of the returned guard's
+/// lifetime. Mirrors the pattern used by `replace_async_handler`.
+pub fn replace_eval_hook(hook: Option<Arc<EvalHookFn>>) -> EvalHookGuard {
+    let mut slot = eval_hook_slot()
+        .write()
+        .unwrap_or_else(|_| panic!("interaction eval hook lock poisoned"));
+    let previous = std::mem::replace(&mut *slot, hook);
+    EvalHookGuard { previous }
+}
+
+/// Return the currently installed eval hook, if any.
+pub fn current_eval_hook() -> Option<Arc<EvalHookFn>> {
+    eval_hook_slot().read().ok().and_then(|slot| slot.clone())
+}

--- a/crates/runmat-wasm/src/lib.rs
+++ b/crates/runmat-wasm/src/lib.rs
@@ -589,6 +589,13 @@ impl RunMatWasm {
         }
         let mut slot = self.session.borrow_mut();
         *slot = session;
+        // Re-install the async stdin handler on the new session if one was previously
+        // registered via setInputHandler. The JS function is still stored in JS_STDIN_HANDLER;
+        // we only need to re-wire the Rust-side handler on the freshly-created RunMatSession.
+        let has_stdin_handler = JS_STDIN_HANDLER.with(|s| s.borrow().is_some());
+        if has_stdin_handler {
+            slot.install_async_input_handler(|req| async move { js_input_request(req).await });
+        }
         runtime_reset_plot_state();
         runtime_invalidate_surface_revisions();
         Ok(())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new cross-crate eval-hook mechanism and nested interpreter execution (including native thread spawning with a larger stack), which could impact runtime stability/performance and error behavior around `input()` parsing.
> 
> **Overview**
> `input()` numeric parsing is upgraded to accept MATLAB-style expressions (scalars, named constants, logicals, and simple matrix literals) via new fast-path parsers plus an optional eval hook for full parse→compile→interpret evaluation.
> 
> `runmat-core` now installs a global `interaction` eval hook per execution (WASM awaits directly; native offloads to a dedicated 16MB-stack thread), `runmat-runtime` adds the eval-hook API and expands `input()` tests/logic, and the `e` constant is removed to better match MATLAB semantics.
> 
> On WASM, `resetSession` now reattaches any previously-registered JS async stdin handler to the newly-created session so input handling survives session resets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7518ac68c1ab591233700e89891d8674162f94f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->