### PR TITLE
Enhance JSON definitions for plotting builtins with additional FAQs, …

### DIFF
--- a/crates/runmat-runtime/src/builtins/builtins-json/area.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/area.json
@@ -10,6 +10,7 @@
     "cumulative area visualization"
   ],
   "summary": "Create filled area plots for cumulative totals, stacked series, and MATLAB `area` workflows.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-area-stacked-energy-mix.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -55,15 +56,68 @@
     {
       "description": "Change the baseline and label the series through the handle",
       "input": "x = 0:0.2:2;\nh = area(x, sin(x) + 2);\nset(h, 'BaseValue', 1, 'DisplayName', 'offset area');\nlegend;"
+    },
+    {
+      "description": "Stacked energy mix",
+      "input": "years = 2018:2025;\nsolar   = [5  8  12 18 25 33 42 50];\nwind    = [10 14 18 22 28 32 36 40];\nhydro   = [30 30 29 28 27 27 26 26];\nmix = [solar; wind; hydro]';\n\narea(years, mix);\ntitle('Energy Generation Mix');\nxlabel('Year');\nylabel('TWh');\nlegend('Solar', 'Wind', 'Hydro');\ngrid on;",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-area-stacked-energy-mix.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How do I create a stacked area chart?",
+      "answer": "Pass a matrix as the y-data. Each column becomes a stacked series, and RunMat accumulates them vertically so the total is visible at the top.\n\n```matlab\nx = 1:6;\nY = [2 3 1; 1 2 2; 3 1 2; 2 2 3; 1 3 1; 2 1 3];\narea(x, Y);\nlegend('A', 'B', 'C');\n```"
+    },
+    {
+      "question": "How do I control the transparency of an area plot?",
+      "answer": "Set `'FaceAlpha'` on the area handle to a value between 0 (fully transparent) and 1 (fully opaque). This is useful when overlaying multiple area series without stacking.\n\n```matlab\narea(x, y1);\nhold on;\nh = area(x, y2);\nset(h, 'FaceAlpha', 0.4);\n```"
+    },
+    {
+      "question": "What's the difference between area and plot?",
+      "answer": "`area` fills the region between the data line and the baseline, giving a visual sense of cumulative magnitude. `plot` just draws the line. Use `area` when the filled region conveys meaning—cumulative totals, part-to-whole breakdowns, or emphasizing the magnitude of a signal relative to a baseline."
     }
   ],
   "links": [
-    { "label": "quiver", "url": "./quiver" },
-    { "label": "bar", "url": "./bar" },
-    { "label": "plot", "url": "./plot" },
-    { "label": "legend", "url": "./legend" },
-    { "label": "get", "url": "./get" },
-    { "label": "set", "url": "./set" }
+    {
+      "label": "quiver",
+      "url": "./quiver"
+    },
+    {
+      "label": "bar",
+      "url": "./bar"
+    },
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "legend",
+      "url": "./legend"
+    },
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/area.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/axis.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/axis.json
@@ -35,11 +35,53 @@
       "input": "subplot(1, 2, 1);\nplot(1:5, [1 4 2 5 3]);\naxis tight;\nsubplot(1, 2, 2);\nplot(1:5, [5 4 3 2 1]);\naxis auto;"
     }
   ],
+  "faqs": [
+    {
+      "question": "How do I get equal aspect ratio so circles look like circles?",
+      "answer": "Call `axis equal` after your plot command. This forces one unit on x to equal one unit on y in screen space. Without it, a circle drawn with `plot(cos(t), sin(t))` will appear as an ellipse if the figure isn't perfectly square.\n\n```matlab\nt = linspace(0, 2*pi, 200);\nplot(cos(t), sin(t));\naxis equal;\n```"
+    },
+    {
+      "question": "How do I set manual axis limits?",
+      "answer": "Pass a four-element vector: `axis([xmin xmax ymin ymax])`. For 3-D plots, use six elements: `axis([xmin xmax ymin ymax zmin zmax])`. This overrides auto-fitting until you call `axis auto` to return to data-driven limits."
+    },
+    {
+      "question": "What does axis tight actually do?",
+      "answer": "`axis tight` fits the axes limits snugly around the plotted data with no padding. Compare to `axis auto`, which may add margin for readability. Use `tight` when you want the data to fill the entire axes area — useful for image-like plots or when whitespace is wasted space."
+    }
+  ],
   "links": [
-    { "label": "grid", "url": "./grid" },
-    { "label": "box", "url": "./box" },
-    { "label": "subplot", "url": "./subplot" },
-    { "label": "plot", "url": "./plot" }
+    {
+      "label": "grid",
+      "url": "./grid"
+    },
+    {
+      "label": "box",
+      "url": "./box"
+    },
+    {
+      "label": "subplot",
+      "url": "./subplot"
+    },
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/cmds.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/bar.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/bar.json
@@ -10,6 +10,7 @@
     "categorical comparison"
   ],
   "summary": "Create bar charts for categorical comparisons, grouped series, stacked values, and MATLAB `bar` workflows.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-bar-grouped-category.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -51,14 +52,64 @@
     {
       "description": "Style a bar object and label it for the legend",
       "input": "h = bar([2 4 1 5]);\nset(h, 'FaceColor', 'g', 'DisplayName', 'counts');\nlegend;"
+    },
+    {
+      "description": "Grouped category comparison",
+      "input": "categories = {'Q1', 'Q2', 'Q3', 'Q4'};\nrevenue = [42 51 63 58; 38 45 52 61; 29 34 48 55];\n\nbar(revenue');\ntitle('Quarterly Revenue by Region');\nxlabel('Quarter');\nylabel('Revenue ($M)');\nlegend('North', 'South', 'West');\ngrid on;",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-bar-grouped-category.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How do I create grouped vs stacked bar charts?",
+      "answer": "Pass a matrix to `bar`. By default, each row becomes a group with side-by-side bars (one per column). To stack them instead, pass `'stacked'` as the second argument.\n\n```matlab\nY = [3 5 2; 4 6 1; 5 4 3];\nbar(Y);            % grouped (default)\nbar(Y, 'stacked'); % stacked\n```"
+    },
+    {
+      "question": "Can I make horizontal bar charts?",
+      "answer": "Use `barh` instead of `bar`. It takes the same inputs but draws bars horizontally. The y-axis becomes the category axis and the x-axis shows values.\n\n```matlab\nbarh([3 5 2 9]);\n```"
+    },
+    {
+      "question": "How do I set custom category labels on the x-axis?",
+      "answer": "After calling `bar`, use `set(gca, 'XTickLabel', ...)` to replace the default numeric labels with strings.\n\n```matlab\nbar([4 7 2]);\nset(gca, 'XTickLabel', {'Q1', 'Q2', 'Q3'});\n```\n\nThe label count should match the number of bar groups."
     }
   ],
   "links": [
-    { "label": "hist", "url": "./hist" },
-    { "label": "histogram", "url": "./histogram" },
-    { "label": "pie", "url": "./pie" },
-    { "label": "legend", "url": "./legend" },
-    { "label": "set", "url": "./set" }
+    {
+      "label": "hist",
+      "url": "./hist"
+    },
+    {
+      "label": "histogram",
+      "url": "./histogram"
+    },
+    {
+      "label": "pie",
+      "url": "./pie"
+    },
+    {
+      "label": "legend",
+      "url": "./legend"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/bar.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/box.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/box.json
@@ -30,10 +30,45 @@
       "input": "subplot(1, 2, 1);\nplot(1:5, 1:5);\nbox off;\nsubplot(1, 2, 2);\nplot(1:5, [5 4 3 2 1]);\nbox on;"
     }
   ],
+  "faqs": [
+    {
+      "question": "When should I turn the box off?",
+      "answer": "Turn `box off` for a cleaner, more modern chart style — especially for presentations or publications where the top and right frame edges add visual noise without carrying data. Many style guides prefer open axes (left + bottom only) for scatter plots and line charts."
+    },
+    {
+      "question": "Does box interact with grid or axis settings?",
+      "answer": "`box`, `grid`, and `axis` are independent axes-state commands. Turning `box off` removes the outer frame but doesn't touch grid lines or axis limits. You can combine them freely: `box off; grid on; axis tight;` is a common clean-chart recipe."
+    }
+  ],
   "links": [
-    { "label": "axis", "url": "./axis" },
-    { "label": "grid", "url": "./grid" },
-    { "label": "subplot", "url": "./subplot" }
+    {
+      "label": "axis",
+      "url": "./axis"
+    },
+    {
+      "label": "grid",
+      "url": "./grid"
+    },
+    {
+      "label": "subplot",
+      "url": "./subplot"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/cmds.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/colorbar.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/colorbar.json
@@ -30,11 +30,53 @@
       "input": "[X, Y] = meshgrid(linspace(-3, 3, 40), linspace(-3, 3, 40));\nZ = sin(X) .* cos(Y);\nsubplot(1, 2, 1);\ncontourf(X, Y, Z);\ncolorbar on;\nsubplot(1, 2, 2);\nsurf(X, Y, Z);\ncolorbar off;"
     }
   ],
+  "faqs": [
+    {
+      "question": "How do I add a label to the colorbar?",
+      "answer": "Use `ylabel` on the colorbar handle, or label the axes directly. In practice, the colorbar inherits its scale from the data range of the parent plot, and you annotate it through standard label commands on the axes.\n\n```matlab\nimagesc(peaks(50));\ncolorbar on;\nylabel('Intensity');\n```"
+    },
+    {
+      "question": "Can I limit the colorbar range without clipping the data?",
+      "answer": "Set `caxis([cmin cmax])` (or `clim([cmin cmax])`) on the axes to control the color mapping range. Values outside that range get clamped to the endpoint colors, but the underlying data stays intact."
+    },
+    {
+      "question": "Does the colorbar track across subplots automatically?",
+      "answer": "No. Colorbar state is subplot-local, so each axes manages its own colorbar independently. You need to call `colorbar on` in each subplot where you want one visible."
+    }
+  ],
   "links": [
-    { "label": "colormap", "url": "./colormap" },
-    { "label": "imagesc", "url": "./imagesc" },
-    { "label": "surf", "url": "./surf" },
-    { "label": "contourf", "url": "./contourf" }
+    {
+      "label": "colormap",
+      "url": "./colormap"
+    },
+    {
+      "label": "imagesc",
+      "url": "./imagesc"
+    },
+    {
+      "label": "surf",
+      "url": "./surf"
+    },
+    {
+      "label": "contourf",
+      "url": "./contourf"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/cmds.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/colormap.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/colormap.json
@@ -30,12 +30,57 @@
       "input": "[X, Y] = meshgrid(linspace(-3, 3, 40), linspace(-3, 3, 40));\nZ = sin(X) .* cos(Y);\nsubplot(1, 2, 1);\nsurf(X, Y, Z);\ncolormap('parula');\nsubplot(1, 2, 2);\ncontourf(X, Y, Z);\ncolormap('turbo');"
     }
   ],
