### PR TITLE
Add GPU-resident gradient builtin

### DIFF
--- a/bindings/ts/src/builtins.ts
+++ b/bindings/ts/src/builtins.ts
@@ -2,7 +2,9 @@ export type BuiltinDocExample = {
   description: string;
   input: string;
   output?: string;
+  image?: string;
   image_webp?: string;
+  matlab_script?: string;
 };
 
 export type BuiltinDocFAQ = {
@@ -13,6 +15,7 @@ export type BuiltinDocFAQ = {
 export type BuiltinDocLink = {
   label: string;
   url: string;
+  thumbnail?: string;
 };
 
 export type BuiltinDocSyntax = {

--- a/crates/runmat-accelerate-api/src/lib.rs
+++ b/crates/runmat-accelerate-api/src/lib.rs
@@ -1942,6 +1942,14 @@ pub trait AccelProvider: Send + Sync {
     ) -> anyhow::Result<GpuTensorHandle> {
         Err(anyhow::anyhow!("diff_dim not supported by provider"))
     }
+    fn gradient_dim(
+        &self,
+        _handle: &GpuTensorHandle,
+        _dim: usize,
+        _spacing: f64,
+    ) -> anyhow::Result<GpuTensorHandle> {
+        Err(anyhow::anyhow!("gradient_dim not supported by provider"))
+    }
     /// Perform an in-place FFT along a zero-based dimension, optionally padding/truncating to `len`.
     fn fft_dim<'a>(
         &'a self,

--- a/crates/runmat-accelerate/src/backend/wgpu/dispatch/common.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/dispatch/common.rs
@@ -15,6 +15,11 @@ pub fn noop_then_poll(device: &wgpu::Device, pipeline: &wgpu::ComputePipeline) {
 
 pub fn submit(device: &wgpu::Device, queue: &wgpu::Queue, enc: wgpu::CommandEncoder) {
     queue.submit(Some(enc.finish()));
+    #[cfg(target_arch = "wasm32")]
+    {
+        device.poll(wgpu::Maintain::Poll);
+    }
+    #[cfg(not(target_arch = "wasm32"))]
     device.poll(wgpu::Maintain::Wait);
 }
 

--- a/crates/runmat-accelerate/src/backend/wgpu/dispatch/gradient.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/dispatch/gradient.rs
@@ -1,0 +1,25 @@
+use super::common::submit;
+
+pub fn run(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    pipeline: &wgpu::ComputePipeline,
+    bind_group: &wgpu::BindGroup,
+    workgroups_x: u32,
+) {
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("runmat-gradient-encoder"),
+    });
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("runmat-gradient-pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, bind_group, &[]);
+        if workgroups_x > 0 {
+            pass.dispatch_workgroups(workgroups_x, 1, 1);
+        }
+    }
+    submit(device, queue, encoder);
+}

--- a/crates/runmat-accelerate/src/backend/wgpu/dispatch/mod.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/dispatch/mod.rs
@@ -10,6 +10,7 @@ pub mod fft;
 pub mod filter;
 pub mod find;
 pub mod flip;
+pub mod gradient;
 pub mod image_normalize;
 pub mod imfilter;
 pub mod ind2sub;

--- a/crates/runmat-accelerate/src/backend/wgpu/params.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/params.rs
@@ -79,6 +79,14 @@ impl PackedI32 {
     }
 }
 
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Pod, Zeroable, Default)]
+pub struct PackedU32(pub [u32; 4]);
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Pod, Zeroable, Default)]
+pub struct PackedF32(pub [f32; 4]);
+
 pub const PERMUTE_MAX_RANK: usize = 128;
 
 #[repr(C)]
