### PR TITLE
refactor: update datetime.json by removing unused links and enhance n…

### DIFF
--- a/crates/runmat-runtime/src/builtins/builtins-json/datetime.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/datetime.json
@@ -94,30 +94,6 @@
   ],
   "links": [
     {
-      "label": "year",
-      "url": "./year"
-    },
-    {
-      "label": "month",
-      "url": "./month"
-    },
-    {
-      "label": "day",
-      "url": "./day"
-    },
-    {
-      "label": "hour",
-      "url": "./hour"
-    },
-    {
-      "label": "minute",
-      "url": "./minute"
-    },
-    {
-      "label": "second",
-      "url": "./second"
-    },
-    {
       "label": "string",
       "url": "./string"
     },

--- a/website/content/resources/guides/what-is-matlab.md
+++ b/website/content/resources/guides/what-is-matlab.md
@@ -192,7 +192,7 @@ RunMat’s strategy (by design) is:
 - Treat “toolbox breadth” as **packages** (rather than baking everything into the core).
 - Focus on **performance and portability**, especially for array-heavy numeric workloads.
 
-As an open source project, RunMat’s framing is discussed explicitly in [Design Philosophy](../DESIGN_PHILOSOPHY.md).
+As an open source project, RunMat’s framing is discussed explicitly in [Design Philosophy](/docs/design-philosophy).
 
 ---
 

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -62,6 +62,133 @@ const nextConfig: NextConfig = {
         destination: '/docs/matlab-function-reference',
         permanent: true,
       },
+
+      // Privacy -> Terms
+      {
+        source: '/privacy',
+        destination: '/docs/terms',
+        permanent: true,
+      },
+
+      // Raw .md file URLs -> correct doc routes
+      {
+        source: '/CLI.md',
+        destination: '/docs/cli',
+        permanent: true,
+      },
+      {
+        source: '/LANGUAGE_COVERAGE.md',
+        destination: '/docs/language-coverage',
+        permanent: true,
+      },
+      {
+        source: '/DESIGN_PHILOSOPHY.md',
+        destination: '/docs/design-philosophy',
+        permanent: true,
+      },
+      {
+        source: '/INTRODUCTION_TO_RUNMAT_GPU.md',
+        destination: '/docs/accelerate/fusion-intro',
+        permanent: true,
+      },
+      {
+        source: '/docs/CLI.md',
+        destination: '/docs/cli',
+        permanent: true,
+      },
+      {
+        source: '/docs/LIBRARY.md',
+        destination: '/docs/library',
+        permanent: true,
+      },
+      {
+        source: '/docs/LANGUAGE_COVERAGE.md',
+        destination: '/docs/language-coverage',
+        permanent: true,
+      },
+      {
+        source: '/docs/INTRODUCTION_TO_RUNMAT_GPU.md',
+        destination: '/docs/accelerate/fusion-intro',
+        permanent: true,
+      },
+      {
+        source: '/resources/DESIGN_PHILOSOPHY.md',
+        destination: '/docs/design-philosophy',
+        permanent: true,
+      },
+
+      // Old acceleration prefix -> correct routes
+      {
+        source: '/docs/acceleration/gpu/gpuArray',
+        destination: '/docs/reference/builtins/gpuarray',
+        permanent: true,
+      },
+      {
+        source: '/docs/acceleration/gpu/gather',
+        destination: '/docs/reference/builtins/gather',
+        permanent: true,
+      },
+
+      // Wrong accelerate sub-paths
+      {
+        source: '/docs/accelerate/gpu-residency',
+        destination: '/docs/accelerate/gpu-behavior',
+        permanent: true,
+      },
+      {
+        source: '/docs/accelerate/how-it-works',
+        destination: '/docs/how-it-works',
+        permanent: true,
+      },
+
+      // Old category-based reference paths -> flat builtins path
+      {
+        source: '/docs/reference/regex/:slug',
+        destination: '/docs/reference/builtins/:slug',
+        permanent: true,
+      },
+      {
+        source: '/docs/reference/trigonometry/:slug',
+        destination: '/docs/reference/builtins/:slug',
+        permanent: true,
+      },
+      {
+        source: '/docs/reference/introspection/:slug',
+        destination: '/docs/reference/builtins/:slug',
+        permanent: true,
+      },
+      {
+        source: '/docs/reference/diagnostics/:slug',
+        destination: '/docs/reference/builtins/:slug',
+        permanent: true,
+      },
+      {
+        source: '/docs/reference/core/:slug',
+        destination: '/docs/reference/builtins/:slug',
+        permanent: true,
+      },
+      {
+        source: '/docs/search/:slug',
+        destination: '/docs/reference/builtins/:slug',
+        permanent: true,
+      },
+
+      // Exact-match redirects for multi-segment old paths
+      {
+        source: '/docs/io/filetext/fread',
+        destination: '/docs/reference/builtins/fread',
+        permanent: true,
+      },
+      {
+        source: '/strings/core/strlength',
+        destination: '/docs/reference/builtins/strlength',
+        permanent: true,
+      },
+      {
+        source: '/builtins/io/repl_fs/cd',
+        destination: '/docs/reference/builtins/cd',
+        permanent: true,
+      },
     ];
   },
 };

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -63,11 +63,11 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
 
-      // Privacy -> Terms
+      // Privacy — no dedicated page yet; temporary redirect until one is created
       {
         source: '/privacy',
         destination: '/docs/terms',
-        permanent: true,
+        permanent: false,
       },
 
       // Raw .md file URLs -> correct doc routes


### PR DESCRIPTION
…ext.config.ts with multiple redirect rules for improved documentation navigation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content/SEO-only changes (docs JSON + Next.js redirects) with no runtime or data-handling impact; main risk is misconfigured redirects causing unexpected navigation loops or 404s.
> 
> **Overview**
> **Documentation navigation cleanup.** Removes unused component-function links (`year`, `month`, etc.) from the `datetime` builtin JSON doc, leaving only the remaining relevant cross-links.
> 
> **Fixes and expands doc routing.** Updates the “What is MATLAB” guide to link to the new `/docs/design-philosophy` route, and extends `next.config.ts` with many redirects (including temporary `/privacy` -> `/docs/terms`, raw `.md` URL redirects, old acceleration paths, and old categorized reference paths) to prevent broken links and normalize docs URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d345b8c60b58e95d9a0ef30baca8187f8213ae2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->