+  "faqs": [
+    {
+      "question": "What colormaps are available?",
+      "answer": "RunMat ships with: `parula`, `viridis`, `plasma`, `inferno`, `magma`, `turbo`, `jet`, `hot`, `cool`, `spring`, `summer`, `autumn`, `winter`, `gray`, `bone`, `copper`, `pink`, and `lines`. Unknown names raise an error — no silent fallback."
+    },
+    {
+      "question": "Which colormaps are perceptually uniform?",
+      "answer": "`viridis`, `plasma`, `inferno`, and `magma` are designed so that equal steps in data value produce equal perceptual changes in color. Use these for quantitative data where you want the visual contrast to faithfully represent magnitude differences. `parula` is also a good default. Avoid `jet` for quantitative work — it introduces false banding."
+    },
+    {
+      "question": "Can I define a custom colormap?",
+      "answer": "Not yet — `colormap` currently accepts named strings only. Custom N×3 RGB matrices are on the roadmap. For now, pick the closest built-in option or combine subplot-level colormaps to get variety across panels."
+    }
+  ],
   "links": [
-    { "label": "colorbar", "url": "./colorbar" },
-    { "label": "imagesc", "url": "./imagesc" },
-    { "label": "image", "url": "./image" },
-    { "label": "surf", "url": "./surf" },
-    { "label": "contourf", "url": "./contourf" }
+    {
+      "label": "colorbar",
+      "url": "./colorbar"
+    },
+    {
+      "label": "imagesc",
+      "url": "./imagesc"
+    },
+    {
+      "label": "image",
+      "url": "./image"
+    },
+    {
+      "label": "surf",
+      "url": "./surf"
+    },
+    {
+      "label": "contourf",
+      "url": "./contourf"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/cmds.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/contour.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/contour.json
@@ -10,6 +10,7 @@
     "topographic lines"
   ],
   "summary": "Create contour line plots for level sets, iso-lines, and MATLAB `contour` workflows.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-contour-thermal-field-level-sets.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -56,14 +57,64 @@
       "description": "Inspect the returned contour handle",
       "input": "[X, Y] = meshgrid(1:20, 1:20);\nZ = X + Y;\nh = contour(X, Y, Z);\nget(h, 'Type')",
       "output": "ans =\n    'contour'"
+    },
+    {
+      "description": "Temperature-style level sets",
+      "input": "[X, Y] = meshgrid(linspace(-3, 3, 120), linspace(-3, 3, 120));\nZ = 2*exp(-((X-1).^2 + Y.^2)) + 1.5*exp(-((X+1.5).^2 + (Y-1).^2)) - exp(-(X.^2 + (Y+1.5).^2));\n\ncontour(X, Y, Z, 20);\ncolormap('turbo');\ncolorbar;\ntitle('Thermal Field — Level Sets');\nxlabel('x (m)');\nylabel('y (m)');\naxis equal;",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-contour-thermal-field-level-sets.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How do I set specific contour levels?",
+      "answer": "Pass a vector of values as the fourth argument. Each value becomes one contour line.\n\n```matlab\ncontour(X, Y, Z, [0.1 0.3 0.5 0.7 0.9]);\n```\n\nIf you pass a scalar instead, it's interpreted as the number of levels (e.g., `contour(X, Y, Z, 20)` draws 20 automatically spaced levels)."
+    },
+    {
+      "question": "Can I add labels to the contour lines?",
+      "answer": "Use `clabel` after `contour` to annotate the lines with their level values. Pass the contour handle to `clabel` so it knows which plot to label.\n\n```matlab\n[C, h] = contour(X, Y, Z);\nclabel(C, h);\n```"
+    },
+    {
+      "question": "What's the difference between contour and contourf?",
+      "answer": "`contour` draws line-only iso-curves — the regions between lines are transparent. `contourf` fills those regions with colors from the active colormap. Use `contour` when you want to overlay on other plots or keep the background visible, and `contourf` when the filled color bands are the primary visualization."
     }
   ],
   "links": [
-    { "label": "contourf", "url": "./contourf" },
-    { "label": "surfc", "url": "./surfc" },
-    { "label": "meshc", "url": "./meshc" },
-    { "label": "colorbar", "url": "./colorbar" },
-    { "label": "colormap", "url": "./colormap" }
+    {
+      "label": "contourf",
+      "url": "./contourf"
+    },
+    {
+      "label": "surfc",
+      "url": "./surfc"
+    },
+    {
+      "label": "meshc",
+      "url": "./meshc"
+    },
+    {
+      "label": "colorbar",
+      "url": "./colorbar"
+    },
+    {
+      "label": "colormap",
+      "url": "./colormap"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/contour.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/contourf.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/contourf.json
@@ -9,6 +9,7 @@
     "matlab contourf"
   ],
   "summary": "Create filled contour plots for level regions, scalar fields, and MATLAB `contourf` workflows.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-contourf-interference-pattern.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -50,14 +51,64 @@
       "description": "Inspect the returned contour-fill handle",
       "input": "[X, Y] = meshgrid(1:20, 1:20);\nZ = X - Y;\nh = contourf(X, Y, Z);\nget(h, 'Type')",
       "output": "ans =\n    'contour'"
+    },
+    {
+      "description": "Filled scalar field with explicit levels",
+      "input": "[X, Y] = meshgrid(linspace(-3, 3, 150), linspace(-3, 3, 150));\nZ = sin(X) .* cos(Y) + 0.5*sin(2*X + Y);\n\ncontourf(X, Y, Z, 25);\ncolormap('turbo');\ncolorbar;\ntitle('Interference Pattern — Filled Contours');\nxlabel('x');\nylabel('y');\naxis equal;",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-contourf-interference-pattern.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What's the difference between contourf and contour?",
+      "answer": "`contourf` fills the regions between contour levels with solid colors from the colormap. `contour` draws only the boundary lines. If you're building a heatmap-style visualization where color bands carry meaning, `contourf` is the right choice. If you just need iso-lines overlaid on something else, use `contour`."
+    },
+    {
+      "question": "How does the colormap interact with contourf?",
+      "answer": "Each filled region maps to a range in the active colormap based on its contour level. Calling `colormap('hot')` after `contourf` recolors all regions immediately. Pair it with `colorbar` to show the value-to-color mapping.\n\n```matlab\ncontourf(X, Y, Z, 15);\ncolormap('hot');\ncolorbar;\n```"
+    },
+    {
+      "question": "How do I control the number of filled levels?",
+      "answer": "Pass an integer as the fourth argument to set the level count: `contourf(X, Y, Z, 20)` creates 20 levels. For exact control, pass a vector of level values instead: `contourf(X, Y, Z, [-1 -0.5 0 0.5 1])`. More levels give smoother color transitions but add rendering cost on large grids."
     }
   ],
   "links": [
-    { "label": "contour", "url": "./contour" },
-    { "label": "colorbar", "url": "./colorbar" },
-    { "label": "colormap", "url": "./colormap" },
-    { "label": "surfc", "url": "./surfc" },
-    { "label": "meshc", "url": "./meshc" }
+    {
+      "label": "contour",
+      "url": "./contour"
+    },
+    {
+      "label": "colorbar",
+      "url": "./colorbar"
+    },
+    {
+      "label": "colormap",
+      "url": "./colormap"
+    },
+    {
+      "label": "surfc",
+      "url": "./surfc"
+    },
+    {
+      "label": "meshc",
+      "url": "./meshc"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/contourf.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/errorbar.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/errorbar.json
@@ -9,6 +9,7 @@
     "matlab errorbar"
   ],
   "summary": "Plot data with symmetric or asymmetric error bars for uncertainty, intervals, and MATLAB `errorbar` workflows.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-error-measurements-intervals.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -50,14 +51,64 @@
     {
       "description": "Style an error-bar object and label it for the legend",
       "input": "x = 1:5;\ny = [1 2 1.5 3 2.5];\nh = errorbar(x, y, 0.2*ones(size(x)), 0.2*ones(size(x)));\nset(h, 'LineWidth', 2, 'DisplayName', 'measurement');\nlegend;"
+    },
+    {
+      "description": "Measurements with confidence intervals",
+      "input": "x = 1:8;\ny = [2.1 3.4 4.2 5.8 5.5 6.1 7.3 8.0];\nneg = [0.3 0.4 0.2 0.5 0.6 0.3 0.4 0.3];\npos = [0.4 0.3 0.3 0.6 0.5 0.4 0.5 0.4];\n\nerrorbar(x, y, neg, pos, 'o-', 'LineWidth', 1.5);\ntitle('Tensile Strength vs. Sample');\nxlabel('Sample #');\nylabel('Strength (MPa)');\ngrid on;",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-error-measurements-intervals.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How do I plot asymmetric error bars?",
+      "answer": "Pass separate lower and upper error vectors. For vertical-only asymmetric bars, use `errorbar(x, y, neg, pos)` where `neg` is the downward extent and `pos` is the upward extent.\n\n```matlab\nx = 1:5;\ny = [2 3 2.5 4 3.5];\nneg = [0.1 0.2 0.15 0.3 0.1];\npos = [0.3 0.4 0.2 0.5 0.25];\nerrorbar(x, y, neg, pos);\n```"
+    },
+    {
+      "question": "Can I add horizontal error bars?",
+      "answer": "Yes. Use the six-argument form `errorbar(x, y, yneg, ypos, xneg, xpos)` to get both vertical and horizontal bars. If you only want horizontal bars, set the vertical error vectors to zero.\n\n```matlab\nx = 1:4; y = [3 4 2 5];\nerrorbar(x, y, zeros(size(x)), zeros(size(x)), 0.2*ones(size(x)), 0.3*ones(size(x)));\n```"
+    },
+    {
+      "question": "Can I combine error bars with a line or scatter plot?",
+      "answer": "Yes—`errorbar` already draws a line through the data points by default. To overlay error bars on a separate plot, call `hold on` first. The error bar handle supports the same `set` properties as line handles, so you can match colors and widths.\n\n```matlab\nplot(x, y, 'b-', 'LineWidth', 2);\nhold on;\nerrorbar(x, y, err, err, 'LineStyle', 'none', 'Color', 'b');\n```"
     }
   ],
   "links": [
-    { "label": "stem", "url": "./stem" },
-    { "label": "plot", "url": "./plot" },
-    { "label": "legend", "url": "./legend" },
-    { "label": "get", "url": "./get" },
-    { "label": "set", "url": "./set" }
+    {
+      "label": "stem",
+      "url": "./stem"
+    },
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "legend",
+      "url": "./legend"
+    },
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/errorbar.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/get.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/get.json
@@ -36,11 +36,53 @@
       "input": "plot(1:5, 1:5);\nlg = legend('series');\nget(lg, 'Orientation')"
     }
   ],
+  "faqs": [
+    {
+      "question": "How do I see all available properties on a handle?",
+      "answer": "Call `get(h)` with no property name. It returns a struct containing every known property for that handle type. This is the fastest way to discover what's queryable on a line, axes, legend, or text object."
+    },
+    {
+      "question": "Can I query properties on axes handles, not just plot objects?",
+      "answer": "Yes. `get(gca, 'XScale')` reads the x-axis scale mode, `get(gca, 'View')` reads the camera angle, and so on. Axes handles, legend handles, text handles, and plot-child handles all go through the same `get` interface."
+    },
+    {
+      "question": "What happens if I query a property that doesn't exist?",
+      "answer": "RunMat raises a plotting error rather than returning empty or silently succeeding. If you're unsure whether a property exists, call `get(h)` first to inspect the full property struct."
+    }
+  ],
   "links": [
-    { "label": "set", "url": "./set" },
-    { "label": "legend", "url": "./legend" },
-    { "label": "subplot", "url": "./subplot" },
-    { "label": "plot", "url": "./plot" }
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "legend",
+      "url": "./legend"
+    },
+    {
+      "label": "subplot",
+      "url": "./subplot"
+    },
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/get.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/grid.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/grid.json
@@ -30,10 +30,49 @@
       "input": "subplot(1, 2, 1);\nplot(1:5, 1:5);\ngrid off;\nsubplot(1, 2, 2);\nplot(1:5, [5 4 3 2 1]);\ngrid on;"
     }
   ],
+  "faqs": [
+    {
+      "question": "Does RunMat support minor grid lines?",
+      "answer": "Not yet — `grid on` enables major grid lines only. Minor grid support (the MATLAB `grid minor` form) is planned. For now, you get the primary tick grid, which covers most use cases."
+    },
+    {
+      "question": "Can I style the grid line color or width?",
+      "answer": "Grid styling is tied to axes properties. You can adjust the grid appearance through the axes handle with `set(gca, 'GridColor', [0.5 0.5 0.5])` and related properties when the axes property path supports them. Check `get(gca)` to see what's currently exposed."
+    },
+    {
+      "question": "Does grid state carry across subplots?",
+      "answer": "No. Grid visibility is subplot-local. Calling `grid on` in one panel doesn't turn it on in others — you need to enable it explicitly in each subplot where you want grid lines."
+    }
+  ],
   "links": [
-    { "label": "axis", "url": "./axis" },
-    { "label": "box", "url": "./box" },
-    { "label": "subplot", "url": "./subplot" }
+    {
+      "label": "axis",
+      "url": "./axis"
+    },
+    {
+      "label": "box",
+      "url": "./box"
+    },
+    {
+      "label": "subplot",
+      "url": "./subplot"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/cmds.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/hist.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/hist.json
@@ -54,10 +54,45 @@
       "output": "% Use histogram(...) instead when you want bin-edge semantics and an object handle"
     }
   ],