@@ -149,6 +157,25 @@ pub struct DiffParams {
     pub total_out: u32,
     pub total_in: u32,
     pub _pad: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+pub struct GradientParamsF64 {
+    pub stride_before: u32,
+    pub segment_len: u32,
+    pub block: u32,
+    pub total: u32,
+    pub spacing: f64,
+    pub _pad0: f64,
+    pub _pad1: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+pub struct GradientParamsF32 {
+    pub meta0: PackedU32,
+    pub meta1: PackedF32,
 }
 
 #[repr(C)]

--- a/crates/runmat-accelerate/src/backend/wgpu/params.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/params.rs
@@ -159,7 +159,7 @@ pub struct DiffParams {
     pub _pad: u32,
 }
 
-#[repr(C)]
+#[repr(C, align(16))]
 #[derive(Clone, Copy, Pod, Zeroable)]
 pub struct GradientParamsF64 {
     pub stride_before: u32,
@@ -169,6 +169,7 @@ pub struct GradientParamsF64 {
     pub spacing: f64,
     pub _pad0: f64,
     pub _pad1: f64,
+    pub _pad2: f64,
 }
 
 #[repr(C)]

--- a/crates/runmat-accelerate/src/backend/wgpu/pipelines.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/pipelines.rs
@@ -63,6 +63,8 @@ const FFT_BLUESTEIN_FINALIZE_SHADER_F32: &str =
     crate::backend::wgpu::shaders::fft::FFT_BLUESTEIN_FINALIZE_SHADER_F32;
 const DIFF_SHADER_F64: &str = crate::backend::wgpu::shaders::diff::DIFF_SHADER_F64;
 const DIFF_SHADER_F32: &str = crate::backend::wgpu::shaders::diff::DIFF_SHADER_F32;
+const GRADIENT_SHADER_F64: &str = crate::backend::wgpu::shaders::gradient::GRADIENT_SHADER_F64;
+const GRADIENT_SHADER_F32: &str = crate::backend::wgpu::shaders::gradient::GRADIENT_SHADER_F32;
 const CUMSUM_SHADER_F64: &str = crate::backend::wgpu::shaders::scan::CUMSUM_SHADER_F64;
 const CUMSUM_SHADER_F32: &str = crate::backend::wgpu::shaders::scan::CUMSUM_SHADER_F32;
 const REPMAT_SHADER_F64: &str = crate::backend::wgpu::shaders::repmat::REPMAT_SHADER_F64;
@@ -214,6 +216,7 @@ pub struct WgpuPipelines {
     pub permute: PipelineBundle,
     pub flip: PipelineBundle,
     pub diff: PipelineBundle,
+    pub gradient: PipelineBundle,
     pub conv1d: PipelineBundle,
     pub filter: PipelineBundle,
     pub cumsum: PipelineBundle,
@@ -451,6 +454,22 @@ impl WgpuPipelines {
             match precision {
                 NumericPrecision::F64 => DIFF_SHADER_F64,
                 NumericPrecision::F32 => DIFF_SHADER_F32,
+            },
+        );
+
+        let gradient = create_pipeline(
+            device,
+            "runmat-gradient-layout",
+            "runmat-gradient-shader",
+            "runmat-gradient-pipeline",
+            vec![
+                storage_read_entry(0),
+                storage_read_write_entry(1),
+                uniform_entry(2),
+            ],
+            match precision {
+                NumericPrecision::F64 => GRADIENT_SHADER_F64,
+                NumericPrecision::F32 => GRADIENT_SHADER_F32,
             },
         );
 
@@ -1435,6 +1454,7 @@ impl WgpuPipelines {
             permute,
             flip,
             diff,
+            gradient,
             conv1d,
             filter,
             cumsum,

--- a/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
@@ -87,10 +87,10 @@ use crate::backend::wgpu::config::{
 };
 use crate::backend::wgpu::params::{
     BandwidthParams, Conv1dParams, CummaxParams, CumminParams, CumprodParams, CumsumParams,
-    DiffParams, FilterParams, ImageNormalizeUniforms, LinearGatherParams, LinearScatterParams,
-    QrPowerIterParams, SymmetryParamsF32, SymmetryParamsF64, SyrkParams, IMAGE_NORMALIZE_FLAG_BIAS,
-    IMAGE_NORMALIZE_FLAG_GAIN, IMAGE_NORMALIZE_FLAG_GAMMA, SYRK_FLAG_ACCUMULATE,
-    SYRK_FLAG_FILL_BOTH,
+    DiffParams, FilterParams, GradientParamsF32, GradientParamsF64, ImageNormalizeUniforms,
+    LinearGatherParams, LinearScatterParams, QrPowerIterParams, SymmetryParamsF32,
+    SymmetryParamsF64, SyrkParams, IMAGE_NORMALIZE_FLAG_BIAS, IMAGE_NORMALIZE_FLAG_GAIN,
+    IMAGE_NORMALIZE_FLAG_GAMMA, SYRK_FLAG_ACCUMULATE, SYRK_FLAG_FILL_BOTH,
 };
 use crate::backend::wgpu::pipelines::{ImageNormalizeBootstrap, WgpuPipelines};
 use crate::backend::wgpu::residency::{BufferResidency, BufferUsageClass};
@@ -1387,6 +1387,24 @@ fn normalize_concat_shape(mut shape: Vec<usize>, dim_zero: usize) -> Vec<usize> 
         shape.pop();
     }
     normalize_scalar_shape(&shape)
+}
+
+fn normalize_gradient_shape(shape: &[usize], len: usize) -> Vec<usize> {
+    if shape.is_empty() {
+        if len == 0 {
+            Vec::new()
+        } else {
+            vec![1, 1]
+        }
+    } else if shape.len() == 1 {
+        if shape[0] == 1 {
+            vec![1, 1]
+        } else {
+            vec![1, shape[0]]
+        }
+    } else {
+        shape.to_vec()
+    }
 }
 
 fn conv1d_output_shape(len: usize, orientation: ProviderConvOrientation) -> Vec<usize> {
@@ -7026,6 +7044,141 @@ impl WgpuProvider {
             }
         }
         Ok(current)
+    }
+
+    pub(crate) fn gradient_exec(
+        &self,
+        handle: &GpuTensorHandle,
+        dim: usize,
+        spacing: f64,
+    ) -> Result<GpuTensorHandle> {
+        let entry = self.get_entry(handle)?;
+
+        ensure!(
+            entry.storage == GpuTensorStorage::Real,
+            "gradient: complex GPU gradients are not implemented"
+        );
+
+        let mut ext_shape = normalize_gradient_shape(&entry.shape, entry.len);
+        if ext_shape.is_empty() {
+            ext_shape = vec![0, 0];
+        }
+        while ext_shape.len() <= dim {
+            ext_shape.push(1);
+        }
+
+        let len_dim = ext_shape[dim];
+        let mut out_shape = normalize_gradient_shape(&entry.shape, entry.len);
+        if out_shape.is_empty() {
+            out_shape = vec![0, 0];
+        }
+        while out_shape.len() <= dim {
+            out_shape.push(1);
+        }
+
+        let out_buffer = self.create_storage_buffer(entry.len, "runmat-gradient-out");
+        if entry.len == 0 {
+            return Ok(self.register_existing_buffer(out_buffer, out_shape, 0));
+        }
+
+        let stride_before = if dim == 0 {
+            1usize
+        } else {
+            product_checked(&ext_shape[..dim])
+                .ok_or_else(|| anyhow!("gradient: stride computation overflow"))?
+                .max(1)
+        };
+        let stride_after = if dim + 1 >= ext_shape.len() {
+            1usize
+        } else {
+            product_checked(&ext_shape[dim + 1..])
+                .ok_or_else(|| anyhow!("gradient: stride computation overflow"))?
+                .max(1)
+        };
+
+        let expected_len = stride_before
+            .checked_mul(len_dim.max(1))
+            .and_then(|v| v.checked_mul(stride_after))
+            .ok_or_else(|| anyhow!("gradient: tensor size exceeds GPU limits"))?;
+        ensure!(
+            expected_len == entry.len,
+            "gradient: tensor shape mismatch (expected {} elements, got {})",
+            expected_len,
+            entry.len
+        );
+
+        let block = stride_before
+            .checked_mul(len_dim.max(1))
+            .ok_or_else(|| anyhow!("gradient: block size exceeds GPU limits"))?;
+        ensure!(
+            len_dim <= u32::MAX as usize
+                && stride_before <= u32::MAX as usize
+                && block <= u32::MAX as usize
+                && entry.len <= u32::MAX as usize,
+            "gradient: tensor exceeds GPU kernel limits"
+        );
+
+        let params_buffer = match self.precision {
+            NumericPrecision::F64 => self.uniform_buffer(
+                &GradientParamsF64 {
+                    stride_before: stride_before as u32,
+                    segment_len: len_dim as u32,
+                    block: block as u32,
+                    total: entry.len as u32,
+                    spacing,
+                    _pad0: 0.0,
+                    _pad1: 0.0,
+                },
+                "runmat-gradient-params",
+            ),
+            NumericPrecision::F32 => self.uniform_buffer(
+                &GradientParamsF32 {
+                    meta0: crate::backend::wgpu::params::PackedU32([
+                        stride_before as u32,
+                        len_dim as u32,
+                        block as u32,
+                        entry.len as u32,
+                    ]),
+                    meta1: crate::backend::wgpu::params::PackedF32([spacing as f32, 0.0, 0.0, 0.0]),
+                },
+                "runmat-gradient-params",
+            ),
+        };
+
+        let bind_group = self
+            .device_ref()
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("runmat-gradient-bind"),
+                layout: &self.pipelines.gradient.layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: entry.buffer.as_ref().as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: out_buffer.as_ref().as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: params_buffer.as_entire_binding(),
+                    },
+                ],
+            });
+
+        let workgroups = crate::backend::wgpu::dispatch::common::dispatch_size(
+            entry.len as u32,
+            crate::backend::wgpu::config::WORKGROUP_SIZE,
+        );
+        crate::backend::wgpu::dispatch::gradient::run(
+            self.device_ref(),
+            self.queue_ref(),
+            &self.pipelines.gradient.pipeline,
+            &bind_group,
+            workgroups,
+        );
+
+        Ok(self.register_existing_buffer(out_buffer, out_shape, entry.len))
     }
 
     pub(crate) fn repmat_exec(
@@ -14465,6 +14618,15 @@ impl AccelProvider for WgpuProvider {
         dim: usize,
     ) -> Result<GpuTensorHandle> {
         self.diff_exec(handle, dim, order)
+    }
+
+    fn gradient_dim(
+        &self,
+        handle: &GpuTensorHandle,
+        dim: usize,
+        spacing: f64,
+    ) -> Result<GpuTensorHandle> {
+        self.gradient_exec(handle, dim, spacing)
     }
 
     fn cumsum_scan(

--- a/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
@@ -7114,6 +7114,7 @@ impl WgpuProvider {
                     spacing,
                     _pad0: 0.0,
                     _pad1: 0.0,
+                    _pad2: 0.0,
                 },
                 "runmat-gradient-params",
             ),

--- a/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
@@ -54,7 +54,7 @@ use runmat_runtime::builtins::math::linalg::structure::ishermitian::ishermitian_
 use runmat_runtime::builtins::math::linalg::structure::issymmetric::ensure_matrix_shape as ensure_symmetry_shape;
 use runmat_runtime::builtins::math::linalg::structure::symrcm::symrcm_host_real_data;
 use runmat_runtime::builtins::math::poly::polyfit::polyfit_host_real_for_provider;
-use runmat_runtime::builtins::math::reduction::compute_median_inplace;
+use runmat_runtime::builtins::math::reduction::{compute_median_inplace, matlab_gradient_shape};
 use runmat_runtime::RuntimeError;
 use runmat_time::Instant;
 use serde::{Deserialize, Serialize};
@@ -1390,21 +1390,7 @@ fn normalize_concat_shape(mut shape: Vec<usize>, dim_zero: usize) -> Vec<usize> 
 }
 
 fn normalize_gradient_shape(shape: &[usize], len: usize) -> Vec<usize> {
-    if shape.is_empty() {
-        if len == 0 {
-            Vec::new()
-        } else {
-            vec![1, 1]
-        }
-    } else if shape.len() == 1 {
-        if shape[0] == 1 {
-            vec![1, 1]
-        } else {
-            vec![1, shape[0]]
-        }
-    } else {
-        shape.to_vec()
-    }
+    matlab_gradient_shape(shape, len)
 }
 
 fn conv1d_output_shape(len: usize, orientation: ProviderConvOrientation) -> Vec<usize> {

--- a/crates/runmat-accelerate/src/backend/wgpu/shaders/gradient.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/shaders/gradient.rs
@@ -11,6 +11,7 @@ struct GradientParams {
     spacing: f64,
     _pad0: f64,
     _pad1: f64,
+    _pad2: f64,
 };
 
 @group(0) @binding(0) var<storage, read> Input: Tensor;

--- a/crates/runmat-accelerate/src/backend/wgpu/shaders/gradient.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/shaders/gradient.rs
@@ -1,0 +1,109 @@
+pub const GRADIENT_SHADER_F64: &str = r#"
+struct Tensor {
+    data: array<f64>,
+};
+
+struct GradientParams {
+    stride_before: u32,
+    segment_len: u32,
+    block: u32,
+    total: u32,
+    spacing: f64,
+    _pad0: f64,
+    _pad1: f64,
+};
+
+@group(0) @binding(0) var<storage, read> Input: Tensor;
+@group(0) @binding(1) var<storage, read_write> Output: Tensor;
+@group(0) @binding(2) var<uniform> params: GradientParams;
+
+@compute @workgroup_size(@WG@)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if (idx >= params.total) {
+        return;
+    }
+    if (params.segment_len <= 1u) {
+        Output.data[idx] = 0.0;
+        return;
+    }
+
+    let block = params.block;
+    let after = idx / block;
+    let within = idx % block;
+    let before = within % params.stride_before;
+    let k = within / params.stride_before;
+    let base = after * block;
+    let center = base + before + k * params.stride_before;
+
+    if (k == 0u) {
+        let right = center + params.stride_before;
+        Output.data[idx] = (Input.data[right] - Input.data[center]) / params.spacing;
+        return;
+    }
+    if (k + 1u == params.segment_len) {
+        let left = center - params.stride_before;
+        Output.data[idx] = (Input.data[center] - Input.data[left]) / params.spacing;
+        return;
+    }
+
+    let left = center - params.stride_before;
+    let right = center + params.stride_before;
+    Output.data[idx] = (Input.data[right] - Input.data[left]) / (2.0 * params.spacing);
+}
+"#;
+
+pub const GRADIENT_SHADER_F32: &str = r#"
+struct Tensor {
+    data: array<f32>,
+};
+
+struct GradientParams {
+    meta0: vec4<u32>,
+    meta1: vec4<f32>,
+};
+
+@group(0) @binding(0) var<storage, read> Input: Tensor;
+@group(0) @binding(1) var<storage, read_write> Output: Tensor;
+@group(0) @binding(2) var<uniform> params: GradientParams;
+
+@compute @workgroup_size(@WG@)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    let stride_before = params.meta0.x;
+    let segment_len = params.meta0.y;
+    let block = params.meta0.z;
+    let total = params.meta0.w;
+    let spacing = params.meta1.x;
+
+    if (idx >= total) {
+        return;
+    }
+    if (segment_len <= 1u) {
+        Output.data[idx] = 0.0;
+        return;
+    }
+
+    let after = idx / block;
+    let within = idx % block;
+    let before = within % stride_before;
+    let k = within / stride_before;
+    let base = after * block;
+    let center = base + before + k * stride_before;
+
+    if (k == 0u) {
+        let right = center + stride_before;
+        Output.data[idx] = (Input.data[right] - Input.data[center]) / spacing;
+        return;
+    }
+    if (k + 1u == segment_len) {
+        let left = center - stride_before;
+        Output.data[idx] = (Input.data[center] - Input.data[left]) / spacing;
+        return;
+    }
+
+    let left = center - stride_before;
+    let right = center + stride_before;
+    Output.data[idx] = (Input.data[right] - Input.data[left]) / (2.0 * spacing);
+}
+"#;

