### PR TITLE
Update README for version 0.4, enhancing plotting capabilities and in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="https://runmat.com/sandbox"><strong>Try it now — no install needed</strong></a> · <a href="https://runmat.com/docs">Docs</a> · <a href="https://runmat.com/blog">Blog</a> · <a href="https://runmat.com">Website</a>
 </p>
 
-<p align="center"><em>Status: Pre-release (v0.3) — core runtime and GPU engine pass thousands of tests. Expect a few rough edges.</em></p>
+<p align="center"><em>Status: Pre-release (v0.4) — core runtime and GPU engine pass thousands of tests. Expect a few rough edges.</em></p>
 
 ---
 
@@ -145,9 +145,9 @@ team management.<br/><br/>
 
 - **Plotting**
 
-  - Interactive 2D and 3D plots  
-  - Line, scatter, and surface plots supported today  
-  - Some advanced plot types (box plots, violin plots) are still in progress  
+  - Interactive 2D and 3D plots with GPU-accelerated rendering
+  - 30+ plot types: line, scatter, bar, surface, mesh, histogram, stem, errorbar, area, contour, pie, plot3, imagesc, and log-scale variants
+  - Graphics handles, subplot state, annotation builtins (`title`, `xlabel`, `legend`), and 3D camera controls
 
   Open-source plotting engine demo (works in CLI and in the browser sandbox):
 
@@ -312,7 +312,7 @@ RunMat uses a tiered CPU runtime plus a fusion engine that automatically picks C
 | 🎨 runmat-plot       | Plotting layer                           | Interactive 2D/3D plots; some advanced plot types still in progress |
 | 🌐 runmat-wasm       | WebAssembly build of the runtime         | Runs in any browser; powers the sandbox at runmat.com               |
 | 📸 runmat-snapshot   | Fast startup snapshots                   | Binary blob serialization / restore                                 |
-| 🧰 runmat-runtime    | Core runtime + 300+ builtin functions    | BLAS/LAPACK integration and other CPU/GPU-accelerated operations    |
+| 🧰 runmat-runtime    | Core runtime + 330+ builtin functions    | BLAS/LAPACK integration and other CPU/GPU-accelerated operations    |
 
 
 ### Why this matters
@@ -370,7 +370,7 @@ For more details, see [Introduction to RunMat GPU](https://runmat.com/docs/accel
 RunMat follows a **fast-by-default runtime, open extension model** philosophy:
 
 - **High-fidelity language coverage**: Core MATLAB syntax, operators, control flow, OOP, and indexing — not a subset, not a new language
-- **Extensive built-ins**: 300+ functions covering core MATLAB built-ins, with more added continuously
+- **Extensive built-ins**: 330+ functions covering core MATLAB built-ins, with more added continuously
 - **Tiered execution**: VM interpreter for fast startup, Turbine JIT for hot code
 - **GPU-first math**: Fusion engine automatically turns MATLAB code into fast GPU workloads
 - **Single portable binary**: One static binary includes the runtime, GPU engine, and plotting — fast startup, modern CLI, Jupyter kernel support

--- a/website/content/docs.ts
+++ b/website/content/docs.ts
@@ -208,7 +208,7 @@ export const docsTree: DocsNode[] = [
           ogDescription: "How RunMat unifies filesystem access across native and browser runtimes.",
         },
       },
-      { title: "Lexer", slug: ["internals", "lexer"], file: "crates/runmat-lexer/README.md", seo: { description: "Tokenizer for MATLAB/Octave with contextual apostrophe and section markers.", keywords: ["lexer", "tokens", "logos", "MATLAB"] } },
+      // Lexer entry removed pending compiler docs rewrite; crate README was deleted in fbd1d97f (lexer crate split).
       { title: "Parser", slug: ["internals", "parser"], file: "crates/runmat-parser/README.md", seo: { description: "Precedence-based parser for MATLAB/Octave with statements, OOP, and command-form.", keywords: ["parser", "AST", "MATLAB", "Octave"] } },
       { title: "HIR", slug: ["internals", "hir"], file: "crates/runmat-hir/README.md", seo: { description: "High-level IR with flow-sensitive inference and class/import validations.", keywords: ["HIR", "type inference", "SSA", "MATLAB"] } },
       // Additional VM internals pages can be added here when dedicated docs are promoted.

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -74,6 +74,15 @@ const nextConfig: NextConfig = {
         permanent: false,
       },
 
+      // Lexer docs — crate README was deleted in the lexer crate split (fbd1d97f) and
+      // replacement is pending the compiler docs rewrite. Temporary so Google re-crawls
+      // once the canonical destination exists.
+      {
+        source: '/docs/internals/lexer',
+        destination: '/docs/architecture',
+        permanent: false,
+      },
+
       // Raw .md file URLs -> correct doc routes
       {
         source: '/CLI.md',


### PR DESCRIPTION
…creasing built-in functions to 330. Adjust website routing for lexer documentation and remove lexer entry pending compiler docs rewrite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates plus a non-permanent redirect to avoid a broken docs route after the lexer README removal.
> 
> **Overview**
> Updates `README.md` messaging for the v0.4 pre-release, expands the plotting feature description, and bumps the advertised builtin count from **300+ → 330+**.
> 
> Removes the lexer page from the website docs navigation (`website/content/docs.ts`) and adds a temporary redirect from `'/docs/internals/lexer'` to `'/docs/architecture'` in `website/next.config.ts` to handle the missing lexer README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5101c9f5fff1f4f2ab889c2e41c45f5daa3f9b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->