+  "faqs": [
+    {
+      "question": "What's the actual difference between hist and histogram?",
+      "answer": "The critical difference is how the second argument is interpreted. `hist(data, v)` treats `v` as **bin centers**. `histogram(data, 'BinEdges', v)` treats `v` as **bin edges**. Beyond that, `histogram` returns a handle object with properties you can query via `get`, while `hist` is a fire-and-forget plotting command."
+    },
+    {
+      "question": "When should I use hist instead of histogram?",
+      "answer": "Use `hist` when you're porting legacy MATLAB code that relies on center-based binning or when you want a quick distribution plot without needing a handle object. For anything new—especially if you need normalization modes, bin-edge control, or programmatic access to bin counts—use `histogram` instead."
+    }
+  ],
   "links": [
-    { "label": "histogram", "url": "./histogram" },
-    { "label": "bar", "url": "./bar" },
-    { "label": "pie", "url": "./pie" }
+    {
+      "label": "histogram",
+      "url": "./histogram"
+    },
+    {
+      "label": "bar",
+      "url": "./bar"
+    },
+    {
+      "label": "pie",
+      "url": "./pie"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/hist.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/histogram.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/histogram.json
@@ -10,6 +10,7 @@
     "distribution analysis"
   ],
   "summary": "Create histogram objects with bin-edge semantics, normalization controls, and MATLAB `histogram` workflows.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-histogram-plot-overlaid-distributions.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -52,13 +53,60 @@
       "description": "Apply normalization through histogram semantics",
       "input": "data = randn(1, 500);\nh = histogram(data, 'Normalization', 'probability');\nget(h, 'Normalization')",
       "output": "ans =\n    'probability'"
+    },
+    {
+      "description": "Overlaid distributions",
+      "input": "a = 2 + 1.2*randn(1, 5000);\nb = 4 + 0.8*randn(1, 5000);\n\nh1 = histogram(a, 'BinEdges', -2:0.25:8, 'Normalization', 'probability');\nset(h1, 'DisplayName', 'Process A');\nhold on;\nh2 = histogram(b, 'BinEdges', -2:0.25:8, 'Normalization', 'probability');\nset(h2, 'DisplayName', 'Process B');\nhold off;\n\ntitle('Distribution Comparison');\nxlabel('Measurement');\nylabel('Probability');\nlegend;\ngrid on;",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-histogram-plot-overlaid-distributions.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How do I set a specific number of bins?",
+      "answer": "Pass the bin count as a second positional argument or use the `'NumBins'` name-value pair.\n\n```matlab\ndata = randn(1, 1000);\nhistogram(data, 30);                    % 30 bins\nhistogram(data, 'NumBins', 50);         % 50 bins\nhistogram(data, 'BinEdges', -3:0.1:3); % exact edges\n```\n\nExplicit `BinEdges` gives you full control over where each bin starts and ends."
+    },
+    {
+      "question": "How do I overlay two distributions on the same axes?",
+      "answer": "Use `hold on` between `histogram` calls and set `'Normalization'` to `'probability'` so both distributions are on a comparable scale.\n\n```matlab\nhistogram(randn(1,1000), 'Normalization', 'probability');\nhold on;\nhistogram(randn(1,1000) + 2, 'Normalization', 'probability');\nlegend('dist A', 'dist B');\n```"
+    },
+    {
+      "question": "What's the difference between histogram and hist?",
+      "answer": "`histogram` is the modern API: it uses bin-edge semantics, returns a handle object you can inspect with `get`/`set`, and supports normalization modes like `'probability'` and `'pdf'`. `hist` is the legacy API that interprets a second vector argument as bin centers. Use `histogram` for new code unless you specifically need center-based binning from a legacy workflow."
     }
   ],
   "links": [
-    { "label": "hist", "url": "./hist" },
-    { "label": "bar", "url": "./bar" },
-    { "label": "get", "url": "./get" },
-    { "label": "set", "url": "./set" }
+    {
+      "label": "hist",
+      "url": "./hist"
+    },
+    {
+      "label": "bar",
+      "url": "./bar"
+    },
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/histogram.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/image.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/image.json
@@ -55,12 +55,57 @@
       "output": "ans =\n    'image'"
     }
   ],
+  "faqs": [
+    {
+      "question": "How do I display RGB data with image?",
+      "answer": "Pass an MxNx3 array where the third dimension holds red, green, and blue channels. Values should be in `[0, 1]` for doubles or `[0, 255]` for uint8.\n\n```matlab\nimg = zeros(100, 100, 3);\nimg(:,:,1) = 1;           % full red\nimg(30:70, 30:70, 2) = 1; % green square\nimage(img);\n```"
+    },
+    {
+      "question": "When should I use image vs imagesc?",
+      "answer": "`image` displays pixel data as-is — either indexed colors through a colormap or direct RGB truecolor. `imagesc` automatically scales a 2-D matrix so its min and max span the full colormap range. If you're showing actual image pixels or pre-indexed data, use `image`. If you're visualizing a matrix of computed values as a heatmap, use `imagesc`."
+    },
+    {
+      "question": "Why does my image appear upside down?",
+      "answer": "By default, `image` sets the y-axis to go from top to bottom (row 1 at the top), which matches matrix indexing. If your coordinate system expects y to increase upward, call `axis xy` after `image` to flip the axis direction. Use `axis ij` to restore the default matrix-style orientation."
+    }
+  ],
   "links": [
-    { "label": "imagesc", "url": "./imagesc" },
-    { "label": "colormap", "url": "./colormap" },
-    { "label": "colorbar", "url": "./colorbar" },
-    { "label": "get", "url": "./get" },
-    { "label": "set", "url": "./set" }
+    {
+      "label": "imagesc",
+      "url": "./imagesc"
+    },
+    {
+      "label": "colormap",
+      "url": "./colormap"
+    },
+    {
+      "label": "colorbar",
+      "url": "./colorbar"
+    },
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/image.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/imagesc.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/imagesc.json
@@ -10,6 +10,7 @@
     "colormap image"
   ],
   "summary": "Display scaled matrix images for heatmaps, colormaps, and MATLAB `imagesc` style visualization.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-imagesc-scaler-field-heatmap.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -51,13 +52,60 @@
     {
       "description": "Use subplot-local color workflows",
       "input": "[X, Y] = meshgrid(linspace(-3, 3, 40), linspace(-3, 3, 40));\nZ = sin(X) .* cos(Y);\nsubplot(1, 2, 1);\nimagesc(Z);\ncolormap('jet');\ncolorbar;\nsubplot(1, 2, 2);\nimagesc(magic(20));\ncolormap('gray');"
+    },
+    {
+      "description": "Dense matrix as a heatmap",
+      "input": "[X, Y] = meshgrid(linspace(-pi, pi, 300), linspace(-pi, pi, 300));\nZ = sin(3*X) .* cos(2*Y) + cos(X.*Y);\n\nimagesc(Z);\ncolormap('turbo');\ncolorbar;\ntitle('Scalar Field Heatmap');\nxlabel('Column');\nylabel('Row');\naxis equal;",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-imagesc-scaler-field-heatmap.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What's the difference between imagesc and image?",
+      "answer": "`imagesc` maps a 2-D matrix through the colormap with automatic scaling — the min value maps to the bottom of the colormap and the max to the top. `image` treats input as direct indexed or truecolor data without automatic scaling. Use `imagesc` for heatmaps and value visualization; use `image` when you have actual image pixel data (RGB arrays or pre-indexed values)."
+    },
+    {
+      "question": "How does colormap scaling work with imagesc?",
+      "answer": "`imagesc` sets the color limits (`caxis`) to `[min(C(:)), max(C(:))]` automatically. Every value in the matrix maps linearly into that range across the active colormap. To override the auto-scaling, call `caxis([lo hi])` after `imagesc`.\n\n```matlab\nimagesc(A);\ncaxis([-1 1]);\ncolorbar;\n```"
+    },
+    {
+      "question": "How do I display a matrix as a heatmap?",
+      "answer": "Pass the matrix directly to `imagesc` and add a colorbar for the legend. Pair with a colormap that suits your data — diverging maps like `'coolwarm'` work well for data centered around zero, sequential maps like `'parula'` for positive-only ranges.\n\n```matlab\nimagesc(myMatrix);\ncolormap('parula');\ncolorbar;\n```"
     }
   ],
   "links": [
-    { "label": "image", "url": "./image" },
-    { "label": "colorbar", "url": "./colorbar" },
-    { "label": "colormap", "url": "./colormap" },
-    { "label": "axis", "url": "./axis" }
+    {
+      "label": "image",
+      "url": "./image"
+    },
+    {
+      "label": "colorbar",
+      "url": "./colorbar"
+    },
+    {
+      "label": "colormap",
+      "url": "./colormap"
+    },
+    {
+      "label": "axis",
+      "url": "./axis"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/imagesc.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/legend.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/legend.json
@@ -36,11 +36,53 @@
       "output": "% Only the left subplot shows a legend"
     }
   ],
+  "faqs": [
+    {
+      "question": "How do I move the legend to a specific corner?",
+      "answer": "Pass the `'Location'` property when creating the legend, or update it afterward with `set`. Standard MATLAB location strings work: `'northeast'`, `'southwest'`, `'northwest'`, `'southeast'`, etc.\n\n```matlab\nlg = legend('a', 'b');\nset(lg, 'Location', 'northwest');\n```"
+    },
+    {
+      "question": "Can I show only some series in the legend?",
+      "answer": "Set `'DisplayName'` only on the series you want labeled, then call `legend` with no arguments. Series without a display name are excluded. Alternatively, pass explicit label strings to `legend` — only the first N plotted objects get entries."
+    },
+    {
+      "question": "Do I need to call legend again after adding more series with hold on?",
+      "answer": "Yes. The legend snapshot is taken when `legend` is called, so new series added after the initial `legend` call won't appear until you call `legend` again. Set display names on all series first, then call `legend` once at the end."
+    }
+  ],
   "links": [
-    { "label": "subplot", "url": "./subplot" },
-    { "label": "get", "url": "./get" },
-    { "label": "set", "url": "./set" },
-    { "label": "plot", "url": "./plot" }
+    {
+      "label": "subplot",
+      "url": "./subplot"
+    },
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/legend.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/loglog.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/loglog.json
@@ -35,11 +35,53 @@
       "output": "% Both axes report 'log'"
     }
   ],
+  "faqs": [
+    {
+      "question": "Why do power-law relationships appear as straight lines on a log-log plot?",
+      "answer": "Taking the log of both sides of `y = a * x^b` gives `log(y) = log(a) + b * log(x)`, which is linear in log-space. The slope of the line equals the exponent `b`, and the y-intercept gives `log(a)`. That's why log-log is the standard way to identify and compare power laws."
+    },
+    {
+      "question": "How is loglog different from semilogx or semilogy?",
+      "answer": "`semilogx` only logs the x-axis (linear y), `semilogy` only logs the y-axis (linear x), and `loglog` logs both. Use `loglog` when both dimensions span orders of magnitude — spectrum plots, scaling benchmarks, fractal dimension analysis."
+    },
+    {
+      "question": "Can I mix loglog with other scale modes in a subplot layout?",
+      "answer": "Yes. Axes scale state is subplot-local, so `loglog` in one panel doesn't affect neighbors.\n\n```matlab\nsubplot(1, 2, 1);\nloglog(x, x.^(-2));\nsubplot(1, 2, 2);\nplot(x, x.^(-2)); % linear axes here\n```"
+    }
+  ],
   "links": [
-    { "label": "plot", "url": "./plot" },
-    { "label": "semilogx", "url": "./semilogx" },
-    { "label": "semilogy", "url": "./semilogy" },
-    { "label": "axis", "url": "./axis" }
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "semilogx",
+      "url": "./semilogx"
+    },
+    {
+      "label": "semilogy",
+      "url": "./semilogy"
+    },
+    {
+      "label": "axis",
+      "url": "./axis"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/loglog.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/mesh.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/mesh.json
@@ -9,6 +9,7 @@
     "3-D grid visualization"
   ],
   "summary": "Create wireframe surface plots for grids, height fields, and MATLAB `mesh` style visualization.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-mesh-hyperbolic-paraboloid.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -50,14 +51,64 @@
       "description": "Inspect the returned surface handle from mesh",
       "input": "[X, Y] = meshgrid(1:20, 1:20);\nZ = X + Y;\nh = mesh(X, Y, Z);\nget(h, 'Type')",
       "output": "ans =\n    'surface'"