--- a/crates/runmat-accelerate/src/backend/wgpu/shaders/mod.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/shaders/mod.rs
@@ -10,6 +10,7 @@ pub mod fft;
 pub mod filter;
 pub mod find;
 pub mod flip;
+pub mod gradient;
 pub mod image_normalize;
 pub mod image_normalize_stub;
 pub mod imfilter;

--- a/crates/runmat-accelerate/src/simple_provider.rs
+++ b/crates/runmat-accelerate/src/simple_provider.rs
@@ -41,8 +41,9 @@ use runmat_runtime::builtins::math::linalg::structure::bandwidth::bandwidth_host
 use runmat_runtime::builtins::math::linalg::structure::ishermitian::ishermitian_host_real_data;
 use runmat_runtime::builtins::math::linalg::structure::issymmetric::issymmetric_host_real_data;
 use runmat_runtime::builtins::math::linalg::structure::symrcm::symrcm_host_real_data;
-use runmat_runtime::builtins::math::reduction::compute_median_inplace;
-use runmat_runtime::builtins::math::reduction::diff_tensor_host;
+use runmat_runtime::builtins::math::reduction::{
+    compute_median_inplace, diff_tensor_host, gradient_real_tensor_host,
+};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -3949,6 +3950,27 @@ impl AccelProvider for InProcessProvider {
         let diffed =
             diff_tensor_host(tensor, order, Some(dim + 1)).map_err(|e| anyhow!("diff_dim: {e}"))?;
         let Tensor { data, shape, .. } = diffed;
+        Ok(self.allocate_tensor(data, shape))
+    }
+
+    fn gradient_dim(
+        &self,
+        handle: &GpuTensorHandle,
+        dim: usize,
+        spacing: f64,
+    ) -> Result<GpuTensorHandle> {
+        let data = {
+            let guard = registry().lock().unwrap();
+            guard
+                .get(&handle.buffer_id)
+                .ok_or_else(|| anyhow!("gradient_dim: unknown tensor handle {}", handle.buffer_id))?
+                .clone()
+        };
+        let tensor =
+            Tensor::new(data, handle.shape.clone()).map_err(|e| anyhow!("gradient_dim: {e}"))?;
+        let gradiented = gradient_real_tensor_host(tensor, dim + 1, spacing)
+            .map_err(|e| anyhow!("gradient_dim: {e}"))?;
+        let Tensor { data, shape, .. } = gradiented;
         Ok(self.allocate_tensor(data, shape))
     }
 