+    },
+    {
+      "description": "Saddle surface showing grid structure",
+      "input": "[X, Y] = meshgrid(linspace(-3, 3, 60), linspace(-3, 3, 60));\nZ = X.^2 - Y.^2;\n\nmesh(X, Y, Z);\ncolormap('jet');\ncolorbar;\ntitle('Hyperbolic Paraboloid');\nxlabel('x');\nylabel('y');\nzlabel('z = x^2 - y^2');\nview(40, 30);",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-mesh-hyperbolic-paraboloid.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Can I get a filled surface instead of wireframe?",
+      "answer": "That's what `surf` is for. `mesh` draws only the grid lines with transparent faces, while `surf` fills the faces with colormap-derived colors. If you want the wireframe look but with partial fill, there's no built-in blend — use `surf` with a low alpha or switch to `mesh` and accept the wireframe."
+    },
+    {
+      "question": "How do I combine a mesh with contour lines underneath?",
+      "answer": "Use `meshc` instead of `mesh`. It draws the same wireframe surface but projects contour lines onto the base plane automatically.\n\n```matlab\n[X, Y] = meshgrid(linspace(-2, 2, 50));\nZ = sin(X.^2 + Y.^2);\nmeshc(X, Y, Z);\n```"
+    },
+    {
+      "question": "Can I control transparency on a mesh plot?",
+      "answer": "Mesh plots don't have filled faces to make transparent — the faces are already open. If you need a semi-transparent surface, use `surf` and set the `FaceAlpha` property on the returned handle. The wireframe edges on `mesh` are always fully opaque."
     }
   ],
   "links": [
-    { "label": "surf", "url": "./surf" },
-    { "label": "meshc", "url": "./meshc" },
-    { "label": "view", "url": "./view" },
-    { "label": "zlabel", "url": "./zlabel" },
-    { "label": "colormap", "url": "./colormap" }
+    {
+      "label": "surf",
+      "url": "./surf"
+    },
+    {
+      "label": "meshc",
+      "url": "./meshc"
+    },
+    {
+      "label": "view",
+      "url": "./view"
+    },
+    {
+      "label": "zlabel",
+      "url": "./zlabel"
+    },
+    {
+      "label": "colormap",
+      "url": "./colormap"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/mesh.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/meshc.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/meshc.json
@@ -52,12 +52,57 @@
       "output": "ans =\n    'surface'"
     }
   ],
+  "faqs": [
+    {
+      "question": "Where does the contour overlay appear in a meshc plot?",
+      "answer": "The contour lines are projected onto the base plane beneath the wireframe, at the z-minimum of the axes. This gives you a top-down height map below the 3-D wireframe so you can read both the grid structure and the level sets at the same time."
+    },
+    {
+      "question": "What's the difference between meshc and mesh?",
+      "answer": "`mesh` draws only the wireframe surface. `meshc` draws the same wireframe plus contour lines projected onto the base plane underneath. If you don't need the contour overlay, use `mesh` — it's the same surface rendering with less visual clutter."
+    },
+    {
+      "question": "Should I use meshc or surfc?",
+      "answer": "Both add contour projections to the base plane. The difference is the surface itself: `meshc` uses a wireframe (transparent faces, grid lines only), while `surfc` uses a shaded, filled surface. Pick `meshc` when you want to see through the geometry, and `surfc` when you want a solid surface on top."
+    }
+  ],
   "links": [
-    { "label": "mesh", "url": "./mesh" },
-    { "label": "surfc", "url": "./surfc" },
-    { "label": "contour", "url": "./contour" },
-    { "label": "contourf", "url": "./contourf" },
-    { "label": "view", "url": "./view" }
+    {
+      "label": "mesh",
+      "url": "./mesh"
+    },
+    {
+      "label": "surfc",
+      "url": "./surfc"
+    },
+    {
+      "label": "contour",
+      "url": "./contour"
+    },
+    {
+      "label": "contourf",
+      "url": "./contourf"
+    },
+    {
+      "label": "view",
+      "url": "./view"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/meshc.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/pie.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/pie.json
@@ -9,6 +9,7 @@
     "matlab pie"
   ],
   "summary": "Create pie charts for part-to-whole comparisons, exploded slices, and MATLAB `pie` workflows.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-apie-budget.webp",
   "requires_feature": null,
   "tested": {
     "unit": "builtins::plotting::pie::tests",
@@ -34,12 +35,56 @@
     {
       "description": "Use labels for slice names",
       "input": "values = [5 3 2];\nlabels = {'compute', 'io', 'render'};\npie(values, labels);"
+    },
+    {
+      "description": "Budget allocation",
+      "input": "values = [35 25 20 12 8];\nlabels = {'Engineering', 'Marketing', 'Operations', 'R&D', 'Admin'};\nexplode = [1 0 0 0 0];\n\npie(values, explode);\ntitle('Annual Budget Allocation');\nlegend(labels);",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-apie-budget.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How do I explode specific slices out of the pie?",
+      "answer": "Pass an explode vector the same length as your values. A `1` pulls that slice outward; a `0` keeps it flush.\n\n```matlab\npie([4 2 3 1], [0 1 0 0]);\n```\n\nThis explodes only the second slice. You can explode multiple slices by setting more entries to `1`."
+    },
+    {
+      "question": "How do I add percentage labels to slices?",
+      "answer": "By default, `pie` displays percentage labels on each slice. To use custom labels instead, pass a cell array of strings as the second argument.\n\n```matlab\npie([5 3 2], {'compute 50%', 'io 30%', 'render 20%'});\n```\n\nIf you want no labels at all, pass empty strings for each slice."
+    },
+    {
+      "question": "When should I use a pie chart vs a bar chart?",
+      "answer": "Pie charts work well when you have a small number of slices (2–5) and the point is to show each slice's share of a whole. Once you go beyond ~6 slices or need to compare absolute values across categories, `bar` is almost always clearer—humans are better at comparing lengths than angles. If two slices are close in size and the difference matters, use `bar`."
     }
   ],
   "links": [
-    { "label": "bar", "url": "./bar" },
-    { "label": "histogram", "url": "./histogram" },
-    { "label": "legend", "url": "./legend" }
+    {
+      "label": "bar",
+      "url": "./bar"
+    },
+    {
+      "label": "histogram",
+      "url": "./histogram"
+    },
+    {
+      "label": "legend",
+      "url": "./legend"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/pie.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/plot.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/plot.json
@@ -11,6 +11,7 @@
     "runmat plotting"
   ],
   "summary": "Create 2-D line plots with handle-based styling, multi-series support, and MATLAB `plot(x, y)` semantics.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-damped-oscillation.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -66,6 +67,25 @@
       "description": "Inspect and update a plotted line through handles",
       "input": "x = 0:0.1:1;\nh = plot(x, x.^2);\nget(h, 'Type')\nset(h, 'Color', 'r', 'Marker', 'o', 'MarkerSize', 6);",
       "output": "ans =\n    'line'"
+    },
+    {
+      "description": "Damped oscillation with envelope",
+      "input": "t = linspace(0, 4*pi, 500);\nenvelope = exp(-0.3*t);\nsignal = envelope .* sin(5*t);\n\nh1 = plot(t, signal);\nset(h1, 'DisplayName', 'Damped signal', 'LineWidth', 1.5);\nhold on;\nh2 = plot(t, envelope, '--');\nset(h2, 'DisplayName', 'Envelope', 'LineWidth', 1.5, 'Color', [0.85 0.33 0.1]);\nh3 = plot(t, -envelope, '--');\nset(h3, 'DisplayName', '-Envelope', 'LineWidth', 1.5, 'Color', [0.85 0.33 0.1]);\nhold off;\n\ntitle('Damped Oscillation');\nxlabel('Time (s)');\nylabel('Amplitude');\nlegend;\ngrid on;",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-damped-oscillation.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How do I plot multiple series on the same axes?",
+      "answer": "Call `hold on` between `plot` calls. Each subsequent `plot` adds a new line to the current axes instead of replacing the previous one.\n\n```matlab\nx = linspace(0, 2*pi, 200);\nplot(x, sin(x));\nhold on;\nplot(x, cos(x));\nlegend('sin', 'cos');\n```\n\nYou can also pass multiple x/y pairs in a single `plot` call, e.g. `plot(x, sin(x), x, cos(x))`, though you lose per-series handle control that way."
+    },
+    {
+      "question": "What line styles and markers does plot accept?",
+      "answer": "Style strings combine a color code, a line style, and a marker in any order. Line styles: `'-'` (solid), `'--'` (dashed), `':'` (dotted), `'-.'` (dash-dot). Markers: `'o'`, `'x'`, `'+'`, `'*'`, `'s'` (square), `'d'` (diamond), `'^'`, `'v'`. Colors: `'r'`, `'g'`, `'b'`, `'k'`, `'m'`, `'c'`, `'y'`. For example, `plot(x, y, 'r--o')` draws a red dashed line with circle markers."
+    },
+    {
+      "question": "When should I use plot vs scatter?",
+      "answer": "`plot` draws connected lines between points and is the right choice for continuous data or time-series. `scatter` draws unconnected markers and supports per-point size and color encoding through `SizeData` and `CData`. If you just want a line chart, use `plot`. If you need to encode a third variable via marker size or color, use `scatter`."
     }
   ],
   "links": [
@@ -100,6 +120,22 @@
     {
       "label": "set",
       "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
     }
   ],
   "source": {

--- a/crates/runmat-runtime/src/builtins/builtins-json/plot3.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/plot3.json
@@ -53,11 +53,53 @@
       "output": "ans =\n    'line'"
     }
   ],
+  "faqs": [
+    {
+      "question": "How do I plot a 3-D trajectory from parametric equations?",
+      "answer": "Generate a parameter vector `t`, compute x(t), y(t), z(t), and pass all three to `plot3`. The line connects points in parameter order.\n\n```matlab\nt = linspace(0, 10*pi, 500);\nplot3(sin(t), cos(t), t);\nzlabel('z');\n```"
+    },
+    {
+      "question": "Can I overlay plot3 lines with scatter3 points?",
+      "answer": "Yes — use `hold on` between calls. Both `plot3` and `scatter3` share the same 3-D axes and camera state, so they compose directly.\n\n```matlab\nt = linspace(0, 4*pi, 200);\nplot3(cos(t), sin(t), t);\nhold on;\nscatter3(cos(t(1:20:end)), sin(t(1:20:end)), t(1:20:end));\n```"
+    },
+    {
+      "question": "How do I control the camera angle on a plot3 figure?",
+      "answer": "Call `view(az, el)` after plotting. `az` is the azimuth (horizontal rotation) and `el` is the elevation (vertical tilt), both in degrees. `view(3)` gives the default 3-D perspective. Camera state is subplot-local, so each subplot can have its own angle."
+    }
+  ],
   "links": [
-    { "label": "scatter3", "url": "./scatter3" },
-    { "label": "view", "url": "./view" },
-    { "label": "zlabel", "url": "./zlabel" },
-    { "label": "legend", "url": "./legend" }
+    {
+      "label": "scatter3",
+      "url": "./scatter3"
+    },
+    {
+      "label": "view",
+      "url": "./view"
+    },
+    {
+      "label": "zlabel",
+      "url": "./zlabel"
+    },
+    {
+      "label": "legend",
+      "url": "./legend"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/plot3.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/quiver.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/quiver.json
@@ -10,6 +10,7 @@
     "direction field"
   ],
   "summary": "Visualize 2-D vector fields with scalable arrows, GPU-aware execution, and MATLAB `quiver` call forms.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-quiver-gradient-vector.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -57,14 +58,64 @@
     {
       "description": "Adjust arrow scaling and head size through the handle",
       "input": "[X, Y] = meshgrid(-2:0.5:2, -2:0.5:2);\nU = -Y;\nV = X;\nh = quiver(X, Y, U, V);\nset(h, 'AutoScaleFactor', 1.5, 'MaxHeadSize', 0.2, 'DisplayName', 'rotation');\nlegend;"
+    },
+    {
+      "description": "Gradient vector field over a scalar potential",
+      "input": "[X, Y] = meshgrid(linspace(-2, 2, 25), linspace(-2, 2, 25));\nZ = X .* exp(-X.^2 - Y.^2);\n[DX, DY] = gradient(Z, X(1,2)-X(1,1), Y(2,1)-Y(1,1));\n\ncontourf(X, Y, Z, 15);\nhold on;\nquiver(X, Y, DX, DY, 'k', 'LineWidth', 1);\nhold off;\n\ncolormap('turbo');\ncolorbar;\ntitle('Gradient Field over Scalar Potential');\nxlabel('x');\nylabel('y');",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-quiver-gradient-vector.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How do I control arrow lengths in a quiver plot?",
+      "answer": "Use the `'AutoScaleFactor'` property. A value of `1` means default scaling, `0` disables auto-scaling entirely (arrows drawn at raw data magnitude), and values like `1.5` or `2` make arrows proportionally longer.\n\n```matlab\nh = quiver(X, Y, U, V);\nset(h, 'AutoScaleFactor', 0); % raw magnitudes, no auto-scaling\n```"
+    },
+    {
+      "question": "Can I overlay quiver arrows on top of a contourf plot?",
+      "answer": "Yes. Plot the filled contour first, then call `hold on` and add the quiver layer. Both share the same axes, so the coordinate grids align automatically.\n\n```matlab\ncontourf(X, Y, Z);\nhold on;\nquiver(X, Y, U, V, 'Color', 'k');\n```"
+    },
+    {
+      "question": "Does RunMat support 3-D quiver plots?",
+      "answer": "Not yet. `quiver` currently handles 2-D vector fields only. For 3-D direction visualization, consider using `plot3` to draw line segments manually, or combine `scatter3` with custom arrow geometry."
     }
   ],
   "links": [
-    { "label": "area", "url": "./area" },
-    { "label": "plot", "url": "./plot" },
-    { "label": "legend", "url": "./legend" },
-    { "label": "get", "url": "./get" },
-    { "label": "set", "url": "./set" }
+    {
+      "label": "area",
+      "url": "./area"
+    },
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "legend",
+      "url": "./legend"
+    },
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/quiver.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/scatter.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/scatter.json
@@ -53,12 +53,57 @@
       "input": "x = 1:10;\nh1 = scatter(x, x);\nset(h1, 'DisplayName', 'linear');\nhold on;\nh2 = scatter(x, x.^2);\nset(h2, 'DisplayName', 'quadratic');\nlegend;"
     }
   ],
+  "faqs": [
+    {
+      "question": "How do I color scatter points by a third variable?",
+      "answer": "Set the `CData` property on the scatter handle to a vector the same length as x and y. The values map into the current colormap.\n\n```matlab\nx = randn(1, 100);\ny = randn(1, 100);\nz = x.^2 + y.^2;\nh = scatter(x, y);\nset(h, 'CData', z);\ncolorbar;\n```\n\nEach point gets a color proportional to its `z` value. Call `colorbar` to show the mapping."
+    },
+    {
+      "question": "What's the difference between scatter and plot?",
+      "answer": "`scatter` draws unconnected markers and supports per-point size (`SizeData`) and per-point color (`CData`). `plot` connects points with lines and applies uniform styling to the whole series. Use `scatter` when the individual point properties carry meaning; use `plot` when the connection between points is what matters."
+    },
+    {
+      "question": "How do I control marker size in scatter?",
+      "answer": "Pass a scalar or vector to `SizeData` via the handle. A scalar sets uniform size; a vector sets per-point sizes.\n\n```matlab\nh = scatter(x, y);\nset(h, 'SizeData', 40);          % uniform size\nset(h, 'SizeData', abs(y) * 50); % size proportional to |y|\n```\n\nThe size unit is points squared, matching MATLAB conventions."
+    }
+  ],
   "links": [
-    { "label": "plot", "url": "./plot" },
-    { "label": "scatter3", "url": "./scatter3" },
-    { "label": "legend", "url": "./legend" },
-    { "label": "get", "url": "./get" },
-    { "label": "set", "url": "./set" }
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "scatter3",
+      "url": "./scatter3"
+    },
+    {
+      "label": "legend",
+      "url": "./legend"
+    },
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/scatter.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/scatter3.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/scatter3.json
@@ -10,6 +10,7 @@
     "gpu plotting"
   ],
   "summary": "Create 3-D scatter plots for spatial point clouds, encoded markers, and MATLAB `scatter3` workflows.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-scatter3-3D-point-cloud.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -52,14 +53,64 @@
       "description": "Use subplot-local camera state with multiple 3-D plots",
       "input": "subplot(1, 2, 1);\nscatter3(1:10, rand(1,10), rand(1,10));\nview(3);\nsubplot(1, 2, 2);\nscatter3(rand(1,10), rand(1,10), rand(1,10));\nview(2);",
       "output": "% The two subplots keep independent 3-D view state"
+    },
+    {
+      "description": "3D point cloud with color-coded altitude",
+      "input": "n = 2000;\ntheta = 4*pi*rand(1, n);\nr = sqrt(rand(1, n));\nx = r .* cos(theta);\ny = r .* sin(theta);\nz = sin(3*r) ./ (1 + r);\n\nscatter3(x, y, z, 12, z, 'filled');\ncolormap('turbo');\ncolorbar;\ntitle('3-D Point Cloud — Altitude Encoded');\nxlabel('x');\nylabel('y');\nzlabel('z');\nview(35, 25);\ngrid on;",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-scatter3-3D-point-cloud.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How do I size scatter3 points by a data variable?",
+      "answer": "Pass a size vector as the fourth argument. Each element controls the marker area for the corresponding point.\n\n```matlab\nt = linspace(0, 4*pi, 200);\nsizes = linspace(5, 50, 200);\nscatter3(cos(t), sin(t), t, sizes);\n```\n\nA scalar fourth argument sets all points to the same size."
+    },
+    {
+      "question": "Can I color scatter3 points by a fourth variable?",
+      "answer": "Pass a color vector as the fifth argument after the size vector. Each value maps through the active colormap. Add `colorbar` to show the mapping.\n\n```matlab\nscatter3(x, y, z, 20, myValues);\ncolormap('turbo');\ncolorbar;\n```"
+    },
+    {
+      "question": "How do I rotate or orbit a scatter3 plot?",
+      "answer": "Use `view(az, el)` to set the camera angle programmatically. `az` is the horizontal orbit in degrees, `el` is the vertical tilt. `view(3)` gives the standard 3-D default. Each subplot keeps its own independent camera state, so you can show the same data from multiple angles in a subplot grid."
     }
   ],
   "links": [
-    { "label": "plot3", "url": "./plot3" },
-    { "label": "scatter", "url": "./scatter" },
-    { "label": "view", "url": "./view" },
-    { "label": "zlabel", "url": "./zlabel" },
-    { "label": "subplot", "url": "./subplot" }
+    {
+      "label": "plot3",
+      "url": "./plot3"
+    },
+    {
+      "label": "scatter",
+      "url": "./scatter"
+    },
+    {
+      "label": "view",
+      "url": "./view"
+    },
+    {
+      "label": "zlabel",
+      "url": "./zlabel"
+    },
+    {
+      "label": "subplot",
+      "url": "./subplot"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/scatter3.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/semilogx.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/semilogx.json
@@ -51,11 +51,53 @@
       "output": "ans =\n    'log'"
     }
   ],
+  "faqs": [
+    {
+      "question": "When should I use semilogx instead of plot?",
+      "answer": "Use `semilogx` when your x-data spans several orders of magnitude and you care about relative differences across that range. Frequency response curves (Bode magnitude plots) are the classic example — frequencies from 1 Hz to 100 kHz are unreadable on a linear axis but spread evenly on a log scale."
+    },
+    {
+      "question": "How is semilogx different from calling plot and then switching the x-axis to log?",
+      "answer": "Functionally identical. `semilogx(x, y)` is shorthand for `plot(x, y)` followed by `set(gca, 'XScale', 'log')`. The convenience form just does both in one call and makes intent clearer when reading code."
+    },
+    {
+      "question": "What happens if my x-data contains zero or negative values?",
+      "answer": "Logarithmic axes only render positive values. Zero and negative x-values are silently excluded from the rendered line — the data handle still holds them, but they won't appear on the plot. Filter your data to the positive domain if you need a continuous curve."
+    }
+  ],
   "links": [
-    { "label": "plot", "url": "./plot" },
-    { "label": "semilogy", "url": "./semilogy" },
-    { "label": "loglog", "url": "./loglog" },
-    { "label": "axis", "url": "./axis" }
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "semilogy",
+      "url": "./semilogy"
+    },
+    {
+      "label": "loglog",
+      "url": "./loglog"
+    },
+    {
+      "label": "axis",
+      "url": "./axis"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/semilogx.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/semilogy.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/semilogy.json
@@ -35,11 +35,53 @@
       "output": "ans =\n    'log'"
     }
   ],
+  "faqs": [
+    {
+      "question": "When is semilogy the right choice over a linear plot?",
+      "answer": "Whenever the interesting structure lives in multiplicative changes along Y — exponential decay, growth rates, signal attenuation. On a log y-axis, `exp(-t)` becomes a straight line, which makes decay constants easy to read directly from the slope."
+    },
+    {
+      "question": "How do I visualize exponential decay and read the time constant?",
+      "answer": "Plot with `semilogy` and the decay appears as a straight line. The slope of that line is the decay rate. For `exp(-t/tau)`, the signal drops by a factor of `e` every `tau` units along the x-axis.\n\n```matlab\nt = linspace(0, 10, 200);\nsemilogy(t, exp(-t/3)); % tau = 3\ngrid on;\n```"
+    },
+    {
+      "question": "What about zero or negative y-values on a log y-axis?",
+      "answer": "They're excluded from rendering since log of zero or negative numbers is undefined. The data handle still stores them, but only positive y-values produce visible points. If your data crosses zero, consider splitting into positive and negative series or using a linear axis."
+    }
+  ],
   "links": [
-    { "label": "plot", "url": "./plot" },
-    { "label": "semilogx", "url": "./semilogx" },
-    { "label": "loglog", "url": "./loglog" },
-    { "label": "axis", "url": "./axis" }
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "semilogx",
+      "url": "./semilogx"
+    },
+    {
+      "label": "loglog",
+      "url": "./loglog"
+    },
+    {
+      "label": "axis",
+      "url": "./axis"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/semilogy.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/set.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/set.json
@@ -35,11 +35,53 @@
       "input": "plot(1:5, 1:5);\nlg = legend('series');\nset(lg, 'Location', 'southwest', 'Orientation', 'horizontal');"
     }
   ],