--- a/crates/runmat-runtime/src/builtins/builtins-json/gradient.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/gradient.json
@@ -1,0 +1,119 @@
+{
+  "title": "gradient",
+  "category": "math/reduction",
+  "keywords": [
+    "gradient",
+    "numerical gradient",
+    "finite difference",
+    "derivative",
+    "gpu"
+  ],
+  "summary": "Numerical gradients using central differences with MATLAB-compatible output ordering.",
+  "references": [],
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [
+      "f32",
+      "f64"
+    ],
+    "broadcasting": "matlab",
+    "notes": "Scalar-spacing gradients call the provider's `gradient_dim` hook and can stay GPU-resident. Coordinate-vector spacing falls back to the host in this implementation."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 1,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::math::reduction::gradient::tests",
+    "integration": "builtins::math::reduction::gradient::tests::gradient_gpu_scalar_spacing_matches_cpu_and_stays_resident"
+  },
+  "description": "`gradient(F)` computes numerical derivatives with central differences in the interior and one-sided differences at the boundaries. For matrices, a single output returns the derivative along columns, while multiple outputs follow MATLAB ordering: first columns, then rows, then higher dimensions.",
+  "behaviors": [
+    "`gradient(F)` chooses the first non-singleton dimension for vectors and returns the column-direction derivative for matrices.",
+    "`[FX, FY] = gradient(F)` on a matrix returns `FX` for dimension 2 (across columns) and `FY` for dimension 1 (down rows), matching MATLAB.",
+    "`gradient(F, h)` applies the same scalar spacing to every returned dimension.",
+    "`gradient(F, hx, hy, ...)` accepts one scalar spacing per output dimension. In v1, each spacing must be scalar.",
+    "Interior points use central differences `(f(i+1) - f(i-1)) / (2*h)`, while the first and last points use one-sided differences.",
+    "Real, logical, and scalar numeric inputs promote through the standard tensor conversion path. Complex host inputs are supported by differentiating the real and imaginary parts independently.",
+    "When a GPU tensor is passed and the active provider implements `gradient_dim`, scalar-spacing gradients stay resident on the device. Complex GPU tensors and coordinate-vector spacing currently gather to the host."
+  ],
+  "examples": [
+    {
+      "description": "Differentiating a row vector",
+      "input": "v = [1 4 9];\ng = gradient(v)",
+      "output": "g = [3 4 5]"
+    },
+    {
+      "description": "Requesting both matrix gradient components",
+      "input": "A = [1 2; 3 4];\n[FX, FY] = gradient(A)",
+      "output": "FX =\n     1     1\n     1     1\n\nFY =\n     2     2\n     2     2"
+    },
+    {
+      "description": "Using scalar spacing on GPU data",
+      "input": "G = gpuArray(single([1 4 9]));\nD = gradient(G, 2);\nout = gather(D)",
+      "output": "out = single([1.5 2.0 2.5])"
+    },
+    {
+      "description": "Feeding `gradient` into a vector-field plot",
+      "input": "[X, Y] = meshgrid(linspace(-2, 2, 25), linspace(-2, 2, 25));\nZ = X .* exp(-X.^2 - Y.^2);\n[DX, DY] = gradient(Z, X(1,2)-X(1,1), Y(2,1)-Y(1,1));\nquiver(X, Y, DX, DY)"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What finite-difference stencil does `gradient` use?",
+      "answer": "RunMat matches MATLAB's shape-preserving behavior: central differences in the interior and first-order one-sided differences at the boundaries."
+    },
+    {
+      "question": "Why does a matrix return the x-direction first?",
+      "answer": "MATLAB defines the first matrix output along dimension 2 (columns), then dimension 1 (rows). RunMat preserves that ordering so plotting workflows like `quiver` line up correctly."
+    },
+    {
+      "question": "Can I pass coordinate vectors for spacing?",
+      "answer": "Not in this version. `gradient(F, X)` and vector-valued `hx`, `hy`, ... are reserved for a follow-up implementation."
+    },
+    {
+      "question": "Does `gradient` support GPU arrays?",
+      "answer": "Yes for default spacing and scalar spacings. With an active provider such as WGPU, the scalar-spacing path stays on the GPU via the `gradient_dim` hook."
+    },
+    {
+      "question": "Do complex inputs work?",
+      "answer": "Yes on the host. Complex GPU tensors currently gather to the host before differencing."
+    }
+  ],
+  "links": [
+    {
+      "label": "diff",
+      "url": "./diff"
+    },
+    {
+      "label": "meshgrid",
+      "url": "./meshgrid"
+    },
+    {
+      "label": "quiver",
+      "url": "./quiver"
+    },
+    {
+      "label": "gpuArray",
+      "url": "./gpuarray"
+    },
+    {
+      "label": "gather",
+      "url": "./gather"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/math/reduction/gradient.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/math/reduction/gradient.rs"
+  },
+  "gpu_residency": "Manual `gpuArray` promotion is optional. When a scalar-spacing gradient starts with GPU-resident data and the active provider implements `gradient_dim`, RunMat keeps the result on the device. If the provider lacks the hook, if spacing is specified with coordinate vectors, or if the input is complex GPU data, RunMat gathers to the host and preserves MATLAB-compatible results.",
+  "gpu_behavior": [
+    "The WGPU backend implements `gradient_dim`, so scalar-spacing gradients execute on the device and return GPU tensors for both single-output and multi-output calls.",
+    "The simple in-process provider also exposes `gradient_dim`, allowing provider-level parity tests without requiring a physical GPU.",
+    "Coordinate-vector spacing is intentionally out of scope for this version and falls back to host evaluation."
+  ]
+}

--- a/crates/runmat-runtime/src/builtins/math/reduction/gradient.rs
+++ b/crates/runmat-runtime/src/builtins/math/reduction/gradient.rs
@@ -293,7 +293,7 @@ fn value_len(value: &Value) -> usize {
     }
 }
 