+  "faqs": [
+    {
+      "question": "Can I set multiple properties in a single call?",
+      "answer": "Yes. Pass alternating property/value pairs: `set(h, 'Color', 'r', 'LineWidth', 2, 'DisplayName', 'trend')`. All updates apply atomically to the same handle."
+    },
+    {
+      "question": "What are the most commonly used properties to set on a line handle?",
+      "answer": "`'Color'`, `'LineWidth'`, `'LineStyle'`, `'Marker'`, and `'DisplayName'` cover most styling needs. `'DisplayName'` is especially useful — it feeds directly into `legend` when you call it without explicit labels.\n\n```matlab\nh = plot(x, y);\nset(h, 'Color', [0.2 0.6 0.8], 'LineWidth', 1.5, 'DisplayName', 'measured');\n```"
+    },
+    {
+      "question": "What happens if I pass a property name that the handle doesn't support?",
+      "answer": "RunMat raises a plotting error immediately. It doesn't silently ignore unknown properties, so typos in property names surface right away rather than producing subtle bugs."
+    }
+  ],
   "links": [
-    { "label": "get", "url": "./get" },
-    { "label": "legend", "url": "./legend" },
-    { "label": "subplot", "url": "./subplot" },
-    { "label": "plot", "url": "./plot" }
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "legend",
+      "url": "./legend"
+    },
+    {
+      "label": "subplot",
+      "url": "./subplot"
+    },
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/set.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/shading.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/shading.json
@@ -30,11 +30,53 @@
       "input": "[X, Y] = meshgrid(linspace(-3, 3, 40), linspace(-3, 3, 40));\nZ = sin(X) .* cos(Y);\nsubplot(1, 2, 1);\nsurf(X, Y, Z);\nshading flat;\nsubplot(1, 2, 2);\nsurf(X, Y, Z);\nshading faceted;"
     }
   ],
+  "faqs": [
+    {
+      "question": "What's the difference between interp, flat, and faceted shading?",
+      "answer": "`flat` fills each face with a single color (the value at one vertex). `interp` smoothly interpolates color across each face, producing a continuous gradient. `faceted` is like `flat` but with visible black edge lines between faces — this is the default `surf` appearance."
+    },
+    {
+      "question": "When should I use shading interp vs faceted?",
+      "answer": "Use `interp` when you want a smooth, publication-quality surface without visible grid edges — good for dense meshes or photorealistic renders. Use `faceted` (the default) when you want to see the mesh structure, which helps during debugging or when the grid resolution matters to the reader."
+    },
+    {
+      "question": "Does shading affect mesh plots or just surf?",
+      "answer": "It applies to both `surf` and `mesh` (and their variants like `surfc`, `meshc`). On a `mesh` plot the effect is most visible in how face colors are computed — `interp` smooths them, `flat` locks each face to one value. Edge visibility is controlled separately."
+    }
+  ],
   "links": [
-    { "label": "surf", "url": "./surf" },
-    { "label": "mesh", "url": "./mesh" },
-    { "label": "colormap", "url": "./colormap" },
-    { "label": "colorbar", "url": "./colorbar" }
+    {
+      "label": "surf",
+      "url": "./surf"
+    },
+    {
+      "label": "mesh",
+      "url": "./mesh"
+    },
+    {
+      "label": "colormap",
+      "url": "./colormap"
+    },
+    {
+      "label": "colorbar",
+      "url": "./colorbar"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/cmds.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/stairs.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/stairs.json
@@ -9,6 +9,7 @@
     "matlab stairs"
   ],
   "summary": "Create step plots for sampled signals, piecewise-constant data, and MATLAB `stairs` workflows.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-stairs-piecewise-constant-step.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -49,14 +50,64 @@
     {
       "description": "Style a stairs object and label it for the legend",
       "input": "h = stairs(0:4, [1 2 2 3 5]);\nset(h, 'Color', 'm', 'LineWidth', 2, 'DisplayName', 'sampled signal');\nlegend;"
+    },
+    {
+      "description": "Piecewise-constant step response",
+      "input": "t = 0:0.5:10;\ny = 1 - exp(-0.5*t);\n\nh = stairs(t, y);\nset(h, 'LineWidth', 2);\ntitle('First-Order Step Response');\nxlabel('Time (s)');\nylabel('Output');\ngrid on;",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-stairs-piecewise-constant-step.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "When should I use stairs instead of plot?",
+      "answer": "`stairs` draws piecewise-constant steps between points, while `plot` linearly interpolates. Use `stairs` when your data is held constant between samples—DAC output, quantized signals, sample-and-hold systems, or any situation where the value doesn't change smoothly between observations."
+    },
+    {
+      "question": "How do I visualize a digital signal with stairs?",
+      "answer": "Pass your time vector and signal values directly. The staircase rendering naturally represents digital/discrete-time signals where values snap between levels.\n\n```matlab\nt = 0:0.01:1;\nsignal = double(square(2*pi*5*t) > 0);\nstairs(t, signal);\nylim([-0.2 1.2]);\n```\n\nThis avoids the misleading diagonal transitions that `plot` would draw between high and low states."
+    },
+    {
+      "question": "Can I add markers to a stairs plot?",
+      "answer": "Yes. Set the `'Marker'` property on the returned handle, just like you would with `plot`.\n\n```matlab\nh = stairs(0:4, [1 3 2 4 1]);\nset(h, 'Marker', 'o', 'MarkerSize', 6);\n```\n\nMarkers appear at each data point (the step corners), not along the flat segments."
     }
   ],
   "links": [
-    { "label": "plot", "url": "./plot" },
-    { "label": "stem", "url": "./stem" },
-    { "label": "scatter", "url": "./scatter" },
-    { "label": "legend", "url": "./legend" },
-    { "label": "set", "url": "./set" }
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "stem",
+      "url": "./stem"
+    },
+    {
+      "label": "scatter",
+      "url": "./scatter"
+    },
+    {
+      "label": "legend",
+      "url": "./legend"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/stairs.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/stem.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/stem.json
@@ -9,6 +9,7 @@
     "matlab stem"
   ],
   "summary": "Create stem plots for discrete signals, sequence visualization, and MATLAB `stem` workflows.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-stem-discrete-sampled-signal.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -51,14 +52,64 @@
       "description": "Inspect a stem handle after plotting",
       "input": "h = stem(1:5, [2 1 3 2 4]);\nget(h, 'Type')",
       "output": "ans =\n    'stem'"
+    },
+    {
+      "description": "Discrete sampled signal",
+      "input": "n = 0:31;\nx = sin(2*pi*n/16) .* (0.9 .^ n);\n\nstem(n, x);\ntitle('Sampled Decaying Sinusoid');\nxlabel('Sample index n');\nylabel('x[n]');\ngrid on;",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-stem-discrete-sampled-signal.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "When should I use stem instead of plot?",
+      "answer": "`stem` is designed for discrete sequences where each sample is an independent value at a specific index—think impulse responses, sampled signals, or coefficient arrays. `plot` connects points with a continuous line, which implies interpolation between samples. If your data is inherently discrete and the gaps between samples matter, `stem` communicates that visually."
+    },
+    {
+      "question": "How do I customize the markers on a stem plot?",
+      "answer": "Use the handle returned by `stem` with `set` to change marker shape, size, fill, and color.\n\n```matlab\nh = stem(1:8, [3 1 4 1 5 9 2 6]);\nset(h, 'Marker', 's', 'MarkerSize', 8, 'Filled', true, 'MarkerFaceColor', 'r');\n```\n\nMarker properties go through the same shared property model as `plot` and `scatter`, so the same property names work."
+    },
+    {
+      "question": "Can I change the baseline of a stem plot?",
+      "answer": "Yes. Set the `'BaseValue'` property on the stem handle to shift the baseline from the default of 0.\n\n```matlab\nh = stem(1:5, [2 4 1 3 5]);\nset(h, 'BaseValue', 2);\n```\n\nStems will then extend from y=2 to each data point rather than from y=0."
     }
   ],
   "links": [
-    { "label": "stairs", "url": "./stairs" },
-    { "label": "errorbar", "url": "./errorbar" },
-    { "label": "legend", "url": "./legend" },
-    { "label": "get", "url": "./get" },
-    { "label": "set", "url": "./set" }
+    {
+      "label": "stairs",
+      "url": "./stairs"
+    },
+    {
+      "label": "errorbar",
+      "url": "./errorbar"
+    },
+    {
+      "label": "legend",
+      "url": "./legend"
+    },
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/stem.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/subplot.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/subplot.json
@@ -36,11 +36,53 @@
       "output": "% Only the first subplot uses a logarithmic x-axis"
     }
   ],
+  "faqs": [
+    {
+      "question": "How do I control the number of rows and columns in a subplot layout?",
+      "answer": "The first two arguments to `subplot(m, n, p)` set the grid dimensions: `m` rows and `n` columns. The third argument `p` selects which slot to activate, counted in row-major order starting at 1. `subplot(3, 1, 2)` gives you the middle row of a three-row single-column layout."
+    },
+    {
+      "question": "Can two subplots share the same x-axis range?",
+      "answer": "Set matching limits on both axes manually with `axis` or `set`. There's no automatic `linkaxes` yet, but explicit limits keep them in sync.\n\n```matlab\nsubplot(2, 1, 1); plot(0:10, rand(1, 11)); axis([0 10 0 1]);\nsubplot(2, 1, 2); plot(0:10, rand(1, 11)); axis([0 10 0 1]);\n```"
+    },
+    {
+      "question": "Can I make subplots of unequal sizes?",
+      "answer": "You can span multiple grid slots by passing a vector as the third argument. `subplot(2, 2, [1 2])` creates a subplot that spans the entire top row of a 2x2 grid, while the bottom row keeps two separate panels."
+    }
+  ],
   "links": [
-    { "label": "plot", "url": "./plot" },
-    { "label": "legend", "url": "./legend" },
-    { "label": "get", "url": "./get" },
-    { "label": "set", "url": "./set" }
+    {
+      "label": "plot",
+      "url": "./plot"
+    },
+    {
+      "label": "legend",
+      "url": "./legend"
+    },
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/subplot.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/surf.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/surf.json
@@ -10,6 +10,7 @@
     "gpu surface rendering"
   ],
   "summary": "Create shaded 3-D surface plots from grids or mesh coordinates with GPU-backed rendering and MATLAB `surf` semantics.",
+  "hero_image": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-surf-damped-radial-ripple.webp",
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
@@ -52,16 +53,72 @@
       "description": "Adjust camera state and z-axis labeling for a surface",
       "input": "[X, Y] = meshgrid(linspace(-2, 2, 60), linspace(-2, 2, 60));\nZ = X .* exp(-X.^2 - Y.^2);\nh = surf(X, Y, Z);\nzlabel('Height');\nview(45, 30);\nget(h, 'Type')",
       "output": "ans =\n    'surface'"
+    },
+    {
+      "description": "Damped radial ripple with interpolated shading",
+      "input": "[X, Y] = meshgrid(linspace(-4, 4, 200), linspace(-4, 4, 200));\nR = sqrt(X.^2 + Y.^2) + 0.01;\nZ = sin(3*R) ./ R;\n\nsurf(X, Y, Z);\nshading interp;\ncolormap('turbo');\ncolorbar;\ntitle('Damped Radial Wavefield');\nxlabel('x');\nylabel('y');\nzlabel('Amplitude');\nview(35, 25);",
+      "image_webp": "https://web.runmatstatic.com/builtin-image/runmat-matlab-plot-surf-damped-radial-ripple.webp"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How do I change the colormap on a surf plot?",
+      "answer": "Call `colormap` after `surf` to swap the palette. The colormap applies to the current axes, so it works per-subplot.\n\n```matlab\nsurf(X, Y, Z);\ncolormap('turbo');\n```\n\nAny named colormap (`'parula'`, `'jet'`, `'hot'`, etc.) or an Nx3 matrix of RGB values works here."
+    },
+    {
+      "question": "How do I rotate or set the 3-D viewing angle?",
+      "answer": "Use `view(az, el)` where `az` is the azimuth in degrees and `el` is the elevation. For example, `view(45, 30)` gives you a 45-degree orbit at 30 degrees above the xy-plane. `view(3)` is a shortcut for the default 3-D perspective, and `view(2)` snaps to a top-down 2-D projection."
+    },
+    {
+      "question": "What's the difference between surf and mesh?",
+      "answer": "`surf` renders a shaded, filled surface where face colors come from the colormap. `mesh` draws only the wireframe grid lines with no face fill. Use `surf` when you want to visualize the shape as a solid surface, and `mesh` when you want to see through the geometry to understand the grid structure underneath."
     }
   ],
   "links": [
-    { "label": "mesh", "url": "./mesh" },
-    { "label": "surfc", "url": "./surfc" },
-    { "label": "view", "url": "./view" },
-    { "label": "zlabel", "url": "./zlabel" },
-    { "label": "colormap", "url": "./colormap" },
-    { "label": "shading", "url": "./shading" },
-    { "label": "colorbar", "url": "./colorbar" }
+    {
+      "label": "mesh",
+      "url": "./mesh"
+    },
+    {
+      "label": "surfc",
+      "url": "./surfc"
+    },
+    {
+      "label": "view",
+      "url": "./view"
+    },
+    {
+      "label": "zlabel",
+      "url": "./zlabel"
+    },
+    {
+      "label": "colormap",
+      "url": "./colormap"
+    },
+    {
+      "label": "shading",
+      "url": "./shading"
+    },
+    {
+      "label": "colorbar",
+      "url": "./colorbar"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/surf.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/surfc.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/surfc.json
@@ -52,12 +52,57 @@
       "output": "ans =\n    'surface'"
     }
   ],
+  "faqs": [
+    {
+      "question": "Where do the contour lines appear in a surfc plot?",
+      "answer": "The contour lines are projected onto the base plane (the z-minimum of the axes). They sit below the surface as a 2-D footprint of the height field. The contour overlay uses the same colormap as the surface, so the colors stay consistent."
+    },
+    {
+      "question": "When should I use surfc vs calling surf and contour separately?",
+      "answer": "`surfc` handles the composite in one call — the contour is automatically projected to the base plane and shares the surface's colormap and axes state. If you call `surf` and `contour` separately, the contour sits at z=0 by default and you'd need to manage hold state and z-placement yourself. Use `surfc` unless you need the contour at a custom z-level or with different level spacing than the default."
+    },
+    {
+      "question": "Can I control how many contour levels surfc draws?",
+      "answer": "The contour overlay in `surfc` uses the default level-generation logic from the contour pipeline. If you need explicit control over level count or spacing, call `surf` and `contour` separately so you can pass a level vector to `contour` directly."
+    }
+  ],
   "links": [
-    { "label": "surf", "url": "./surf" },
-    { "label": "meshc", "url": "./meshc" },
-    { "label": "contour", "url": "./contour" },
-    { "label": "contourf", "url": "./contourf" },
-    { "label": "view", "url": "./view" }
+    {
+      "label": "surf",
+      "url": "./surf"
+    },
+    {
+      "label": "meshc",
+      "url": "./meshc"
+    },
+    {
+      "label": "contour",
+      "url": "./contour"
+    },
+    {
+      "label": "contourf",
+      "url": "./contourf"
+    },
+    {
+      "label": "view",
+      "url": "./view"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/surfc.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/view.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/view.json
@@ -36,13 +36,61 @@
       "output": "% Returns a 1x2 vector [60 20]"
     }
   ],