-fn matlab_gradient_shape(shape: &[usize], len: usize) -> Vec<usize> {
+pub fn matlab_gradient_shape(shape: &[usize], len: usize) -> Vec<usize> {
     if shape.is_empty() {
         if len == 0 {
             Vec::new()

--- a/crates/runmat-runtime/src/builtins/math/reduction/gradient.rs
+++ b/crates/runmat-runtime/src/builtins/math/reduction/gradient.rs
@@ -357,13 +357,19 @@ pub fn gradient_real_tensor_host(
     } = tensor;
     let dim_index = dim.saturating_sub(1);
     let mut shape = matlab_gradient_shape(&shape, data.len());
-    while shape.len() <= dim_index {
-        shape.push(1);
-    }
 
     if data.is_empty() {
-        return Tensor::new_with_dtype(Vec::new(), shape, dtype)
+        // Return early before the `push(1)` padding loop: that loop would give a
+        // shape like [1] or [1,1] whose product is 1 ≠ 0, violating Tensor's
+        // invariant. Use the normalised shape directly, falling back to [0,0] if
+        // matlab_gradient_shape returned an empty vec (untyped empty tensor).
+        let empty_shape = if shape.is_empty() { vec![0, 0] } else { shape };
+        return Tensor::new_with_dtype(Vec::new(), empty_shape, dtype)
             .map_err(|e| gradient_error(format!("gradient: {e}")));
+    }
+
+    while shape.len() <= dim_index {
+        shape.push(1);
     }
 
     let mut ext_shape = shape.clone();
@@ -417,13 +423,17 @@ pub fn gradient_complex_tensor_host(
     let ComplexTensor { data, shape, .. } = tensor;
     let dim_index = dim.saturating_sub(1);
     let mut shape = matlab_gradient_shape(&shape, data.len());
-    while shape.len() <= dim_index {
-        shape.push(1);
-    }
 
     if data.is_empty() {
-        return ComplexTensor::new(Vec::new(), shape)
+        // Same fix as gradient_real_tensor_host: avoid padding the shape with 1s
+        // before the early return, which would produce product ≠ 0 for empty data.
+        let empty_shape = if shape.is_empty() { vec![0, 0] } else { shape };
+        return ComplexTensor::new(Vec::new(), empty_shape)
             .map_err(|e| gradient_error(format!("gradient: {e}")));
+    }
+
+    while shape.len() <= dim_index {
+        shape.push(1);
     }
 
     let mut ext_shape = shape.clone();

--- a/crates/runmat-runtime/src/builtins/math/reduction/gradient.rs
+++ b/crates/runmat-runtime/src/builtins/math/reduction/gradient.rs
@@ -1,0 +1,678 @@
+//! MATLAB-compatible `gradient` builtin with scalar-spacing GPU residency.
+
+use runmat_accelerate_api::{GpuTensorHandle, GpuTensorStorage};
+use runmat_builtins::{ComplexTensor, ResolveContext, Tensor, Type, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::gpu_helpers;
+use crate::builtins::common::random_args::complex_tensor_into_value;
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ProviderHook, ReductionNaN, ResidencyPolicy, ScalarType, ShapeRequirements,
+};
+use crate::builtins::common::tensor;
+use crate::builtins::math::type_resolvers::numeric_unary_type;
+use crate::{build_runtime_error, BuiltinResult, RuntimeError};
+
+const NAME: &str = "gradient";
+
+fn gradient_error(message: impl Into<String>) -> RuntimeError {
+    build_runtime_error(message).with_builtin(NAME).build()
+}
+
+fn gradient_type(args: &[Type], ctx: &ResolveContext) -> Type {
+    numeric_unary_type(args, ctx)
+}
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::math::reduction::gradient")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: "gradient",
+    op_kind: GpuOpKind::Custom("numerical-gradient"),
+    supported_precisions: &[ScalarType::F32, ScalarType::F64],
+    broadcast: BroadcastSemantics::Matlab,
+    provider_hooks: &[ProviderHook::Custom("gradient_dim")],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::NewHandle,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes:
+        "Providers may keep scalar-spacing gradients on device via `gradient_dim`; coordinate-vector spacing falls back to the host in this implementation.",
+};
+
+#[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::math::reduction::gradient")]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: "gradient",
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: false,
+    notes: "Gradient preserves input shape and uses edge-aware finite differences, so providers expose it through a custom sink hook.",
+};
+
+#[runtime_builtin(
+    name = "gradient",
+    category = "math/reduction",
+    summary = "Numerical gradients using central differences with MATLAB-compatible output ordering.",
+    keywords = "gradient,numerical gradient,finite difference,vector field,gpu",
+    accel = "gradient",
+    type_resolver(gradient_type),
+    builtin_path = "crate::builtins::math::reduction::gradient"
+)]
+async fn gradient_builtin(value: Value, rest: Vec<Value>) -> crate::BuiltinResult<Value> {
+    let requested_outputs = crate::output_count::current_output_count().unwrap_or(1);
+    if requested_outputs == 0 {
+        return Ok(Value::OutputList(Vec::new()));
+    }
+
+    let available_outputs = gradient_output_dims(value_shape(&value), value_len(&value));
+    if requested_outputs > available_outputs.len() {
+        return Err(gradient_error(format!(
+            "gradient: requested {requested_outputs} outputs, but input supports at most {}",
+            available_outputs.len()
+        )));
+    }
+
+    let spacings = parse_spacings(&rest, available_outputs.len()).await?;
+    let outputs =
+        evaluate_gradient_outputs(value, &available_outputs[..requested_outputs], &spacings)
+            .await?;
+
+    if crate::output_count::current_output_count().is_some() {
+        return Ok(Value::OutputList(outputs));
+    }
+
+    Ok(outputs
+        .into_iter()
+        .next()
+        .expect("single-output gradient result"))
+}
+
+async fn evaluate_gradient_outputs(
+    value: Value,
+    requested_dims: &[usize],
+    all_spacings: &[f64],
+) -> BuiltinResult<Vec<Value>> {
+    if let Value::GpuTensor(handle) = value {
+        return gradient_gpu_outputs(handle, requested_dims, all_spacings).await;
+    }
+
+    evaluate_host_gradient_outputs(value, requested_dims, all_spacings)
+}
+
+fn evaluate_host_gradient_outputs(
+    value: Value,
+    requested_dims: &[usize],
+    all_spacings: &[f64],
+) -> BuiltinResult<Vec<Value>> {
+    match value {
+        Value::Tensor(tensor) => {
+            let mut outputs = Vec::with_capacity(requested_dims.len());
+            for &dim in requested_dims {
+                let spacing = spacing_for_dim(dim, requested_dims, all_spacings);
+                outputs.push(tensor::tensor_into_value(gradient_real_tensor_host(
+                    tensor.clone(),
+                    dim,
+                    spacing,
+                )?));
+            }
+            Ok(outputs)
+        }
+        Value::LogicalArray(logical) => {
+            let tensor = tensor::logical_to_tensor(&logical).map_err(gradient_error)?;
+            let mut outputs = Vec::with_capacity(requested_dims.len());
+            for &dim in requested_dims {
+                let spacing = spacing_for_dim(dim, requested_dims, all_spacings);
+                outputs.push(tensor::tensor_into_value(gradient_real_tensor_host(
+                    tensor.clone(),
+                    dim,
+                    spacing,
+                )?));
+            }
+            Ok(outputs)
+        }
+        Value::Num(_) | Value::Int(_) | Value::Bool(_) => {
+            let tensor = tensor::value_into_tensor_for(NAME, value).map_err(gradient_error)?;
+            let mut outputs = Vec::with_capacity(requested_dims.len());
+            for &dim in requested_dims {
+                let spacing = spacing_for_dim(dim, requested_dims, all_spacings);
+                outputs.push(tensor::tensor_into_value(gradient_real_tensor_host(
+                    tensor.clone(),
+                    dim,
+                    spacing,
+                )?));
+            }
+            Ok(outputs)
+        }
+        Value::Complex(re, im) => {
+            let tensor = ComplexTensor {
+                data: vec![(re, im)],
+                shape: vec![1, 1],
+                rows: 1,
+                cols: 1,
+            };
+            let mut outputs = Vec::with_capacity(requested_dims.len());
+            for &dim in requested_dims {
+                let spacing = spacing_for_dim(dim, requested_dims, all_spacings);
+                outputs.push(complex_tensor_into_value(gradient_complex_tensor_host(
+                    tensor.clone(),
+                    dim,
+                    spacing,
+                )?));
+            }
+            Ok(outputs)
+        }
+        Value::ComplexTensor(tensor) => {
+            let mut outputs = Vec::with_capacity(requested_dims.len());
+            for &dim in requested_dims {
+                let spacing = spacing_for_dim(dim, requested_dims, all_spacings);
+                outputs.push(complex_tensor_into_value(gradient_complex_tensor_host(
+                    tensor.clone(),
+                    dim,
+                    spacing,
+                )?));
+            }
+            Ok(outputs)
+        }
+        other => Err(gradient_error(format!(
+            "gradient: unsupported input type {:?}; expected numeric or logical data",
+            other
+        ))),
+    }
+}
+
+async fn gradient_gpu_outputs(
+    handle: GpuTensorHandle,
+    requested_dims: &[usize],
+    all_spacings: &[f64],
+) -> BuiltinResult<Vec<Value>> {
+    if runmat_accelerate_api::handle_storage(&handle) == GpuTensorStorage::ComplexInterleaved {
+        let gathered = gpu_helpers::gather_value_async(&Value::GpuTensor(handle)).await?;
+        return evaluate_host_gradient_outputs(gathered, requested_dims, all_spacings);
+    }
+
+    if let Some(provider) = runmat_accelerate_api::provider() {
+        let mut outputs = Vec::with_capacity(requested_dims.len());
+        for &dim in requested_dims {
+            let spacing = spacing_for_dim(dim, requested_dims, all_spacings);
+            match provider.gradient_dim(&handle, dim.saturating_sub(1), spacing) {
+                Ok(device_result) => outputs.push(gpu_helpers::resident_gpu_value(device_result)),
+                Err(_) => {
+                    let gathered =
+                        gpu_helpers::gather_value_async(&Value::GpuTensor(handle)).await?;
+                    return evaluate_host_gradient_outputs(gathered, requested_dims, all_spacings);
+                }
+            }
+        }
+        return Ok(outputs);
+    }
+
+    let gathered = gpu_helpers::gather_value_async(&Value::GpuTensor(handle)).await?;
+    evaluate_host_gradient_outputs(gathered, requested_dims, all_spacings)
+}
+
+fn spacing_for_dim(dim: usize, available_dims: &[usize], spacings: &[f64]) -> f64 {
+    if spacings.len() == 1 {
+        return spacings[0];
+    }
+
+    let index = available_dims
+        .iter()
+        .position(|candidate| *candidate == dim)
+        .expect("spacing lookup requires matching dimension");
+    spacings[index]
+}
+
+async fn parse_spacings(args: &[Value], available_dims: usize) -> BuiltinResult<Vec<f64>> {
+    match args.len() {
+        0 => Ok(vec![1.0; available_dims]),
+        1 => {
+            let spacing = parse_scalar_spacing(&args[0]).await?;
+            Ok(vec![spacing; available_dims])
+        }
+        count if count == available_dims => {
+            let mut spacings = Vec::with_capacity(args.len());
+            for value in args {
+                spacings.push(parse_scalar_spacing(value).await?);
+            }
+            Ok(spacings)
+        }
+        _ => Err(gradient_error(format!(
+            "gradient: expected 0, 1, or {available_dims} scalar spacing arguments"
+        ))),
+    }
+}
+
+async fn parse_scalar_spacing(value: &Value) -> BuiltinResult<f64> {
+    match value {
+        Value::Tensor(tensor) if tensor.data.is_empty() => {
+            return Err(gradient_error(
+                "gradient: empty spacing arguments are not supported",
+            ))
+        }
+        _ => {}
+    }
+
+    let Some(spacing) = tensor::scalar_f64_from_value_async(value)
+        .await
+        .map_err(gradient_error)?
+    else {
+        return Err(gradient_error(
+            "gradient: only scalar spacings are supported in this implementation",
+        ));
+    };
+
+    if !spacing.is_finite() {
+        return Err(gradient_error("gradient: spacing must be finite"));
+    }
+    if spacing == 0.0 {
+        return Err(gradient_error("gradient: spacing must be nonzero"));
+    }
+    Ok(spacing)
+}
+
+fn value_shape(value: &Value) -> &[usize] {
+    match value {
+        Value::Tensor(tensor) => &tensor.shape,
+        Value::LogicalArray(logical) => &logical.shape,
+        Value::ComplexTensor(tensor) => &tensor.shape,
+        Value::GpuTensor(handle) => &handle.shape,
+        _ => &[],
+    }
+}
+
+fn value_len(value: &Value) -> usize {
+    match value {
+        Value::Tensor(tensor) => tensor.data.len(),
+        Value::LogicalArray(logical) => logical.data.len(),
+        Value::ComplexTensor(tensor) => tensor.data.len(),
+        Value::GpuTensor(handle) => product(&handle.shape),
+        _ => 1,
+    }
+}
+
+fn matlab_gradient_shape(shape: &[usize], len: usize) -> Vec<usize> {
+    if shape.is_empty() {
+        if len == 0 {
+            Vec::new()
+        } else {
+            vec![1, 1]
+        }
+    } else if shape.len() == 1 {
+        if shape[0] == 1 {
+            vec![1, 1]
+        } else {
+            vec![1, shape[0]]
+        }
+    } else {
+        shape.to_vec()
+    }
+}
+
+fn gradient_output_dims(shape: &[usize], len: usize) -> Vec<usize> {
+    let normalized_shape = matlab_gradient_shape(shape, len);
+    let mut ext_shape = if normalized_shape.is_empty() {
+        if len == 0 {
+            vec![0, 0]
+        } else {
+            vec![1, 1]
+        }
+    } else {
+        normalized_shape
+    };
+    if ext_shape.len() == 1 {
+        ext_shape.push(1);
+    }
+
+    if ext_shape.len() <= 2 {
+        let rows = ext_shape.first().copied().unwrap_or(1);
+        let cols = ext_shape.get(1).copied().unwrap_or(1);
+        if rows == 1 && cols == 1 {
+            vec![1]
+        } else if rows == 1 {
+            vec![2]
+        } else if cols == 1 {
+            vec![1]
+        } else {
+            vec![2, 1]
+        }
+    } else {
+        let mut dims = vec![2, 1];
+        for dim in 3..=ext_shape.len() {
+            dims.push(dim);
+        }
+        dims
+    }
+}
+
+pub fn gradient_real_tensor_host(
+    tensor: Tensor,
+    dim: usize,
+    spacing: f64,
+) -> BuiltinResult<Tensor> {
+    let Tensor {
+        data, shape, dtype, ..
+    } = tensor;
+    let dim_index = dim.saturating_sub(1);
+    let mut shape = matlab_gradient_shape(&shape, data.len());
+    while shape.len() <= dim_index {
+        shape.push(1);
+    }
+
+    if data.is_empty() {
+        return Tensor::new_with_dtype(Vec::new(), shape, dtype)
+            .map_err(|e| gradient_error(format!("gradient: {e}")));
+    }
+
+    let mut ext_shape = shape.clone();
+    while ext_shape.len() <= dim_index {
+        ext_shape.push(1);
+    }
+    let len_dim = ext_shape[dim_index];
+    let stride_before = if dim_index == 0 {
+        1usize
+    } else {
+        product(&ext_shape[..dim_index]).max(1)
+    };
+    let stride_after = if dim_index + 1 >= ext_shape.len() {
+        1usize
+    } else {
+        product(&ext_shape[dim_index + 1..]).max(1)
+    };
+
+    let mut out = vec![0.0; data.len()];
+    if len_dim > 1 {
+        let block = stride_before
+            .checked_mul(len_dim)
+            .ok_or_else(|| gradient_error("gradient: block size overflow"))?;
+        for after in 0..stride_after {
+            let base = after
+                .checked_mul(block)
+                .ok_or_else(|| gradient_error("gradient: indexing overflow"))?;
+            for before in 0..stride_before {
+                for k in 0..len_dim {
+                    let idx = base + before + k * stride_before;
+                    out[idx] = if k == 0 {
+                        (data[idx + stride_before] - data[idx]) / spacing
+                    } else if k + 1 == len_dim {
+                        (data[idx] - data[idx - stride_before]) / spacing
+                    } else {
+                        (data[idx + stride_before] - data[idx - stride_before]) / (2.0 * spacing)
+                    };
+                }
+            }
+        }
+    }
+
+    Tensor::new_with_dtype(out, shape, dtype).map_err(|e| gradient_error(format!("gradient: {e}")))
+}
+
+pub fn gradient_complex_tensor_host(
+    tensor: ComplexTensor,
+    dim: usize,
+    spacing: f64,
+) -> BuiltinResult<ComplexTensor> {
+    let ComplexTensor { data, shape, .. } = tensor;
+    let dim_index = dim.saturating_sub(1);
+    let mut shape = matlab_gradient_shape(&shape, data.len());
+    while shape.len() <= dim_index {
+        shape.push(1);
+    }
+
+    if data.is_empty() {
+        return ComplexTensor::new(Vec::new(), shape)
+            .map_err(|e| gradient_error(format!("gradient: {e}")));
+    }
+
+    let mut ext_shape = shape.clone();
+    while ext_shape.len() <= dim_index {
+        ext_shape.push(1);
+    }
+    let len_dim = ext_shape[dim_index];
+    let stride_before = if dim_index == 0 {
+        1usize
+    } else {
+        product(&ext_shape[..dim_index]).max(1)
+    };
+    let stride_after = if dim_index + 1 >= ext_shape.len() {
+        1usize
+    } else {
+        product(&ext_shape[dim_index + 1..]).max(1)
+    };
+
+    let mut out = vec![(0.0, 0.0); data.len()];
+    if len_dim > 1 {
+        let block = stride_before
+            .checked_mul(len_dim)
+            .ok_or_else(|| gradient_error("gradient: block size overflow"))?;
+        for after in 0..stride_after {
+            let base = after
+                .checked_mul(block)
+                .ok_or_else(|| gradient_error("gradient: indexing overflow"))?;
+            for before in 0..stride_before {
+                for k in 0..len_dim {
+                    let idx = base + before + k * stride_before;
+                    out[idx] = if k == 0 {
+                        scale_complex(
+                            sub_complex(data[idx + stride_before], data[idx]),
+                            1.0 / spacing,
+                        )
+                    } else if k + 1 == len_dim {
+                        scale_complex(
+                            sub_complex(data[idx], data[idx - stride_before]),
+                            1.0 / spacing,
+                        )
+                    } else {
+                        scale_complex(
+                            sub_complex(data[idx + stride_before], data[idx - stride_before]),
+                            0.5 / spacing,
+                        )
+                    };
+                }
+            }
+        }
+    }
+
+    ComplexTensor::new(out, shape).map_err(|e| gradient_error(format!("gradient: {e}")))
+}
+
+fn sub_complex(lhs: (f64, f64), rhs: (f64, f64)) -> (f64, f64) {
+    (lhs.0 - rhs.0, lhs.1 - rhs.1)
+}
+
+fn scale_complex(value: (f64, f64), scale: f64) -> (f64, f64) {
+    (value.0 * scale, value.1 * scale)
+}
+
+fn product(dims: &[usize]) -> usize {
+    dims.iter()
+        .copied()
+        .fold(1usize, |acc, value| acc.saturating_mul(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtins::common::test_support;
+    use futures::executor::block_on;
+    #[cfg(feature = "wgpu")]
+    use runmat_accelerate_api::AccelProvider;
+    #[cfg(feature = "wgpu")]
+    use runmat_accelerate_api::HostTensorView;
+    use runmat_builtins::{NumericDType, Tensor};
+
+    fn gradient_builtin(value: Value, rest: Vec<Value>) -> BuiltinResult<Value> {
+        block_on(super::gradient_builtin(value, rest))
+    }
+
+    #[test]
+    fn gradient_row_vector_returns_horizontal_derivative() {
+        let tensor = Tensor::new(vec![1.0, 4.0, 9.0], vec![1, 3]).unwrap();
+        let result = gradient_builtin(Value::Tensor(tensor), Vec::new()).expect("gradient");
+        assert_eq!(
+            result,
+            Value::Tensor(Tensor::new(vec![3.0, 4.0, 5.0], vec![1, 3]).unwrap())
+        );
+    }
+
+    #[test]
+    fn gradient_one_dimensional_tensor_is_treated_as_row_vector() {
+        let tensor = Tensor::new(vec![1.0, 4.0, 9.0], vec![3]).unwrap();
+        let result =
+            gradient_builtin(Value::Tensor(tensor), vec![Value::Num(2.0)]).expect("gradient");
+        match result {
+            Value::Tensor(out) => {
+                assert_eq!(out.shape, vec![1, 3]);
+                assert_eq!(out.data, vec![1.5, 2.0, 2.5]);
+            }
+            other => panic!("expected tensor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gradient_matrix_outputs_follow_matlab_order() {
+        let tensor = Tensor::new(vec![1.0, 3.0, 2.0, 4.0], vec![2, 2]).unwrap();
+        let _guard = crate::output_count::push_output_count(Some(2));
+        let result = gradient_builtin(Value::Tensor(tensor), Vec::new()).expect("gradient");
+        match result {
+            Value::OutputList(outputs) => {
+                let fx = test_support::gather(outputs[0].clone()).expect("fx");
+                let fy = test_support::gather(outputs[1].clone()).expect("fy");
+                assert_eq!(fx.data, vec![1.0, 1.0, 1.0, 1.0]);
+                assert_eq!(fy.data, vec![2.0, 2.0, 2.0, 2.0]);
+            }
+            other => panic!("expected output list, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gradient_scalar_spacing_scales_output() {
+        let tensor = Tensor::new(vec![1.0, 4.0, 9.0], vec![1, 3]).unwrap();
+        let result =
+            gradient_builtin(Value::Tensor(tensor), vec![Value::Num(2.0)]).expect("gradient");
+        match result {
+            Value::Tensor(out) => assert_eq!(out.data, vec![1.5, 2.0, 2.5]),
+            other => panic!("expected tensor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gradient_preserves_single_precision_host_tensor() {
+        let tensor =
+            Tensor::new_with_dtype(vec![1.0, 4.0, 9.0], vec![1, 3], NumericDType::F32).unwrap();
+        let result = gradient_builtin(Value::Tensor(tensor), Vec::new()).expect("gradient");
+        match result {
+            Value::Tensor(out) => assert_eq!(out.dtype, NumericDType::F32),
+            other => panic!("expected tensor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gradient_complex_host_supported() {
+        let tensor =
+            ComplexTensor::new(vec![(1.0, 1.0), (4.0, 3.0), (9.0, 6.0)], vec![1, 3]).unwrap();
+        let result = gradient_builtin(Value::ComplexTensor(tensor), Vec::new()).expect("gradient");
+        match result {
+            Value::ComplexTensor(out) => {
+                assert_eq!(out.data, vec![(3.0, 2.0), (4.0, 2.5), (5.0, 3.0)]);
+            }
+            other => panic!("expected complex tensor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gradient_rejects_coordinate_vector_spacing_in_v1() {
+        let tensor = Tensor::new(vec![1.0, 4.0, 9.0], vec![1, 3]).unwrap();
+        let spacing = Tensor::new(vec![0.0, 1.0, 2.0], vec![1, 3]).unwrap();
+        let err =
+            gradient_builtin(Value::Tensor(tensor), vec![Value::Tensor(spacing)]).unwrap_err();
+        assert!(err.message().contains("scalar"));
+    }
+
+    #[test]
+    fn gradient_rejects_too_many_outputs() {
+        let tensor = Tensor::new(vec![1.0, 2.0, 3.0], vec![3, 1]).unwrap();
+        let _guard = crate::output_count::push_output_count(Some(2));
+        let err = gradient_builtin(Value::Tensor(tensor), Vec::new()).unwrap_err();
+        assert!(err.message().contains("requested 2 outputs"));
+    }
+
+    #[test]
+    #[cfg(feature = "wgpu")]
+    fn gradient_gpu_scalar_spacing_matches_cpu_and_stays_resident() {
+        let _guard = test_support::accel_test_lock();
+        let Ok(provider) = runmat_accelerate::backend::wgpu::provider::register_wgpu_provider(
+            runmat_accelerate::backend::wgpu::provider::WgpuProviderOptions::default(),
+        ) else {
+            return;
+        };
+        let host =
+            Tensor::new_with_dtype(vec![1.0, 4.0, 9.0], vec![1, 3], NumericDType::F32).unwrap();
+        let view = HostTensorView {
+            data: &host.data,
+            shape: &host.shape,
+        };
+        let handle = provider.upload(&view).expect("upload");
+        let result =
+            gradient_builtin(Value::GpuTensor(handle), vec![Value::Num(2.0)]).expect("gradient");
+        match result {
+            Value::GpuTensor(out) => {
+                let gathered = test_support::gather(Value::GpuTensor(out)).expect("gather");
+                assert_eq!(gathered.data, vec![1.5, 2.0, 2.5]);
+                assert_eq!(gathered.dtype, NumericDType::F32);
+            }
+            other => panic!("expected gpu tensor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "wgpu")]
+    fn gradient_gpu_one_dimensional_shape_matches_matlab_row_vector_semantics() {
+        let _guard = test_support::accel_test_lock();
+        let Ok(provider) = runmat_accelerate::backend::wgpu::provider::register_wgpu_provider(
+            runmat_accelerate::backend::wgpu::provider::WgpuProviderOptions::default(),
+        ) else {
+            return;
+        };
+        let data = [1.0, 4.0, 9.0];
+        let shape = [3usize];
+        let view = HostTensorView {
+            data: &data,
+            shape: &shape,
+        };
+        let handle = provider.upload(&view).expect("upload");
+        let result =
+            gradient_builtin(Value::GpuTensor(handle), vec![Value::Num(2.0)]).expect("gradient");
+        let gathered = test_support::gather(result).expect("gather");
+        assert_eq!(gathered.shape, vec![1, 3]);
+        assert_eq!(gathered.data, vec![1.5, 2.0, 2.5]);
+    }
+
+    #[test]
+    #[cfg(feature = "wgpu")]
+    fn gradient_gpu_multi_output_uses_output_list() {
+        let _guard = test_support::accel_test_lock();
+        let Ok(provider) = runmat_accelerate::backend::wgpu::provider::register_wgpu_provider(
+            runmat_accelerate::backend::wgpu::provider::WgpuProviderOptions::default(),
+        ) else {
+            return;
+        };
+        let host = Tensor::new(vec![1.0, 3.0, 2.0, 4.0], vec![2, 2]).unwrap();
+        let view = HostTensorView {
+            data: &host.data,
+            shape: &host.shape,
+        };
+        let handle = provider.upload(&view).expect("upload");
+        let _out_guard = crate::output_count::push_output_count(Some(2));
+        let result = gradient_builtin(Value::GpuTensor(handle), Vec::new()).expect("gradient");
+        match result {
+            Value::OutputList(outputs) => {
+                assert!(matches!(outputs[0], Value::GpuTensor(_)));
+                assert!(matches!(outputs[1], Value::GpuTensor(_)));
+            }
+            other => panic!("expected output list, got {other:?}"),
+        }
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/reduction/mod.rs
+++ b/crates/runmat-runtime/src/builtins/math/reduction/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod type_resolvers;
 pub(crate) mod var;
 
 pub use self::diff::diff_tensor_host;
-pub use self::gradient::{gradient_complex_tensor_host, gradient_real_tensor_host};
+pub use self::gradient::{gradient_complex_tensor_host, gradient_real_tensor_host, matlab_gradient_shape};
 pub use self::median::compute_median_inplace;
 pub use cummax::evaluate as evaluate_cummax;
 pub use cummin::evaluate as evaluate_cummin;

--- a/crates/runmat-runtime/src/builtins/math/reduction/mod.rs
+++ b/crates/runmat-runtime/src/builtins/math/reduction/mod.rs
@@ -19,7 +19,9 @@ pub(crate) mod type_resolvers;
 pub(crate) mod var;
 
 pub use self::diff::diff_tensor_host;
-pub use self::gradient::{gradient_complex_tensor_host, gradient_real_tensor_host, matlab_gradient_shape};
+pub use self::gradient::{
+    gradient_complex_tensor_host, gradient_real_tensor_host, matlab_gradient_shape,
+};
 pub use self::median::compute_median_inplace;
 pub use cummax::evaluate as evaluate_cummax;
 pub use cummin::evaluate as evaluate_cummin;

--- a/crates/runmat-runtime/src/builtins/math/reduction/mod.rs
+++ b/crates/runmat-runtime/src/builtins/math/reduction/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod cummin;
 pub(crate) mod cumprod;
 pub(crate) mod cumsum;
 pub(crate) mod diff;
+pub(crate) mod gradient;
 pub(crate) mod max;
 pub(crate) mod mean;
 pub(crate) mod median;
@@ -18,6 +19,7 @@ pub(crate) mod type_resolvers;
 pub(crate) mod var;
 
 pub use self::diff::diff_tensor_host;
+pub use self::gradient::{gradient_complex_tensor_host, gradient_real_tensor_host};
 pub use self::median::compute_median_inplace;
 pub use cummax::evaluate as evaluate_cummax;
 pub use cummin::evaluate as evaluate_cummin;

--- a/crates/runmat-wasm/tests/gradient_gpu.rs
+++ b/crates/runmat-wasm/tests/gradient_gpu.rs
@@ -1,0 +1,120 @@
+#![cfg(target_arch = "wasm32")]
+
+use runmat_wasm::init_runmat;
+use serde::Deserialize;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExecPayload {
+    value_text: Option<String>,
+    error: Option<ExecError>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExecError {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GpuStatusPayload {
+    requested: bool,
+    active: bool,
+    error: Option<String>,
+}
+
+fn init_options(enable_gpu: bool) -> JsValue {
+    let options = js_sys::Object::new();
+    js_sys::Reflect::set(
+        &options,
+        &JsValue::from_str("enableGpu"),
+        &JsValue::from_bool(enable_gpu),
+    )
+    .expect("set enableGpu");
+    options.into()
+}
+
+#[wasm_bindgen_test(async)]
+async fn gradient_gpu_row_vector_matches_expected_output() {
+    let runtime = init_runmat(init_options(true))
+        .await
+        .expect("initialize wasm runtime");
+
+    let gpu_status: GpuStatusPayload =
+        serde_wasm_bindgen::from_value(runtime.gpu_status().expect("gpu status"))
+            .expect("deserialize gpu status");
+
+    let payload: ExecPayload = serde_wasm_bindgen::from_value(
+        runtime
+            .execute(
+                "G = gpuArray(single([1 4 9]));\nD = gradient(G, 2);\nout = gather(D)".to_string(),
+            )
+            .await
+            .expect("execute gradient script"),
+    )
+    .expect("deserialize execution payload");
+
+    if let Some(err) = payload.error {
+        panic!(
+            "gradient wasm execution failed: {} (gpu requested={}, active={}, gpu error={:?})",
+            err.message, gpu_status.requested, gpu_status.active, gpu_status.error
+        );
+    }
+
+    let value_text = payload.value_text.unwrap_or_default();
+    assert!(
+        value_text.contains("1.5") && value_text.contains("2") && value_text.contains("2.5"),
+        "unexpected gradient output: {:?} (gpu requested={}, active={}, gpu error={:?})",
+        value_text,
+        gpu_status.requested,
+        gpu_status.active,
+        gpu_status.error
+    );
+}
+
+#[wasm_bindgen_test(async)]
+async fn gradient_gpu_row_vector_matches_expected_output_without_webgpu() {
+    let runtime = init_runmat(init_options(false))
+        .await
+        .expect("initialize wasm runtime");
+
+    let gpu_status: GpuStatusPayload =
+        serde_wasm_bindgen::from_value(runtime.gpu_status().expect("gpu status"))
+            .expect("deserialize gpu status");
+    assert!(
+        !gpu_status.active,
+        "expected CPU fallback test to disable GPU"
+    );
+
+    let payload: ExecPayload = serde_wasm_bindgen::from_value(
+        runtime
+            .execute(
+                "G = gpuArray(single([1 4 9]));\nD = gradient(G, 2);\nout = gather(D)".to_string(),
+            )
+            .await
+            .expect("execute gradient script"),
+    )
+    .expect("deserialize execution payload");
+
+    if let Some(err) = payload.error {
+        panic!(
+            "gradient wasm CPU-fallback execution failed: {} (gpu requested={}, active={}, gpu error={:?})",
+            err.message, gpu_status.requested, gpu_status.active, gpu_status.error
+        );
+    }
+
+    let value_text = payload.value_text.unwrap_or_default();
+    assert!(
+        value_text.contains("1.5") && value_text.contains("2") && value_text.contains("2.5"),
+        "unexpected CPU-fallback gradient output: {:?} (gpu requested={}, active={}, gpu error={:?})",
+        value_text,
+        gpu_status.requested,
+        gpu_status.active,
+        gpu_status.error
+    );
+}


### PR DESCRIPTION
## Summary
- Add a `gradient` builtin with MATLAB-style row-vector semantics and shape-preserving finite differences.
- Wire the builtin through the accelerate API, simple provider, and WGPU backend so scalar-spacing cases stay GPU-resident.
- Add browser wasm regressions for both WebGPU and CPU-fallback execution paths.

## Testing
- Unit tests for gradient shape handling and scalar-spacing behavior.
- Browser wasm tests in headless Chrome covering the gradient repro with and without WebGPU enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new numeric builtin plus a new GPU provider hook and WGPU compute pipeline/shader, which can affect correctness/perf across CPU/GPU paths and introduce backend-specific edge cases (shapes, empty tensors, wasm polling).
> 
> **Overview**
> Introduces a new MATLAB-compatible `gradient` builtin (central differences with boundary handling) including multi-output ordering semantics and scalar spacing validation, with host fallbacks for unsupported cases (e.g., coordinate-vector spacing and complex GPU tensors).
> 
> Extends the acceleration surface with a `gradient_dim` provider hook and implements it in both the simple provider and the WGPU backend via a new compute shader/pipeline, uniform params, and dispatch helper; also adjusts WGPU command submission polling on `wasm32`.
> 
> Adds builtin documentation (`builtins-json/gradient.json`), updates TS builtin doc types to support new media/link metadata, and includes wasm browser regression tests covering both WebGPU-enabled and CPU-fallback execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82435be846d26cac3b5379332206e806e1da21bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->