+  "faqs": [
+    {
+      "question": "What do azimuth and elevation mean in view(az, el)?",
+      "answer": "Azimuth is the horizontal rotation around the z-axis (0° looks along the y-axis toward the origin). Elevation is the angle above the x-y plane (0° is level, 90° is directly overhead). `view(45, 30)` gives the classic isometric-ish perspective for 3-D surfaces."
+    },
+    {
+      "question": "How do I reset to the default 2-D or 3-D view?",
+      "answer": "`view(2)` sets the camera to top-down (azimuth 0, elevation 90) — useful for looking at a surface as a heatmap. `view(3)` restores the default 3-D camera at `[-37.5, 30]`, which is the standard MATLAB 3-D preset."
+    },
+    {
+      "question": "Can I set different view angles per subplot?",
+      "answer": "Yes. View state is subplot-local. Pass the axes handle explicitly to target a specific panel.\n\n```matlab\nax1 = subplot(1, 2, 1); surf(X, Y, Z); view(ax1, 0, 90);\nax2 = subplot(1, 2, 2); surf(X, Y, Z); view(ax2, 45, 30);\n```"
+    }
+  ],
   "links": [
-    { "label": "plot3", "url": "./plot3" },
-    { "label": "scatter3", "url": "./scatter3" },
-    { "label": "surf", "url": "./surf" },
-    { "label": "zlabel", "url": "./zlabel" },
-    { "label": "get", "url": "./get" },
-    { "label": "set", "url": "./set" }
+    {
+      "label": "plot3",
+      "url": "./plot3"
+    },
+    {
+      "label": "scatter3",
+      "url": "./scatter3"
+    },
+    {
+      "label": "surf",
+      "url": "./surf"
+    },
+    {
+      "label": "zlabel",
+      "url": "./zlabel"
+    },
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/view.rs`",

--- a/crates/runmat-runtime/src/builtins/builtins-json/zlabel.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/zlabel.json
@@ -34,12 +34,57 @@
       "input": "[X, Y] = meshgrid(linspace(-3, 3, 30), linspace(-3, 3, 30));\nZ = sin(X) .* cos(Y);\nsubplot(1, 2, 1);\nsurf(X, Y, Z);\nax = subplot(1, 2, 2);\nplot3(cos(0:0.1:5), sin(0:0.1:5), 0:0.1:5);\nzlabel(ax, 'Trajectory Height');"
     }
   ],
+  "faqs": [
+    {
+      "question": "When do I need zlabel vs just xlabel/ylabel?",
+      "answer": "`zlabel` only applies to 3-D axes — `surf`, `mesh`, `plot3`, `scatter3`, etc. For 2-D plots, the z-axis doesn't exist, so `zlabel` has no effect. If you're plotting in 3-D, always label all three axes so readers can orient themselves."
+    },
+    {
+      "question": "Can I use LaTeX formatting in zlabel?",
+      "answer": "You can use LaTeX-style inline math in the label string with standard TeX markup. Subscripts, superscripts, and Greek letters work in label text.\n\n```matlab\nzlabel('Temperature (\\circC)');\nzlabel('\\sigma_{z} (MPa)');\n```"
+    },
+    {
+      "question": "How do I style the z-axis label after creating it?",
+      "answer": "`zlabel` returns a text handle that works with `get` and `set`. You can change font weight, size, color, and other text properties through that handle.\n\n```matlab\nh = zlabel('Elevation (m)');\nset(h, 'FontWeight', 'bold', 'FontSize', 14);\n```"
+    }
+  ],
   "links": [
-    { "label": "view", "url": "./view" },
-    { "label": "plot3", "url": "./plot3" },
-    { "label": "surf", "url": "./surf" },
-    { "label": "get", "url": "./get" },
-    { "label": "set", "url": "./set" }
+    {
+      "label": "view",
+      "url": "./view"
+    },
+    {
+      "label": "plot3",
+      "url": "./plot3"
+    },
+    {
+      "label": "surf",
+      "url": "./surf"
+    },
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Choosing the right plot type",
+      "url": "/docs/plotting/choosing-the-right-plot-type"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    },
+    {
+      "label": "Plot replay and export",
+      "url": "/docs/plotting/plot-replay-and-export"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
   ],
   "source": {
     "label": "`crates/runmat-runtime/src/builtins/plotting/ops/zlabel.rs`",

--- a/website/app/docs/reference/builtins/[slug]/meta.ts
+++ b/website/app/docs/reference/builtins/[slug]/meta.ts
@@ -24,12 +24,17 @@ export function builtinMetadataForSlug(slug: string): Metadata {
       : (builtin.description || FALLBACK_DESCRIPTION).trim();
 
     const title = `${builtin.title} — MATLAB Function Reference | Run Examples Live`;
+    const ogImagePath = builtin.hero_image || `/docs/reference/builtins/${slug}/opengraph-image`;
+    const ogImageAlt = summary
+      ? `${builtin.title} in RunMat — ${summary}`
+      : `${builtin.title} — MATLAB function reference in RunMat`;
     return buildPageMetadata({
       title,
       description,
       canonicalPath: `/docs/reference/builtins/${slug}`,
       ogType: 'article',
-      ogImagePath: `/docs/reference/builtins/${slug}/opengraph-image`,
+      ogImagePath,
+      ogImageAlt,
     });
 }
 
@@ -53,8 +58,10 @@ export function builtinOgTitleSubtitle(slug: string): { title: string; subtitle:
 
 export function builtinJsonLD(slug: string): string {
     const builtin = getBuiltinDocBySlug(slug);
+    const title = builtin?.title ?? slug;
     const examples = builtin?.examples ?? [];
     const faqs = builtin?.faqs ?? [];
+    const heroImage = builtin?.hero_image || "https://web.runmatstatic.com/runmat-sandbox-dark.png";
 
     const mainEntityRefs: Record<string, string>[] = [{"@id": "#source-code"}];
     if (examples.length > 0) mainEntityRefs.push({"@id": "#how-to-guide"});
@@ -65,13 +72,13 @@ export function builtinJsonLD(slug: string): string {
             "@type": "WebPage",
             "@id": `https://runmat.com/docs/reference/builtins/${slug}`,
             "url": `https://runmat.com/docs/reference/builtins/${slug}`,
-            "name": `${builtin?.title} - RunMat Reference`,
+            "name": `${title} - RunMat Reference`,
             "isPartOf": {"@id": "https://runmat.com/#website"},
             "author": {"@id": "https://runmat.com/#organization"},
             "publisher": {"@id": "https://runmat.com/#organization"},
             "primaryImageOfPage": {
                 "@type": "ImageObject",
-                "url": "https://web.runmatstatic.com/runmat-sandbox-dark.png"
+                "url": heroImage
             },
             "breadcrumb": {"@id": `https://runmat.com/docs/reference/builtins/${slug}#breadcrumbs`},
             "mainEntity": {"@id": "#article"}
@@ -82,15 +89,16 @@ export function builtinJsonLD(slug: string): string {
             "itemListElement": [
                 {"@type": "ListItem", "position": 1, "name": "Docs", "item": "https://runmat.com/docs"},
                 {"@type": "ListItem", "position": 2, "name": "Reference", "item": "https://runmat.com/docs/matlab-function-reference"},
-                {"@type": "ListItem", "position": 3, "name": builtin?.title, "item": `https://runmat.com/docs/reference/builtins/${slug}`}
+                {"@type": "ListItem", "position": 3, "name": title, "item": `https://runmat.com/docs/reference/builtins/${slug}`}
             ]
         },
         {
             "@type": "APIReference",
             "@id": `https://runmat.com/docs/reference/builtins/${slug}#article`,
-            "headline": `${builtin?.title} in MATLAB — runnable examples + source (RunMat)`,
-            "alternativeHeadline": `${builtin?.title} Function Reference`,
-            "description": `Run ${builtin?.title} in your browser. Open-source, JIT-compiled MATLAB-compatible documentation for ${builtin?.description}.`,
+            "headline": `${title} in MATLAB — runnable examples + source (RunMat)`,
+            "alternativeHeadline": `${title} Function Reference`,
+            "description": `Run ${title} in your browser. Open-source, JIT-compiled MATLAB-compatible documentation for ${stripMarkdown(builtin?.description ?? '')}`.slice(0, 300),
+            "image": heroImage,
             "proficiencyLevel": "Beginner",
             "programmingModel": "Procedural",
             "assemblyVersion": "RunMat 0.1.0",
@@ -100,8 +108,8 @@ export function builtinJsonLD(slug: string): string {
             "publisher": {"@id": "https://runmat.com/#organization"},
             "about": {
                 "@type": "DefinedTerm",
-                "name": builtin?.title,
-                "description": builtin?.description,
+                "name": title,
+                "description": stripMarkdown(builtin?.description ?? ''),
                 "inDefinedTermSet": {
                     "@type": "DefinedTermSet",
                     "name": "RunMat Builtin Functions",
@@ -113,8 +121,8 @@ export function builtinJsonLD(slug: string): string {
         {
             "@type": "SoftwareSourceCode",
             "@id": "#source-code",
-            "name": `${builtin?.title}.rs`,
-            "description": `The Rust implementation of the ${builtin?.title} function, compatible with all RunMat targets.`,
+            "name": `${title}.rs`,
+            "description": `The Rust implementation of the ${title} function, compatible with all RunMat targets.`,
             "codeRepository": "https://github.com/runmat-org/runmat",
             "programmingLanguage": {"@type": "ComputerLanguage", "name": "Rust"},
             "codeSampleType": "full implementation",
@@ -129,17 +137,22 @@ export function builtinJsonLD(slug: string): string {
         graph.push({
             "@type": "HowTo",
             "@id": "#how-to-guide",
-            "name": `How to use ${builtin?.title} in RunMat`,
+            "name": `How to use ${title} in RunMat`,
+            "description": `Runnable examples showing how to use ${title} in RunMat. Each example runs in the browser with no setup.`,
+            "image": heroImage,
             "step": examples.map(example => {
                 const description = example.description?.trim() || 'Example';
                 const anchor = description.toLowerCase().replace(/\s+/g, '-');
-                return {
+                const stepImage = example.image_webp || example.image;
+                const step: Record<string, unknown> = {
                     "@type": "HowToStep",
                     "name": description,
                     "url": `https://runmat.com/docs/reference/builtins/${slug}#${anchor}`,
                     "text": example.input,
                     "itemListElement": {"@type": "HowToDirection", "text": example.input}
                 };
+                if (stepImage) step.image = stepImage;
+                return step;
             })
         });
     }
@@ -151,10 +164,56 @@ export function builtinJsonLD(slug: string): string {
             "mainEntity": faqs.map(faq => ({
                 "@type": "Question",
                 "name": faq.question,
-                "acceptedAnswer": {"@type": "Answer", "text": faq.answer}
+                "acceptedAnswer": {"@type": "Answer", "text": markdownToHtml(faq.answer)}
             }))
         });
     }
 
     return JSON.stringify({"@context": "https://schema.org", "@graph": graph});
+}
+
+// Strip markdown formatting for use in plain-text schema.org fields
+// (descriptions, about.description). Preserves content, removes backticks,
+// code fences, and list bullets so search engines see clean prose.
+function stripMarkdown(text: string): string {
+    return text
+        .replace(/```[\s\S]*?```/g, '') // remove fenced code blocks
+        .replace(/`([^`]+)`/g, '$1')     // unwrap inline code
+        .replace(/\*\*([^*]+)\*\*/g, '$1') // bold
+        .replace(/\*([^*]+)\*/g, '$1')     // italic
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // links
+        .replace(/^\s*[-*]\s+/gm, '')     // list bullets
+        .replace(/\s+/g, ' ')              // collapse whitespace
+        .trim();
+}
+
+// Minimal markdown-to-HTML conversion for FAQ answers in JSON-LD.
+// Google's FAQPage spec supports HTML in answer text, but not raw markdown.
+// Converts code fences, inline code, bold/italic, and paragraphs.
+function markdownToHtml(text: string): string {
+    let html = text;
+    html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code) => {
+        const escaped = String(code)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+        return `<pre><code>${escaped.trim()}</code></pre>`;
+    });
+    html = html.replace(/`([^`]+)`/g, (_m, code) => {
+        const escaped = String(code)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+        return `<code>${escaped}</code>`;
+    });
+    html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+    html = html.replace(/(^|[^*])\*([^*\n]+)\*/g, '$1<em>$2</em>');
+    html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+    const paragraphs = html.split(/\n{2,}/).map(p => {
+        const trimmed = p.trim();
+        if (!trimmed) return '';
+        if (trimmed.startsWith('<pre>') || trimmed.startsWith('<ul>')) return trimmed;
+        return `<p>${trimmed.replace(/\n/g, ' ')}</p>`;
+    }).filter(Boolean);
+    return paragraphs.join('');
 }

--- a/website/app/docs/reference/builtins/[slug]/page.tsx
+++ b/website/app/docs/reference/builtins/[slug]/page.tsx
@@ -143,8 +143,12 @@ function renderBuiltinDocBlocks(doc: BuiltinDocEntry): BuiltinDocBlock[] {
   }
 
   if (doc.links && doc.links.length > 0) {
-    const linkInline = renderSeeAlsoLinks(doc.links);
-    if (linkInline.length > 0) {
+    const isGuideLink = (url: string) => url.startsWith('/docs/') || url.startsWith('/blog/');
+    const functionLinks = doc.links.filter(l => l.url?.trim() && l.label?.trim() && !isGuideLink(l.url.trim()));
+    const guideLinks = doc.links.filter(l => l.url?.trim() && l.label?.trim() && isGuideLink(l.url.trim()));
+
+    if (functionLinks.length > 0) {
+      const hasThumbnails = functionLinks.some(link => link.thumbnail);
       blocks.push(createHeading(2, parseInline('Related functions to explore')));
       blocks.push({
         type: 'paragraph',
@@ -152,7 +156,32 @@ function renderBuiltinDocBlocks(doc: BuiltinDocEntry): BuiltinDocBlock[] {
           `These functions work well alongside \`${title}\`. Each page has runnable examples you can try in the browser.`
         ),
       });
-      blocks.push({ type: 'paragraph', content: linkInline });
+      if (hasThumbnails) {
+        blocks.push({
+          type: 'link-grid',
+          items: functionLinks.map(link => ({
+            label: link.label.trim(),
+            href: link.url.trim(),
+            thumbnail: link.thumbnail,
+          })),
+        });
+      } else {
+        const linkInline = renderSeeAlsoLinks(functionLinks);
+        if (linkInline.length > 0) {
+          blocks.push({ type: 'paragraph', content: linkInline });
+        }
+      }
+    }
+
+    if (guideLinks.length > 0) {
+      blocks.push(createHeading(2, parseInline('More plotting resources')));
+      blocks.push({
+        type: 'list',
+        ordered: false,
+        items: guideLinks.map(link => [
+          { type: 'link' as const, label: parseInline(link.label.trim()), href: link.url.trim() },
+        ]),
+      });
     }
   }
 
@@ -215,6 +244,15 @@ function renderExamples(examples: BuiltinDocExample[]): BuiltinDocBlock[] {
     if (hasText(example.output)) {
       blocks.push({ type: 'paragraph', content: [textNode('Expected output:')] });
       blocks.push(createCodeBlock(example.output, { language: 'matlab' }));
+    }
+    const exampleImage = example.image_webp || example.image;
+    if (exampleImage) {
+      blocks.push({
+        type: 'image',
+        src: exampleImage,
+        alt: description || 'Example output',
+        caption: 'Expected output:',
+      });
     }
   }
   return blocks;

--- a/website/components/BuiltinDocRenderer.tsx
+++ b/website/components/BuiltinDocRenderer.tsx
@@ -17,6 +17,8 @@ export type BuiltinDocBlock =
   | { type: 'list'; ordered: boolean; items: BuiltinDocInlineNode[][] }
   | { type: 'code'; language?: string; runnable?: boolean; content: string }
   | { type: 'table'; headers: BuiltinDocInlineNode[][]; rows: BuiltinDocInlineNode[][][] }
+  | { type: 'image'; src: string; alt: string; caption?: string }
+  | { type: 'link-grid'; items: { label: string; href: string; thumbnail?: string }[] }
   | { type: 'divider' };
 
 type BuiltinDocRendererProps = {
@@ -96,6 +98,46 @@ function renderBlock(block: BuiltinDocBlock): React.ReactNode {
               ))}
             </tbody>
           </table>
+        </div>
+      );
+    case 'image':
+      return (
+        <figure className="my-8">
+          {block.caption && (
+            <figcaption className="mb-2 text-sm text-muted-foreground">
+              {block.caption}
+            </figcaption>
+          )}
+          <img
+            src={block.src}
+            alt={block.alt}
+            loading="lazy"
+            className="rounded-lg border border-border w-full max-w-2xl"
+          />
+        </figure>
+      );
+    case 'link-grid':
+      return (
+        <div className="my-8 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+          {block.items.map((item, index) => (
+            <a
+              key={index}
+              href={item.href}
+              className="group flex flex-col items-center gap-2 rounded-lg border border-border p-3 hover:border-blue-500/50 hover:bg-muted/50 transition-colors"
+            >
+              {item.thumbnail && (
+                <img
+                  src={item.thumbnail}
+                  alt={`${item.label} preview`}
+                  loading="lazy"
+                  className="rounded w-full h-auto aspect-[5/3] object-cover"
+                />
+              )}
+              <span className="text-sm font-mono text-foreground group-hover:text-blue-500 transition-colors">
+                {item.label}
+              </span>
+            </a>
+          ))}
         </div>
       );
     case 'divider':

--- a/website/lib/builtins.ts
+++ b/website/lib/builtins.ts
@@ -30,6 +30,9 @@ export type BuiltinDocExample = {
   description: string;
   input: string;
   output?: string;
+  image?: string;
+  image_webp?: string;
+  matlab_script?: string;
 };
 
 export type BuiltinDocFAQ = {
@@ -40,6 +43,7 @@ export type BuiltinDocFAQ = {
 export type BuiltinDocLink = {
   label: string;
   url: string;
+  thumbnail?: string;
 };
 
 export type BuiltinDocSyntax = {
@@ -61,6 +65,7 @@ export type BuiltinDoc = {
   summary: string;
   references: string[];
   description?: string;
+  hero_image?: string;
   behaviors?: string[];
   examples?: BuiltinDocExample[];
   faqs?: BuiltinDocFAQ[];

--- a/website/lib/seo.ts
+++ b/website/lib/seo.ts
@@ -16,12 +16,16 @@ export type PageSeoOptions = {
   canonicalPath: string; // e.g. "/docs/cli"
   ogType?: "website" | "article";
   ogImagePath?: string; // e.g. "/docs/opengraph-image"
+  ogImageAlt?: string;
 };
 
 export function buildPageMetadata(opts: PageSeoOptions): Metadata {
   const canonical = toAbsoluteUrl(opts.canonicalPath);
   const ogImage = opts.ogImagePath ? toAbsoluteUrl(opts.ogImagePath) : undefined;
   const ogType = opts.ogType ?? "website";
+  const ogImageEntry = ogImage
+    ? [{ url: ogImage, ...(opts.ogImageAlt ? { alt: opts.ogImageAlt } : {}) }]
+    : undefined;
 
   return {
     title: opts.title,
@@ -32,13 +36,13 @@ export function buildPageMetadata(opts: PageSeoOptions): Metadata {
       description: opts.description,
       type: ogType,
       url: canonical,
-      ...(ogImage ? { images: [ogImage] } : {}),
+      ...(ogImageEntry ? { images: ogImageEntry } : {}),
     },
     twitter: {
       card: "summary_large_image",
       title: opts.title,
       description: opts.description,
-      ...(ogImage ? { images: [ogImage] } : {}),
+      ...(ogImageEntry ? { images: ogImageEntry } : {}),
     },
   };
 }


### PR DESCRIPTION
…examples, and hero images. Updated area, axis, bar, box, colorbar, colormap, contour, contourf, errorbar, get, grid, hist, histogram, image, imagesc, legend, and loglog files to improve documentation and user guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation/metadata changes with minimal runtime impact; main risk is SEO/rendering regressions if the new JSON fields aren’t present or are malformed.
> 
> **Overview**
> Improves the plotting builtin reference content by adding `hero_image` fields, new FAQs, additional examples (some with `image_webp` screenshots), and extra “plotting resources” links across many builtin JSON definitions.
> 
> Updates the docs site to consume these new fields: builtins pages can now render example output images and an optional thumbnail-based related-links grid, and “See also” links are split into related functions vs guide/blog resources.
> 
> Enhances SEO output for builtin pages by preferring per-builtin `hero_image` for OpenGraph/Twitter images (with `ogImageAlt`), and by expanding JSON-LD generation (cleaner descriptions via markdown stripping, HTML conversion for FAQ answers, and optional images on HowTo steps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac34d0ce065e342218f1ecd496c8d1d9c0537a1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->