### PR TITLE
Update documentation links and speed up media caching

### DIFF
--- a/docs/GPU_BEHAVIOR_NOTES.md
+++ b/docs/GPU_BEHAVIOR_NOTES.md
@@ -1,4 +1,4 @@
-## GPU Residency & Precision Guide
+# GPU Residency & Precision Guide
 
 RunMat keeps tensors on the GPU whenever that offers a measurable win, but it
 never changes numeric precision behind the user’s back. This document walks

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1,4 +1,4 @@
-## Language Compatibility Modes
+# RunMat Language Compatibility Modes
 
 Philosophy: RunMat's input language surface is compatible with MATLAB syntax so the language you already know works here — no new language to learn. The goal is not to replicate a legacy runtime function-for-function, but to give engineers a modern, high-performance environment for math and physics that feels immediately familiar. Where MATLAB conventions conflict with clarity or performance, RunMat offers explicit opt-in/opt-out controls via compatibility modes.
 

--- a/website/app/docs/reference/builtins/[slug]/meta.ts
+++ b/website/app/docs/reference/builtins/[slug]/meta.ts
@@ -62,16 +62,48 @@ export function builtinJsonLD(slug: string): string {
     const examples = builtin?.examples ?? [];
     const faqs = builtin?.faqs ?? [];
     const heroImage = builtin?.hero_image || "https://web.runmatstatic.com/runmat-sandbox-dark.png";
+    const sourceUrl = builtin?.source?.url?.trim();
 
-    const mainEntityRefs: Record<string, string>[] = [{"@id": "#source-code"}];
-    if (examples.length > 0) mainEntityRefs.push({"@id": "#how-to-guide"});
-    if (faqs.length > 0) mainEntityRefs.push({"@id": "#faq"});
+    const pageUrl = `https://runmat.com/docs/reference/builtins/${slug}`;
+    const articleId = `${pageUrl}#article`;
+    const breadcrumbId = `${pageUrl}#breadcrumbs`;
+    const sourceCodeId = `${pageUrl}#source-code`;
+    const howToId = `${pageUrl}#how-to-guide`;
+    const faqId = `${pageUrl}#faq`;
+
+    const mainEntityRefs: Record<string, string>[] = [];
+    if (sourceUrl) mainEntityRefs.push({ "@id": sourceCodeId });
+    if (examples.length > 0) mainEntityRefs.push({ "@id": howToId });
+    if (faqs.length > 0) mainEntityRefs.push({ "@id": faqId });
+
+    const apiReference: Record<string, unknown> = {
+        "@type": "APIReference",
+        "@id": articleId,
+        "headline": `${title} in MATLAB — runnable examples + source (RunMat)`,
+        "description": `Run ${title} in your browser. Open-source, JIT-compiled MATLAB-compatible documentation for ${stripMarkdown(builtin?.description ?? '')}`.slice(0, 300),
+        "image": heroImage,
+        "dateModified": new Date().toISOString(),
+        "programmingLanguage": {"@type": "ComputerLanguage", "name": "MATLAB", "alternateName": "RunMat"},
+        "author": {"@id": "https://runmat.com/#organization"},
+        "publisher": {"@id": "https://runmat.com/#organization"},
+        "about": {
+            "@type": "DefinedTerm",
+            "name": title,
+            "description": stripMarkdown(builtin?.description ?? ''),
+            "inDefinedTermSet": {
+                "@type": "DefinedTermSet",
+                "name": "RunMat Builtin Functions",
+                "url": "https://runmat.com/docs/matlab-function-reference"
+            }
+        },
+    };
+    if (mainEntityRefs.length > 0) apiReference.mainEntity = mainEntityRefs;
 
     const graph: Record<string, unknown>[] = [
         {
             "@type": "WebPage",
-            "@id": `https://runmat.com/docs/reference/builtins/${slug}`,
-            "url": `https://runmat.com/docs/reference/builtins/${slug}`,
+            "@id": pageUrl,
+            "url": pageUrl,
             "name": `${title} - RunMat Reference`,
             "isPartOf": {"@id": "https://runmat.com/#website"},
             "author": {"@id": "https://runmat.com/#organization"},
@@ -80,47 +112,25 @@ export function builtinJsonLD(slug: string): string {
                 "@type": "ImageObject",
                 "url": heroImage
             },
-            "breadcrumb": {"@id": `https://runmat.com/docs/reference/builtins/${slug}#breadcrumbs`},
-            "mainEntity": {"@id": "#article"}
+            "breadcrumb": {"@id": breadcrumbId},
+            "mainEntity": {"@id": articleId}
         },
         {
             "@type": "BreadcrumbList",
-            "@id": `https://runmat.com/docs/reference/builtins/${slug}#breadcrumbs`,
+            "@id": breadcrumbId,
             "itemListElement": [
                 {"@type": "ListItem", "position": 1, "name": "Docs", "item": "https://runmat.com/docs"},
                 {"@type": "ListItem", "position": 2, "name": "Reference", "item": "https://runmat.com/docs/matlab-function-reference"},
-                {"@type": "ListItem", "position": 3, "name": title, "item": `https://runmat.com/docs/reference/builtins/${slug}`}
+                {"@type": "ListItem", "position": 3, "name": title, "item": pageUrl}
             ]
         },
-        {
-            "@type": "APIReference",
-            "@id": `https://runmat.com/docs/reference/builtins/${slug}#article`,
-            "headline": `${title} in MATLAB — runnable examples + source (RunMat)`,
-            "alternativeHeadline": `${title} Function Reference`,
-            "description": `Run ${title} in your browser. Open-source, JIT-compiled MATLAB-compatible documentation for ${stripMarkdown(builtin?.description ?? '')}`.slice(0, 300),
-            "image": heroImage,
-            "proficiencyLevel": "Beginner",
-            "programmingModel": "Procedural",
-            "assemblyVersion": "RunMat 0.1.0",
-            "dateModified": new Date().toISOString().split('T')[0],
-            "programmingLanguage": {"@type": "ComputerLanguage", "name": "MATLAB", "alternateName": "RunMat"},
-            "author": {"@id": "https://runmat.com/#organization"},
-            "publisher": {"@id": "https://runmat.com/#organization"},
-            "about": {
-                "@type": "DefinedTerm",
-                "name": title,
-                "description": stripMarkdown(builtin?.description ?? ''),
-                "inDefinedTermSet": {
-                    "@type": "DefinedTermSet",
-                    "name": "RunMat Builtin Functions",
-                    "url": "https://runmat.com/docs/matlab-function-reference"
-                }
-            },
-            "mainEntity": mainEntityRefs
-        },
-        {
+        apiReference,
+    ];
+
+    if (sourceUrl) {
+        graph.push({
             "@type": "SoftwareSourceCode",
-            "@id": "#source-code",
+            "@id": sourceCodeId,
             "name": `${title}.rs`,
             "description": `The Rust implementation of the ${title} function, compatible with all RunMat targets.`,
             "codeRepository": "https://github.com/runmat-org/runmat",
@@ -129,14 +139,14 @@ export function builtinJsonLD(slug: string): string {
             "targetProduct": {"@type": "SoftwareApplication", "name": "RunMat"},
             "license": "https://opensource.org/licenses/MIT",
             "runtimePlatform": ["RunMat Web (WASM)", "RunMat Desktop", "RunMat CLI"],
-            "url": builtin?.source?.url
-        },
-    ];
+            "url": sourceUrl,
+        });
+    }
 
     if (examples.length > 0) {
         graph.push({
             "@type": "HowTo",
-            "@id": "#how-to-guide",
+            "@id": howToId,
             "name": `How to use ${title} in RunMat`,
             "description": `Runnable examples showing how to use ${title} in RunMat. Each example runs in the browser with no setup.`,
             "image": heroImage,
@@ -147,9 +157,8 @@ export function builtinJsonLD(slug: string): string {
                 const step: Record<string, unknown> = {
                     "@type": "HowToStep",
                     "name": description,
-                    "url": `https://runmat.com/docs/reference/builtins/${slug}#${anchor}`,
+                    "url": `${pageUrl}#${anchor}`,
                     "text": example.input,
-                    "itemListElement": {"@type": "HowToDirection", "text": example.input}
                 };
                 if (stepImage) step.image = stepImage;
                 return step;
@@ -160,7 +169,7 @@ export function builtinJsonLD(slug: string): string {
     if (faqs.length > 0) {
         graph.push({
             "@type": "FAQPage",
-            "@id": "#faq",
+            "@id": faqId,
             "mainEntity": faqs.map(faq => ({
                 "@type": "Question",
                 "name": faq.question,

--- a/website/app/docs/reference/builtins/[slug]/meta.ts
+++ b/website/app/docs/reference/builtins/[slug]/meta.ts
@@ -82,7 +82,6 @@ export function builtinJsonLD(slug: string): string {
         "headline": `${title} in MATLAB — runnable examples + source (RunMat)`,
         "description": `Run ${title} in your browser. Open-source, JIT-compiled MATLAB-compatible documentation for ${stripMarkdown(builtin?.description ?? '')}`.slice(0, 300),
         "image": heroImage,
-        "dateModified": new Date().toISOString(),
         "programmingLanguage": {"@type": "ComputerLanguage", "name": "MATLAB", "alternateName": "RunMat"},
         "author": {"@id": "https://runmat.com/#organization"},
         "publisher": {"@id": "https://runmat.com/#organization"},

--- a/website/app/docs/reference/builtins/[slug]/page.tsx
+++ b/website/app/docs/reference/builtins/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import {
   getBuiltinDocBySlug,
   getBuiltinMetadata,
@@ -38,9 +38,9 @@ export default async function BuiltinDetailPage({ params }: { params: Promise<{ 
   const { slug } = await params;
   const builtins = loadBuiltins();
   const b = builtins.find(x => x.slug === slug);
-  if (!b) redirect('/docs/matlab-function-reference');
+  if (!b) notFound();
   const doc = getBuiltinDocBySlug(slug);
-  if (!doc) redirect('/docs/matlab-function-reference');
+  if (!doc) notFound();
   const blocks = renderBuiltinDocBlocks(doc);
   const toc = extractHeadingsFromBlocks(blocks);
   const metadata = getBuiltinMetadata(b);

--- a/website/app/docs/reference/builtins/[slug]/page.tsx
+++ b/website/app/docs/reference/builtins/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { permanentRedirect } from 'next/navigation';
+import { redirect } from 'next/navigation';
 import {
   getBuiltinDocBySlug,
   getBuiltinMetadata,
@@ -38,9 +38,9 @@ export default async function BuiltinDetailPage({ params }: { params: Promise<{ 
   const { slug } = await params;
   const builtins = loadBuiltins();
   const b = builtins.find(x => x.slug === slug);
-  if (!b) permanentRedirect('/docs/matlab-function-reference');
+  if (!b) redirect('/docs/matlab-function-reference');
   const doc = getBuiltinDocBySlug(slug);
-  if (!doc) permanentRedirect('/docs/matlab-function-reference');
+  if (!doc) redirect('/docs/matlab-function-reference');
   const blocks = renderBuiltinDocBlocks(doc);
   const toc = extractHeadingsFromBlocks(blocks);
   const metadata = getBuiltinMetadata(b);

--- a/website/app/docs/reference/builtins/[slug]/page.tsx
+++ b/website/app/docs/reference/builtins/[slug]/page.tsx
@@ -23,6 +23,7 @@ import { SandboxCta } from '@/components/SandboxCta';
 
 
 export const dynamic = 'force-static';
+export const dynamicParams = false;
 
 export async function generateStaticParams() {
   const builtins = loadBuiltins();

--- a/website/app/docs/reference/builtins/[slug]/page.tsx
+++ b/website/app/docs/reference/builtins/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { notFound } from 'next/navigation';
+import { permanentRedirect } from 'next/navigation';
 import {
   getBuiltinDocBySlug,
   getBuiltinMetadata,
@@ -38,9 +38,9 @@ export default async function BuiltinDetailPage({ params }: { params: Promise<{ 
   const { slug } = await params;
   const builtins = loadBuiltins();
   const b = builtins.find(x => x.slug === slug);
-  if (!b) return notFound();
+  if (!b) permanentRedirect('/docs/matlab-function-reference');
   const doc = getBuiltinDocBySlug(slug);
-  if (!doc) return notFound();
+  if (!doc) permanentRedirect('/docs/matlab-function-reference');
   const blocks = renderBuiltinDocBlocks(doc);
   const toc = extractHeadingsFromBlocks(blocks);
   const metadata = getBuiltinMetadata(b);

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -75,20 +75,7 @@ export default function RootLayout({
       <head>
         <link rel="preconnect" href="https://web.runmatstatic.com" crossOrigin="" />
         <link rel="dns-prefetch" href="https://web.runmatstatic.com" />
-        <link
-          rel="preload"
-          as="image"
-          href="https://web.runmatstatic.com/video/posters/runmat-wave-simulation-720.webp"
-          fetchPriority="high"
-          media="(max-width: 768px)"
-        />
-        <link
-          rel="preload"
-          as="image"
-          href="https://web.runmatstatic.com/video/posters/runmat-wave-simulation.webp"
-          fetchPriority="high"
-          media="(min-width: 769px)"
-        />
+
         <link rel="icon" href="/favicon.ico" sizes="32x32" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -78,7 +78,16 @@ export default function RootLayout({
         <link
           rel="preload"
           as="image"
+          href="https://web.runmatstatic.com/video/posters/runmat-wave-simulation-720.webp"
+          fetchPriority="high"
+          media="(max-width: 768px)"
+        />
+        <link
+          rel="preload"
+          as="image"
           href="https://web.runmatstatic.com/video/posters/runmat-wave-simulation.webp"
+          fetchPriority="high"
+          media="(min-width: 769px)"
         />
         <link rel="icon" href="/favicon.ico" sizes="32x32" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -185,6 +185,20 @@ export const metadata: Metadata = {
 export default function HomePage() {
   return (
     <div className="flex flex-col min-h-screen home-page">
+      <link
+        rel="preload"
+        as="image"
+        href="https://web.runmatstatic.com/video/posters/runmat-wave-simulation-720.webp"
+        fetchPriority="high"
+        media="(max-width: 768px)"
+      />
+      <link
+        rel="preload"
+        as="image"
+        href="https://web.runmatstatic.com/video/posters/runmat-wave-simulation.webp"
+        fetchPriority="high"
+        media="(min-width: 769px)"
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import LazyVideo from "@/components/LazyVideo";
 
 export default function Hero() {
   return (
@@ -31,18 +32,17 @@ export default function Hero() {
             href="/docs/reference/builtins/surf#wave-interference-from-8-point-sources"
             className="group relative rounded-lg border border-border overflow-hidden min-h-[360px] flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
-            <video
+            <LazyVideo
               className="w-full h-auto min-h-[360px] object-cover"
-              autoPlay
               muted
               loop
               playsInline
-              preload="none"
               poster="https://web.runmatstatic.com/video/posters/runmat-wave-simulation.webp"
+              mobilePoster="https://web.runmatstatic.com/video/posters/runmat-wave-simulation-720.webp"
               aria-label="RunMat wave simulation demo"
             >
               <source src="https://web.runmatstatic.com/video/runmat-wave-simulation.mp4" type="video/mp4" />
-            </video>
+            </LazyVideo>
             <span className="hidden sm:flex absolute bottom-2 right-2 items-center gap-1 rounded-md bg-black/40 backdrop-blur-sm px-2 py-1 text-[10px] font-medium text-white/70 transition-colors group-hover:text-white group-hover:bg-black/60">
               <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="m18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /><polyline points="15 3 21 3 21 9" /><line x1="10" x2="21" y1="14" y2="3" /></svg>
               surf() example

--- a/website/components/LazyVideo.tsx
+++ b/website/components/LazyVideo.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useEffect, useRef, type ComponentProps } from "react";
+import { useEffect, useRef, useState, type ComponentProps } from "react";
 
-type VideoProps = Omit<ComponentProps<"video">, "autoPlay" | "preload">;
+type VideoProps = Omit<ComponentProps<"video">, "autoPlay" | "preload"> & {
+  mobilePoster?: string;
+  mobileMediaQuery?: string;
+};
 
 /**
  * A video element that defers loading until it scrolls into view.
@@ -11,9 +14,28 @@ type VideoProps = Omit<ComponentProps<"video">, "autoPlay" | "preload">;
  * overrides `preload` and forces an immediate download, this component
  * keeps `preload="none"` effective by only calling `.play()` once the
  * element enters the viewport via Intersection Observer.
+ *
+ * When `mobilePoster` is provided, it is used for viewports matching
+ * `mobileMediaQuery` (default: "(max-width: 768px)") so mobile clients
+ * pull a smaller still image as their LCP candidate.
  */
-export default function LazyVideo(props: VideoProps) {
+export default function LazyVideo({
+  mobilePoster,
+  mobileMediaQuery = "(max-width: 768px)",
+  poster,
+  ...props
+}: VideoProps) {
   const ref = useRef<HTMLVideoElement>(null);
+  const [activePoster, setActivePoster] = useState<string | undefined>(poster);
+
+  useEffect(() => {
+    if (!mobilePoster || typeof window === "undefined") return;
+    const media = window.matchMedia(mobileMediaQuery);
+    const update = () => setActivePoster(media.matches ? mobilePoster : poster);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, [mobilePoster, mobileMediaQuery, poster]);
 
   useEffect(() => {
     const el = ref.current;
@@ -33,5 +55,5 @@ export default function LazyVideo(props: VideoProps) {
     return () => observer.disconnect();
   }, []);
 
-  return <video ref={ref} preload="none" {...props} />;
+  return <video ref={ref} preload="none" poster={activePoster} {...props} />;
 }

--- a/website/components/LazyVideo.tsx
+++ b/website/components/LazyVideo.tsx
@@ -26,10 +26,15 @@ export default function LazyVideo({
   ...props
 }: VideoProps) {
   const ref = useRef<HTMLVideoElement>(null);
-  const [activePoster, setActivePoster] = useState<string | undefined>(poster);
+  // Start with no poster to avoid SSR baking the desktop URL into HTML,
+  // which would cause mobile browsers to fetch it before the effect swaps
+  // to mobilePoster — downloading both images.
+  const [activePoster, setActivePoster] = useState<string | undefined>(
+    mobilePoster ? undefined : poster,
+  );
 
   useEffect(() => {
-    if (!mobilePoster || typeof window === "undefined") return;
+    if (!mobilePoster) return;
     const media = window.matchMedia(mobileMediaQuery);
     const update = () => setActivePoster(media.matches ? mobilePoster : poster);
     update();

--- a/website/components/benchmarks/BenchmarkShowcaseCarousel.tsx
+++ b/website/components/benchmarks/BenchmarkShowcaseCarousel.tsx
@@ -1,11 +1,20 @@
 "use client";
 
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import type { BenchmarkChartData, BenchmarkShowcaseSlide } from "@/lib/marketing-benchmarks";
 import { cn } from "@/lib/utils";
 
-import BenchmarkBarChart from "./charts/BenchmarkBarChart";
-import BenchmarkLineChart from "./charts/BenchmarkLineChart";
+const ChartFallback = () => <div className="w-full" style={{ height: 320 }} />;
+
+const BenchmarkBarChart = dynamic(() => import("./charts/BenchmarkBarChart"), {
+  ssr: false,
+  loading: ChartFallback,
+});
+const BenchmarkLineChart = dynamic(() => import("./charts/BenchmarkLineChart"), {
+  ssr: false,
+  loading: ChartFallback,
+});
 
 interface BenchmarkShowcaseCarouselProps {
   slides: BenchmarkShowcaseSlide[];

--- a/website/content/blog/introducing-runmat.md
+++ b/website/content/blog/introducing-runmat.md
@@ -133,7 +133,7 @@ If you've written MATLAB code, you know the trade-offs:
 - GNU Octave is free and compatible with lots of code, but startup and hot-path performance can be limiting.
 - Moving to a new language means rewriting and - perhaps most importantly - **retraining**.
 
-RunMat aims for a fourth path: keep the MATLAB language you know, but put it on a modern engine with a smaller core, clean semantics, and open extensibility.
+RunMat aims for a fourth path: keep the MATLAB language you know, but put it on a modern engine with a smaller core, clean semantics, and open extensibility. If you want a short background explainer, see this [guide](/resources/guides/what-is-matlab).
 
 ---
 

--- a/website/content/blog/matlab-alternatives.md
+++ b/website/content/blog/matlab-alternatives.md
@@ -174,7 +174,7 @@ jsonLd:
           name: "Is there a free version of MATLAB?"
           acceptedAnswer:
             "@type": "Answer"
-            text: "MATLAB itself is not free. MathWorks ended perpetual licenses in January 2026 and sells subscriptions ($119/year for students, $165/year for home use, $2,000+ per seat for professionals). Free, open-source alternatives include RunMat, GNU Octave, Python, and Julia."
+            text: "MATLAB itself is not free. MathWorks ended perpetual Student and Home licenses in January 2026 and now sells subscriptions starting at $119/year for students, $165/year for home use, and $940/year per seat for professionals (commonly over $2,000 with toolboxes). Free, open-source alternatives include RunMat, GNU Octave, Python, and Julia."
         - "@type": "Question"
           name: "What is the best open-source MATLAB alternative?"
           acceptedAnswer:
@@ -184,7 +184,7 @@ jsonLd:
           name: "Is there a free MATLAB alternative for Linux?"
           acceptedAnswer:
             "@type": "Answer"
-            text: "Yes. RunMat, Octave, Python, and Julia all run natively on Linux and install via package managers or a single binary. RunMat also runs in the browser with GPU acceleration on Linux via WebGPU (Chrome 113+, Firefox 139+)."
+            text: "Yes. RunMat, Octave, Python, and Julia all run natively on Linux and install via package managers or a single binary. RunMat also runs in the browser with GPU acceleration on Linux via WebGPU (Chrome 113+, Firefox 141+)."
         - "@type": "Question"
           name: "Is there a free alternative to Simulink?"
           acceptedAnswer:
@@ -194,7 +194,7 @@ jsonLd:
           name: "How much does a MATLAB license cost?"
           acceptedAnswer:
             "@type": "Answer"
-            text: "As of 2026, MATLAB costs $119/year for students, $165/year for home users, and $2,000+ per seat per year for professional use, with toolboxes adding further cost. MathWorks ended perpetual licenses in January 2026, making the pricing subscription-only."
+            text: "As of 2026, MATLAB subscriptions start at $119/year for students, $165/year for home users, and $940/year per seat for professional use, with toolboxes adding $500–$1,500 each. MathWorks ended perpetual Student and Home licenses in January 2026; commercial perpetual licenses remain available at $2,150+."
         - "@type": "Question"
           name: "Can I run MATLAB code online without installing anything?"
           acceptedAnswer:
@@ -233,14 +233,14 @@ jsonLd:
 *This article was originally published in September 2025 and has been updated for 2026 with new sections on Browser-Based Computing, GPU Acceleration, Version Control, Large File Handling, and Airgap Deployment.*
 
 ## Why are engineers searching for MATLAB alternatives?
-Engineers search for MATLAB alternatives because licenses cost over $2,000 per seat and MathWorks has moved to subscription-only pricing, making the cost recurring rather than one-time. This guide compares the top four free options (RunMat, Octave, Julia, and Python) across real engineering use cases, performance, compatibility, and library support.
+Engineers search for MATLAB alternatives because professional licenses start at $940/year per seat (and commonly exceed $2,000 with toolboxes), and MathWorks has ended perpetual pricing for Student and Home tiers, pushing more users toward recurring subscriptions. This guide compares the top four free options (RunMat, Octave, Julia, and Python) across real engineering use cases, focusing on speed, compatibility, and how much of MATLAB's library surface each tool actually covers.
 
 ## What is the best free alternative to MATLAB?
 
 The best free alternatives to MATLAB in 2026 are **RunMat**, **GNU Octave**, **Python (NumPy/SciPy)**, and **Julia**. RunMat is the fastest drop-in replacement for existing `.m` files and the only option with automatic cross-vendor GPU acceleration and a full browser IDE. Octave is the most mature MATLAB-compatible interpreter. Python has the largest set of scientific libraries. Julia is the strongest pure-performance choice.
 
 1. [RunMat](https://runmat.com). Free and open source. Runs existing MATLAB code unchanged, JIT-compiled, with automatic GPU acceleration on NVIDIA, AMD, Intel, and Apple hardware. Ships with [20+ GPU-accelerated plot types](/docs/plotting) and an interactive 3D camera, plus a browser sandbox that needs no install.
-2. [GNU Octave](https://octave.org). Free, mature, MATLAB-syntax. Interpreter-only (no JIT or GPU), but stable and widely used in academia.
+2. [GNU Octave](https://octave.org). Free and mature, with MATLAB-compatible syntax. Interpreter-only (no JIT or GPU), but stable and widely used in academia. For a deeper look at what Octave got right and where it differs from modern runtimes, see [MATLAB vs Octave: 30 years of compatibility](/blog/matlab-vs-octave).
 3. [Python (NumPy/SciPy)](https://numpy.org). Free, with a vast library collection. Requires rewriting MATLAB code in Python syntax.
 4. [Julia](https://julialang.org). Free, designed for numerical performance. Familiar syntax for MATLAB users, but it is a new language to learn.
 
@@ -273,20 +273,20 @@ To verify any of this yourself, paste a `.m` file into the [browser sandbox](htt
 ### Data Analysis and Visualization
 The most common use cases for MATLAB alternatives are data analysis and visualization. Each free alternative handles these workflows differently.
 
-RunMat supports [20+ plot types](/docs/plotting) including [`plot`, `scatter`, `hist`, `surf`, `contour`, `bar`, `pie`, `stem`, `quiver`, `area`, `errorbar`](/docs/matlab-function-reference#plotting) alongside `figure`, `subplot`, `hold`, and `gcf`. Rendering is GPU-first: vertex buffers are built on-device and rendered through WebGPU in the browser or Metal/Vulkan/DX12 natively, so plots involving large datasets avoid CPU-side bottlenecks. An interactive 3D camera supports rotation, panning, and zoom, with reversed-Z depth and dynamic clip planes for precision in LiDAR, CFD, or radar visualization. Figure scenes can be exported and reimported for persistence and replay. For a walkthrough of all supported plot types, see the [MATLAB plotting guide](/blog/matlab-plotting-guide).
+RunMat supports [20+ plot types](/docs/plotting) including [`plot`, `scatter`, `hist`, `surf`, `contour`, `bar`, `pie`, `stem`, `quiver`, `area`, `errorbar`](/docs/matlab-function-reference#plotting) alongside `figure`, `subplot`, `hold`, and `gcf`. Rendering is GPU-first: vertex buffers are built on-device and rendered through WebGPU in the browser or Metal/Vulkan/DX12 natively, so plots involving large datasets avoid CPU-side bottlenecks. An interactive 3D camera supports orbit and pan with scroll-wheel zoom, using reversed-Z depth and dynamic clip planes for precision in LiDAR, CFD, or radar visualization. Figure scenes can be exported and reimported for persistence and replay. For a walkthrough of all supported plot types, see the [MATLAB plotting guide](/blog/matlab-plotting-guide).
 
-Octave maintains strong compatibility with MATLAB's syntax, supporting everyday data analysis tasks like matrix operations, file I/O, and 2D and 3D plotting. For most scripts, functions behave nearly identically. [Octave 11](https://octave.org/NEWS-11.html) (February 2026) brought concrete performance improvements: convolution on short-by-wide arrays runs 10-150x faster depending on shape, and `sum`/`cumsum` on logical inputs are up to 6x faster. Visualization is less polished than MATLAB's, but functional.
+Octave maintains strong compatibility with MATLAB's syntax, supporting everyday data analysis tasks like matrix operations and file I/O alongside 2D and 3D plotting. For most scripts, functions behave nearly identically. [Octave 11](https://octave.org/NEWS-11.html) (February 2026) brought concrete performance improvements: convolution on short-by-wide arrays runs 10% to 150x faster depending on shape, and `sum`/`cumsum` on logical inputs are up to 6x faster. Visualization is less polished than MATLAB's, but functional.
 
-Python relies on specialized libraries. [NumPy 2.0](https://numpy.org/doc/2.0/release/2.0.0-notes.html) (released June 2024) cleaned up ~10% of the main namespace, added a proper DType API for custom data types, and introduced a native `StringDType`. Pandas simplifies data wrangling, and Matplotlib and Seaborn offer flexible plotting. The syntax differs from MATLAB and takes some adjustment, but Python's library set goes well beyond numerical analysis. Engineers can clean data, apply ML models, query databases, and automate workflows in the same environment.
+Python relies on specialized libraries. [NumPy 2.0](https://numpy.org/doc/2.0/release/2.0.0-notes.html) (released June 2024) cleaned up ~10% of the main namespace and added a proper DType API for custom data types, including a native `StringDType`. Pandas simplifies data wrangling, and Matplotlib and Seaborn offer flexible plotting. The syntax differs from MATLAB and takes some adjustment, but Python's library set goes well beyond numerical analysis. Engineers can clean data, apply ML models, query databases, and automate workflows in the same environment.
 
 Julia combines math-friendly syntax with high performance. Packages like DataFrames.jl support structured data handling, while Plots.jl and related libraries handle visualization. Its 1-based indexing and matrix-oriented design feel familiar to MATLAB users. [Julia 1.12](https://julialang.org/blog/2025/10/julia-1.12-highlights/) (October 2025) improved the interactive workflow: constants and structs can now be redefined through the world-age mechanism, and Revise.jl 3.13 makes this automatic, so engineers no longer need to restart Julia after changing a type definition. Julia has fewer packages than Python, but the collection is growing fast.
 
 ### Simulation and System Modeling
-Simulation and system modeling in MATLAB alternatives means solving ODEs, running Monte Carlo sweeps, or building discrete-time controllers in script. None of these tools replicate Simulink's graphical block-diagram modeling. Each offers script-based simulation with different tradeoffs in speed and solver coverage.
+Simulation and system modeling in MATLAB alternatives means solving ODEs and running Monte Carlo sweeps or discrete-time controllers in script. None of these tools replicate Simulink's graphical block-diagram modeling. Each offers script-based simulation with different tradeoffs in speed and solver coverage.
 
 RunMat runs MATLAB simulation scripts (ODEs, discrete-time models) at near-native speed. Monte Carlo simulations and batch parameter sweeps benefit from [automatic GPU acceleration](/blog/runmat-accelerate-fastest-runtime-for-your-math). Control systems packages (transfer functions, state-space analysis) are on the [roadmap](/docs/roadmap).
 
-Octave includes MATLAB-compatible ODE solvers (`ode45`, `ode23`) and a control package (`tf`, `step`, `lsim`) for transfer functions and state-space models. Engineers can simulate filters, controllers, or dynamic systems with almost the same functions used in MATLAB, so the transition requires almost no syntax changes.
+Octave includes MATLAB-compatible ODE solvers (`ode45`, `ode23`) and a control package (`tf`, `step`, `lsim`) for transfer functions and state-space models. Engineers can simulate feedback controllers and dynamic systems with almost the same functions used in MATLAB, so the transition requires almost no syntax changes.
 
 Python, with libraries like SciPy and python-control, provides mature tools for system simulation and modeling. Performance is good when using optimized SciPy solvers or NumPy operations.
 
@@ -331,7 +331,7 @@ For a deeper dive into why MATLAB loops are slow, see [MATLAB For Loops Are Slow
 
 GPU acceleration in MATLAB requires the Parallel Computing Toolbox and an NVIDIA GPU. Free alternatives differ sharply: RunMat offloads automatically to any GPU vendor, Julia requires explicit CuArray types, Python needs CuPy or PyTorch, and Octave has no GPU support at all.
 
-RunMat [automatically offloads computations to the GPU](/blog/how-to-use-gpu-in-matlab) without code changes, fusing chains of elementwise math into single kernels and keeping data [resident on the GPU](/docs/accelerate/gpu-behavior) between operations. It supports NVIDIA, AMD, Intel, and Apple GPUs through a unified backend (Metal on macOS, DirectX 12 on Windows, Vulkan on Linux), and WebGPU in browser builds. On memory-bound workloads, fusion produces measurable gains: Monte Carlo simulations (5M paths) run ~2.8x faster than PyTorch and ~130x faster than NumPy; elementwise chains (1B elements) can be ~100x+ faster than PyTorch. For implementation detail, see the [Introduction to RunMat Fusion](/docs/accelerate/fusion-intro).
+RunMat [automatically offloads computations to the GPU](/blog/how-to-use-gpu-in-matlab) without code changes, fusing chains of elementwise math into single kernels and keeping data [resident on the GPU](/docs/accelerate/gpu-behavior) between operations. It supports NVIDIA, AMD, Intel, and Apple GPUs through a unified backend (Metal on macOS, Vulkan on Linux, DirectX 12 on Windows), with WebGPU in browser builds. On memory-bound workloads, fusion produces measurable gains: Monte Carlo simulations (5M paths) run ~2.8x faster than PyTorch and ~130x faster than NumPy; elementwise chains (1B elements) can be ~100x+ faster than PyTorch. For implementation detail, see the [Introduction to RunMat Fusion](/docs/accelerate/fusion-intro).
 
 MATLAB requires explicit `gpuArray` calls and only supports NVIDIA GPUs via the Parallel Computing Toolbox (additional license required), with no automatic fusion. Python's GPU support is library-specific: PyTorch and TensorFlow are excellent for ML workloads, [CuPy](https://cupy.dev) provides a NumPy-like API on NVIDIA, and Apple Silicon users have PyTorch's MPS backend or JAX's Metal support, all with explicit device management. Julia uses CUDA.jl with explicit `CuArray` types; AMDGPU.jl adds AMD support (Linux-only); [Metal.jl](https://github.com/JuliaGPU/Metal.jl) v1.9 in early 2026 added MPSGraph and `MtlArray` for Apple Silicon. GNU Octave has no meaningful GPU support; computations run on CPU only.
 
@@ -360,7 +360,7 @@ disp(price);
 ---
 
 ## The same code, in each language
-MATLAB code runs unchanged in RunMat and Octave. Python and Julia require syntax changes: library imports, different array APIs, and language-specific idioms. The same sine-wave plot in each language follows below.
+MATLAB code runs unchanged in RunMat and Octave. Python and Julia require syntax changes -- different imports, different array APIs, and in Python's case entirely different idioms. The same sine-wave plot in each language follows below.
 
 ### RunMat / Octave (MATLAB syntax)
 ```matlab:runnable
@@ -403,12 +403,12 @@ plot(x, y, title="Sine Wave")
 
 Julia's syntax is very close to MATLAB's, with minor differences like the broadcast dot (`sin.(x)`). It requires loading a plotting package, but otherwise feels familiar.
 
-MATLAB, Octave, and RunMat let you reuse code directly. Python adds library imports but maps closely. Julia is concise and fast, with slightly different idioms.
+RunMat and Octave both run the same code as MATLAB. Python adds library imports but maps closely. Julia is concise and fast, with slightly different idioms.
 
 ---
 
 ## Installing on Windows, Mac, and Linux
-MATLAB requires a multi-GB installer and an annual license ($119/year for students, $165/year for home use, $2,000+ per seat for professionals) (MathWorks [ended perpetual licenses](https://www.mathworks.com/pricing-licensing.html) in January 2026). Free alternatives install in minutes with no license server or account required.
+MATLAB requires a multi-GB installer and an annual license ($119/year for students, $165/year for home use, $940+/year per seat for professionals -- commonly over $2,000 with toolboxes) (MathWorks [ended perpetual Student and Home licenses](https://www.mathworks.com/pricing-licensing.html) in January 2026). Free alternatives install in minutes with no license server or account required.
 
 RunMat installs on Windows, Linux, and macOS via a one-line command or package manager, and engineers can usually be running scripts within a minute. For zero-install access, the [browser sandbox](https://runmat.com/sandbox) provides a full IDE with editor, console, plotting, and variable inspector. No account required, code stays local (see [Can I run MATLAB code in the browser?](#can-i-run-matlab-code-in-the-browser) below for details). A native desktop app with the same UI and full local file access is coming soon. Built in Rust, RunMat offers consistent behavior across operating systems with no license manager or environment configuration.
 
@@ -424,7 +424,7 @@ Julia offers easy cross-platform installation via downloads or package managers.
 
 RunMat is the only MATLAB-syntax tool that runs entirely client-side in the browser with GPU acceleration and no usage quotas. Other browser options either run on remote servers (MATLAB Online, Octave Online, Google Colab) or run with major constraints (Pyodide).
 
-RunMat provides a full [browser IDE](/docs/desktop-browser-guide) with a MATLAB-style editor, file tree, console, variable inspector, and live GPU-accelerated [plotting](/docs/plotting), all running client-side via WebAssembly. No server processes your code, so there are no time limits or usage quotas. WebGPU acceleration is available in Chrome 113+, Edge 113+, Safari 18+, and Firefox 139+. File persistence requires signing in; a native desktop app with the same UI and full local file access is coming soon. Startup is instant (~5 ms) and the IDE works offline once loaded. Real-time project sync is available for teams who sign in. <a href="/sandbox" data-ph-capture-attribute-destination="sandbox" data-ph-capture-attribute-source="blog-matlab-alternatives" data-ph-capture-attribute-cta="open-sandbox">Open the RunMat sandbox</a> in any supported browser.
+RunMat provides a full [browser IDE](/docs/desktop-browser-guide) with a MATLAB-style editor, file tree, console, variable inspector, and live GPU-accelerated [plotting](/docs/plotting), all running client-side via WebAssembly. No server processes your code, so there are no time limits or usage quotas. WebGPU acceleration is available in Chrome 113+, Edge 113+, Safari 26+, and Firefox 141+. File persistence requires signing in; a native desktop app with the same UI and full local file access is coming soon. Startup is instant (~5 ms) and the IDE works offline once loaded. Real-time project sync is available for teams who sign in. <a href="/sandbox" data-ph-capture-attribute-destination="sandbox" data-ph-capture-attribute-source="blog-matlab-alternatives" data-ph-capture-attribute-cta="open-sandbox">Open the RunMat sandbox</a> in any supported browser.
 
 <a href="/sandbox" data-ph-capture-attribute-destination="sandbox" data-ph-capture-attribute-source="blog-matlab-alternatives" data-ph-capture-attribute-cta="browser-video">
   <video autoPlay loop muted playsInline preload="metadata" poster="https://web.runmatstatic.com/video/posters/3d-interactive-plotting-runmat.png" className="my-6 w-full rounded-lg cursor-pointer">
@@ -432,7 +432,7 @@ RunMat provides a full [browser IDE](/docs/desktop-browser-guide) with a MATLAB-
   </video>
 </a>
 
-MATLAB Online runs on MathWorks' cloud servers, where your browser is just a thin client. It requires a MathWorks account and an internet connection. The free tier caps usage at 20 hours per month with 15-minute execution caps and idle timeouts, and provides 1 vCPU with 4 GB of memory and 5 GB of MATLAB Drive storage (20 GB for licensed users). No GPU acceleration is available in standard cloud sessions. Basic file sharing is available through MATLAB Drive, but there is no real-time co-editing.
+MATLAB Online runs on MathWorks' cloud servers, where your browser is just a thin client. It requires a MathWorks account and an internet connection. The free tier caps usage at 20 hours per month with 15-minute execution caps and idle timeouts, and provides several vCPUs with 16 GB of memory and 5 GB of MATLAB Drive storage (20 GB for licensed users). No GPU acceleration is available in standard cloud sessions. Basic file sharing is available through MATLAB Drive, but there is no real-time co-editing.
 
 Octave Online offers GNU Octave as a free hosted service. Like MATLAB Online, it runs on remote servers. Execution time is strictly limited (~10 seconds per command by default, extendable manually). No GPU support is available. Octave Online does offer real-time collaboration similar to Google Docs for signed-in users, which is useful for teaching and pair work, but the execution constraints make it impractical for serious computation.
 
@@ -458,11 +458,11 @@ x = x0 * cos(omega * t);
 plot(t, x);
 ```
 
-GNU Octave also prioritizes source compatibility, and most MATLAB scripts run with little or no modification. Its syntax and functions closely match MATLAB's, though some newer features or specialized toolboxes may be missing or require Octave Forge packages. Octave's `classdef` support is partial: events, metaclass queries, and some handle-class features are absent or incomplete, which matters for codebases that rely on MATLAB's OOP model. Octave handles most procedural engineering scripts reliably and can read and write `.mat` files, making it a practical choice for reusing MATLAB code. The main differences appear at the edges, in specialized toolboxes and performance at scale.
+GNU Octave also prioritizes source compatibility, and most MATLAB scripts run with little or no modification. Its syntax and functions closely match MATLAB's, though some newer features or specialized toolboxes may be missing or require Octave Forge packages. Octave's `classdef` support is partial: events and metaclass queries are absent, and some handle-class features remain incomplete, which matters for codebases that rely on MATLAB's OOP model. Octave handles most procedural engineering scripts reliably and can read and write `.mat` files, making it a practical choice for reusing MATLAB code. The main differences appear at the edges, in specialized toolboxes and performance at scale.
 
 Python cannot run MATLAB code directly. Tools like [SMOP](https://github.com/victorlei/smop) can auto-translate `.m` files, but results often require manual cleanup. Large codebases usually need to be rewritten by hand, which takes months for anything non-trivial. Many teams instead maintain MATLAB for legacy projects and start new development in Python. The upside is flexibility. Once translated, Python code benefits from its large library collection, but direct reuse of MATLAB code is not realistic.
 
-Julia, like Python, requires rewriting MATLAB code. The transition is somewhat easier because Julia shares MATLAB's 1-based indexing, column-major arrays, and many familiar function names. Numeric code often translates line by line, though plotting, specialized toolboxes, or GUI code require Julia equivalents. Rewriting in Julia can pay off with higher performance and cleaner code design, but reuse is limited to manual porting.
+Julia, like Python, requires rewriting MATLAB code. The transition is somewhat easier because Julia shares MATLAB's 1-based indexing and column-major arrays, and many function names carry over directly. Numeric code often translates line by line, though plotting and any GUI code still require Julia-specific equivalents. Rewriting in Julia can pay off with higher performance and cleaner code design, but reuse is limited to manual porting.
 
 ## Where Octave, Python, and Julia each beat RunMat today
 
@@ -470,9 +470,9 @@ RunMat suits most engineers reusing existing `.m` files. It doesn't suit every w
 
 **Octave.** Octave has a 30+ year track record and is the most cited free MATLAB-compatible interpreter in academic literature. Its [Octave Forge](https://octave.sourceforge.io/) packages for signal processing, image processing, and control systems have been in production use for two decades, and edge cases like older `classdef` patterns and obscure built-ins are often better covered than in any newer entrant. For unattended runs on lab machines that may never see a network, Octave still wins on sheer predictability.
 
-**Python.** Python's library ecosystem is unmatched and unlikely to ever be caught: hundreds of thousands of PyPI packages, the deepest machine-learning toolchain in any language (PyTorch, JAX, scikit-learn), and skills that transfer cleanly to web, data, automation, or production services. If the project is going to grow past numerical computing, Python wins by default regardless of how MATLAB-shaped the original code is.
+**Python.** Python's library ecosystem is unmatched and unlikely to ever be caught: hundreds of thousands of PyPI packages and the deepest machine-learning toolchain in any language (PyTorch, JAX, scikit-learn), with skills that transfer to web development, data pipelines, and production deployment. If the project is going to grow past numerical computing, Python wins by default regardless of how MATLAB-shaped the original code is.
 
-**Julia.** Julia has the highest pure-performance ceiling of the four, and `DifferentialEquations.jl` covers stiff ODEs, SDEs, and DAE systems beyond what MATLAB itself ships. The type system enables compiler-level specialization that MATLAB-syntax tools structurally cannot match for some workloads, and the `Project.toml` / `Manifest.toml` reproducibility model is cleaner than Python's. When the workload is HPC-class and you're willing to write in a new language, Julia is hard to beat on raw technical merit.
+**Julia.** Julia has the highest pure-performance ceiling of the four, and `DifferentialEquations.jl` covers stiff ODEs and SDEs alongside DAE systems well beyond what MATLAB itself ships. The type system enables compiler-level specialization that MATLAB-syntax tools structurally cannot match for some workloads, and the `Project.toml` / `Manifest.toml` reproducibility model is cleaner than Python's. When the workload is HPC-class and you're willing to write in a new language, Julia is hard to beat on raw technical merit.
 
 ## How do I trust the numerical results?
 
@@ -480,7 +480,7 @@ Bit-exact parity with MATLAB is not a meaningful goal for any runtime. IEEE 754 
 
 MATLAB is a closed binary, so the evidence chain stops at the vendor. NumPy, SciPy, and Octave are open source and document their dependencies, but none publishes a consolidated per-builtin coverage table. Julia is open source with strong test coverage in its standard library, though documenting *every* numerical backend is left to package authors.
 
-RunMat publishes a single [Correctness & Trust](/docs/correctness) page listing every numerical builtin, its implementation (external Rust crate, LAPACK routine, or in-repo solver), a live GitHub link to the parity test, and the enforced tolerance. Every GPU-accelerated path is tolerance-checked against its CPU reference. Every parity test ships in the repository and runs with standard `cargo test`, with no MATLAB license and no external data files required. If a dependency version bump breaks a tolerance in CI, the bump doesn't ship.
+RunMat publishes a single [Correctness & Trust](/docs/correctness) page listing every numerical builtin, its implementation source (external Rust crate, LAPACK routine, or in-repo solver) alongside a live GitHub link to the parity test and the enforced tolerance. Every GPU-accelerated path is tolerance-checked against its CPU reference. Every parity test ships in the repository and runs with standard `cargo test`, with no MATLAB license and no external data files required. If a dependency version bump breaks a tolerance in CI, the bump doesn't ship.
 
 ## Which have built-in version control?
 
@@ -498,7 +498,7 @@ Most MATLAB engineers have no version control because git was not designed for t
 
 ## Handling datasets larger than 10 GB
 
-Engineering datasets routinely exceed 10 GB per project. Wind tunnel measurements, sensor logs, and simulation outputs all dwarf the code producing them. The free alternatives handle this very differently.
+Engineering datasets routinely exceed 10 GB per project. Wind tunnel data, sensor logs, simulation outputs, post-processing results -- they all dwarf the code producing them. The free alternatives handle this very differently.
 
 | Tool | Approach | Sharding / large-file handling |
 |------|---------|-------------------------------|
@@ -529,9 +529,9 @@ RunMat's airgap path is straightforward: copy one binary onto approved media, ru
 ## Which is easiest to learn?
 Switching from MATLAB means learning not just new syntax, but new habits. The quality of tutorials, forums, and documentation often determines whether the transition goes well.
 
-RunMat and Octave have the smallest learning curves because they preserve MATLAB syntax. RunMat's community is still small, but MATLAB resources apply directly, and the [open-source model](/docs/contributing) means you can file issues and talk to the developers on GitHub. Octave has a longer track record in academia, with mailing lists, a wiki, and Octave Forge packages that replace MATLAB's toolbox system. Octave's syntax is fine; the sticking points are edge cases like GUI building and Java interop, which remain less polished.
+RunMat and Octave have the smallest learning curves because they preserve MATLAB syntax. RunMat's community is still small, but MATLAB resources apply directly, and the [open-source model](/docs/contributing) means you can file issues and talk to the developers on GitHub. Octave has a longer track record in academia, with mailing lists and a wiki, plus Octave Forge packages that replace MATLAB's toolbox system. Octave's syntax is fine; the sticking points are edge cases like GUI building and Java interop, which remain less polished.
 
-Python requires the biggest adjustment. Engineers must learn indentation-scoped blocks, 0-based indexing, and a modular library stack (NumPy, SciPy, Matplotlib, Pandas). The upside is a large community, thousands of tutorials, and wide university adoption. After the initial ramp, many engineers prefer Python for general-purpose work beyond numerical computing. Julia sits between: its syntax is close to MATLAB's, but MATLAB veterans need to unlearn forced vectorization since Julia's loops are already fast. Julia's community is smaller but active, with documentation written specifically for MATLAB switchers.
+Python requires the biggest adjustment. Engineers must learn indentation-scoped blocks and 0-based indexing, then assemble a modular library stack (NumPy, SciPy, Matplotlib, Pandas). The upside is a massive community with thousands of tutorials and broad university adoption. After the initial ramp, many engineers prefer Python for general-purpose work beyond numerical computing. Julia sits between: its syntax is close to MATLAB's, but MATLAB veterans need to unlearn forced vectorization since Julia's loops are already fast. Julia's community is smaller but active, with documentation written specifically for MATLAB switchers.
 
 ## See it in action
 
@@ -551,19 +551,19 @@ plot(1:length(s), s);
 
 ### What is the best free alternative to MATLAB?
 
-RunMat is the best free alternative for engineers who want to run existing `.m` files. It is JIT-compiled, supports automatic GPU acceleration across NVIDIA, AMD, Intel, and Apple hardware, and runs in the browser without any install. GNU Octave is the most mature option and works well for teaching and legacy scripts. Python and Julia are free but require rewriting MATLAB code in new syntax.
+RunMat is the best free alternative for engineers who want to run existing `.m` files. It is JIT-compiled with automatic GPU acceleration across NVIDIA, AMD, Intel, and Apple hardware, and it runs in the browser without any install. GNU Octave is the most mature option and works well for teaching and legacy scripts. Python and Julia are free but require rewriting MATLAB code in new syntax.
 
 ### Is there a free version of MATLAB?
 
-MATLAB itself is not free. MathWorks ended perpetual licenses in January 2026 and sells subscriptions ($119/year for students, $165/year for home use, $2,000+ per seat for professionals). Free, open-source alternatives include RunMat, GNU Octave, Python, and Julia.
+MATLAB itself is not free. MathWorks ended perpetual Student and Home licenses in January 2026 and now sells subscriptions starting at $119/year for students, $165/year for home use, and $940/year per seat for professionals (commonly over $2,000 with toolboxes). Free, open-source alternatives include RunMat, GNU Octave, Python, and Julia.
 
 ### What is the best open-source MATLAB alternative?
 
-RunMat and GNU Octave are the leading open-source alternatives. RunMat is Apache-2.0 licensed and is the only one that pairs a JIT with automatic GPU acceleration and a built-in browser IDE. Octave is GPL-licensed and has 30+ years of maturity, at the cost of no JIT and no GPU support.
+RunMat and GNU Octave are the leading open-source alternatives. RunMat is Apache-2.0 licensed and is the only one that pairs a JIT and automatic GPU acceleration with a built-in browser IDE. Octave is GPL-licensed and has 30+ years of maturity, at the cost of no JIT and no GPU support.
 
 ### Is there a free MATLAB alternative for Linux?
 
-Yes. RunMat, Octave, Python, and Julia all run natively on Linux and install via package managers or a single binary. RunMat also runs in the browser with GPU acceleration on Linux via WebGPU (Chrome 113+, Firefox 139+).
+Yes. RunMat, Octave, Python, and Julia all run natively on Linux and install via package managers or a single binary. RunMat also runs in the browser with GPU acceleration on Linux via WebGPU (Chrome 113+, Firefox 141+).
 
 ### Is there a free alternative to Simulink?
 
@@ -571,7 +571,7 @@ None of the free MATLAB alternatives replicate Simulink's graphical block-diagra
 
 ### How much does a MATLAB license cost?
 
-As of 2026, MATLAB costs $119/year for students, $165/year for home users, and $2,000+ per seat per year for professional use, with toolboxes adding further cost. MathWorks ended perpetual licenses in January 2026, making the pricing subscription-only.
+As of 2026, MATLAB subscriptions start at $119/year for students, $165/year for home users, and $940/year per seat for professional use, with toolboxes adding $500–$1,500 each. MathWorks ended perpetual Student and Home licenses in January 2026; commercial perpetual licenses remain available at $2,150+.
 
 ### Can I run MATLAB code online without installing anything?
 
@@ -579,7 +579,7 @@ Yes. RunMat's [browser sandbox](https://runmat.com/sandbox) runs MATLAB-syntax c
 
 ### Python vs Octave: which is better for MATLAB users?
 
-GNU Octave is better if the goal is reusing existing `.m` files; Octave preserves MATLAB syntax and most scripts run unmodified. Python is better if you plan to rewrite code and want access to its much larger library set (ML, web, and automation), with the tradeoff that MATLAB code must be ported.
+GNU Octave is better if the goal is reusing existing `.m` files; Octave preserves MATLAB syntax and most scripts run unmodified. Python is better if you plan to rewrite code and want access to its much larger library set (ML, web development, data pipelines, automation), with the tradeoff that MATLAB code must be ported.
 
 ### What is the best free alternative to MATLAB for existing code?
 
@@ -596,6 +596,6 @@ RunMat includes automatic per-save versioning with immutable snapshots and git e
 RunMat ships as a single static binary with no external dependencies or license server, making it straightforward to deploy on air-gapped networks. MATLAB requires a FlexLM license server, and Python requires pre-staging all package dependencies.
 
 ## Before your next MATLAB renewal
-MathWorks ended perpetual licenses in January 2026. If your team is facing a renewal, run your actual `.m` files through RunMat and Octave before signing. The gap between what free alternatives cover and what MATLAB charges $2,000+ per seat for has narrowed enough that many teams can switch without rewriting code. For workloads that need Python or Julia, those tools complement rather than replace MATLAB-syntax alternatives.
+MathWorks ended perpetual Student and Home licenses in January 2026, and professional subscriptions start at $940/year per seat before toolboxes. If your team is facing a renewal, run your actual `.m` files through RunMat and Octave before signing. The gap between what free alternatives cover and what MATLAB charges for has narrowed enough that many teams can switch without rewriting code. For workloads that need Python or Julia, those tools complement rather than replace MATLAB-syntax alternatives.
 
 *Try RunMat free today at [runmat.com](https://runmat.com). RunMat is a free, open source community project developed by [Dystr](https://dystr.com).*

--- a/website/content/blog/matlab-vs-octave.md
+++ b/website/content/blog/matlab-vs-octave.md
@@ -14,6 +14,7 @@ excerpt: "An engineering retrospective on what MATLAB compatibility costs to bui
 ogType: "article"
 ogTitle: "MATLAB vs Octave: 30 Years of Compatibility and What Changed in 2026"
 ogDescription: "MATLAB compatibility is a bigger engineering problem than it looks. Octave figured out most of it over 30+ years. What that work entails, and what is different in 2026."
+image: "https://web.runmatstatic.com/blog-images/MATLAB-v-Octave.png"
 twitterCard: "summary_large_image"
 twitterTitle: "MATLAB vs Octave: 30 Years of Compatibility and What Changed"
 twitterDescription: "An engineering retrospective on what MATLAB compatibility costs to build, what Octave got right, and what changed in 2026."

--- a/website/content/blog/matlab-vs-octave.md
+++ b/website/content/blog/matlab-vs-octave.md
@@ -1,0 +1,294 @@
+---
+title: "MATLAB vs Octave: 30 Years of Compatibility and What Changed in 2026"
+description: "MATLAB vs Octave compared from the inside. What Octave got right over 30+ years of compatibility work, where the gaps are, and what is different about building a MATLAB-compatible runtime in 2026."
+date: "2026-04-24"
+readTime: "15 min read"
+authors:
+  - name: "Fin Watterson"
+    url: "https://www.linkedin.com/in/finbarrwatterson/"
+slug: "matlab-vs-octave"
+visibility: "unlisted"
+tags: ["MATLAB", "Octave", "GNU Octave", "RunMat", "scientific computing"]
+keywords: "matlab vs octave, gnu octave, octave alternative, matlab compatibility, john w eaton, octave forge, matlab compatible runtime"
+excerpt: "An engineering retrospective on what MATLAB compatibility costs to build, what Octave got right over 30+ years, and what has changed about building this kind of runtime in 2026."
+ogType: "article"
+ogTitle: "MATLAB vs Octave: 30 Years of Compatibility and What Changed in 2026"
+ogDescription: "MATLAB compatibility is a bigger engineering problem than it looks. Octave figured out most of it over 30+ years. What that work entails, and what is different in 2026."
+twitterCard: "summary_large_image"
+twitterTitle: "MATLAB vs Octave: 30 Years of Compatibility and What Changed"
+twitterDescription: "An engineering retrospective on what MATLAB compatibility costs to build, what Octave got right, and what changed in 2026."
+canonical: "https://runmat.com/blog/matlab-vs-octave"
+jsonLd:
+  "@context": "https://schema.org"
+  "@graph":
+    - "@type": "BreadcrumbList"
+      itemListElement:
+        - "@type": "ListItem"
+          position: 1
+          name: "RunMat"
+          item: "https://runmat.com"
+        - "@type": "ListItem"
+          position: 2
+          name: "Blog"
+          item: "https://runmat.com/blog"
+        - "@type": "ListItem"
+          position: 3
+          name: "MATLAB vs Octave"
+          item: "https://runmat.com/blog/matlab-vs-octave"
+
+    - "@type": "TechArticle"
+      "@id": "https://runmat.com/blog/matlab-vs-octave#article"
+      headline: "MATLAB vs Octave: 30 Years of Compatibility and What Changed in 2026"
+      description: "An engineering retrospective on what MATLAB compatibility costs to build, what Octave got right over 30+ years, and what has changed about building a MATLAB-compatible runtime in 2026."
+      datePublished: "2026-04-24T00:00:00Z"
+      proficiencyLevel: "Professional"
+      hasPart:
+        "@id": "https://runmat.com/blog/matlab-vs-octave#faq"
+      author:
+        - "@type": "Person"
+          name: "Fin Watterson"
+          url: "https://www.linkedin.com/in/finbarrwatterson/"
+      publisher:
+        "@id": "https://runmat.com/#organization"
+      about:
+        - "@type": "SoftwareApplication"
+          name: "GNU Octave"
+          applicationCategory: "ScientificApplication"
+          operatingSystem: "Windows, Linux, macOS"
+          offers:
+            "@type": "Offer"
+            price: "0"
+            priceCurrency: "USD"
+        - "@type": "SoftwareApplication"
+          name: "MATLAB"
+          applicationCategory: "ScientificApplication"
+          operatingSystem: "Windows, Linux, macOS"
+        - "@type": "SoftwareApplication"
+          name: "RunMat"
+          applicationCategory: "ScientificApplication"
+          operatingSystem: "Browser, Windows, Linux, macOS"
+          offers:
+            "@type": "Offer"
+            price: "0"
+            priceCurrency: "USD"
+
+    - "@type": "FAQPage"
+      "@id": "https://runmat.com/blog/matlab-vs-octave#faq"
+      mainEntityOfPage:
+        "@id": "https://runmat.com/blog/matlab-vs-octave"
+      mainEntity:
+        - "@type": "Question"
+          name: "Is GNU Octave the same as MATLAB?"
+          acceptedAnswer:
+            "@type": "Answer"
+            text: "No. GNU Octave is a free, open-source interpreter that aims for compatibility with MATLAB's language and .mat file format. Most MATLAB scripts run in Octave with little or no modification, but Octave lacks a JIT compiler, GPU support, Simulink, and many specialized toolboxes."
+        - "@type": "Question"
+          name: "Is Octave slower than MATLAB?"
+          acceptedAnswer:
+            "@type": "Answer"
+            text: "For loop-heavy code, yes. Octave is an interpreter with no JIT compiler, so loops can run 10x to 100x slower than in MATLAB or Julia. Vectorized operations perform better because they call compiled C/Fortran routines internally."
+        - "@type": "Question"
+          name: "Does Octave support GPU acceleration?"
+          acceptedAnswer:
+            "@type": "Answer"
+            text: "No. GNU Octave has no GPU support. MATLAB offers GPU computing via the Parallel Computing Toolbox (NVIDIA only). RunMat provides automatic cross-vendor GPU acceleration on NVIDIA, AMD, Intel, and Apple hardware."
+        - "@type": "Question"
+          name: "Can Octave open MATLAB .mat files?"
+          acceptedAnswer:
+            "@type": "Answer"
+            text: "Yes. Octave supports .mat file formats from v4 through v7.3 (HDF5). Engineers can move .mat files between MATLAB and Octave without conversion."
+        - "@type": "Question"
+          name: "Does Octave support MATLAB classdef?"
+          acceptedAnswer:
+            "@type": "Answer"
+            text: "Partially. Octave supports properties, methods, inheritance, and basic handle classes. Events, metaclass queries via ?ClassName, and some handle-class edge cases remain incomplete."
+        - "@type": "Question"
+          name: "Why is Octave called Octave?"
+          acceptedAnswer:
+            "@type": "Answer"
+            text: "Octave is named after Octave Levenspiel, a chemical engineering professor known for his textbook on chemical reaction engineering. The name has nothing to do with music."
+        - "@type": "Question"
+          name: "Who created GNU Octave?"
+          acceptedAnswer:
+            "@type": "Answer"
+            text: "John W. Eaton created GNU Octave. He began development in February 1992 while at the University of Texas. The project was conceived around 1988 as companion software for a chemical reactor design textbook."
+---
+
+Write `Z = Y * X'` in MATLAB and you are looking at a matrix multiply and transpose. The code reads like the equation on the whiteboard. Engineers who review Kalman filters or finite element assemblies for a living rely on that: if the code matches the derivation, mistakes are visible. If it doesn't, they aren't.
+
+The language was never the part people wanted to leave. MathWorks took MATLAB commercial in 1984, and by the early 1990s it was the standard computational tool in engineering departments. John W. Eaton was finishing his PhD at the University of Texas in 1992 when he and his colleagues, James B. Rawlings (Wisconsin-Madison) and John G. Ekerdt (UT Austin), were writing a chemical reactor design textbook. The faculty used MATLAB for the computational exercises. The students were stuck with Fortran. In his [DSC-2001 paper](https://r-project.org/conferences/DSC-2001/Proceedings/Eaton.pdf), Eaton wrote that "we eventually decided to implement something that would be mostly Matlab-compatible so that our colleagues could switch to using Octave without having to learn a completely new language." One of the project's explicit goals, as he later told the [FSF](https://www.fsf.org/blogs/licensing/interview-with-john-w.-eaton-of-gnu-octave), was "to liberate the code written for the proprietary program, MATLAB."
+
+The first Octave alpha (version 0.60) shipped on January 4, 1993. Version 1.0 followed in February 1994. Thirty-two years later, Octave 11.1 shipped in February 2026 and the project remains actively maintained. The name honors [Octave Levenspiel](https://en.wikipedia.org/wiki/Octave_Levenspiel), a chemical engineering professor known for his textbook on reaction engineering. It has nothing to do with music.
+
+We build [RunMat](https://runmat.com), which is trying to do the same thing with a different engine. We have been working on the same compatibility surface Eaton defined, so everything here comes with that bias.
+
+## What "MATLAB compatibility" actually requires
+
+Most people who say "MATLAB compatible" are thinking about syntax: 1-based indexing, column-major storage, the colon operator, `A * B` for matrix multiply. That part is real but small. The actual surface area is much larger.
+
+MATLAB is a coupled system. The language, the data format, the plotting model, and the command-line semantics all depend on each other. A partial list of what "compatibility" means in practice:
+
+The type system is one example. Every value is an array. Scalars are 1x1 arrays. Strings have historically been char arrays (row vectors of character codes), with a newer `string` type layered on top. Complex numbers are a property of the array, not a separate type. Logical arrays behave like numeric arrays in arithmetic but have different indexing semantics.
+
+Then there is the OOP layer. MATLAB's `classdef` system supports properties with validation, methods, events, handle classes (reference semantics), value classes (copy semantics), enumerations, and the `?ClassName` metaclass operator for runtime introspection. Codebases written after R2008a increasingly depend on this, and it is one of the hardest subsystems to replicate.
+
+Variadic functions interact with cell array expansion and struct field access in ways that require careful handling of the call stack. `[a, b] = deal(x, y)` and `{c{:}} = func()` are both valid and both exercise different code paths.
+
+Indexing is deceptively complex. `end` inside an index expression computes the size of the relevant dimension, and it composes: `A(end-1:end, :)` requires the runtime to know which dimension `end` refers to at each position. Every indexing syntax dispatches through `subsref` and `subsasgn` in user-defined classes, whether it is curly-brace access into cells or dot access into structs.
+
+The `.mat` binary format is another surface. MathWorks has revised it at least five times (v4, v5, v6, v7, v7.3/HDF5), each with different compression and type representation. Real-world codebases contain files saved across decades of MATLAB versions. How much of this a compatible runtime needs to support depends on the use case: production data pipelines increasingly use HDF5 or Parquet directly, but lab environments often still pass `.mat` files around.
+
+Command syntax creates parser ambiguity. `hold on` is valid MATLAB. So is `hold('on')`. The parser needs to distinguish between commands (where arguments are unquoted strings) and function calls (where arguments are expressions), and it resolves the ambiguity using heuristics about what names are known functions. The parser's behavior depends on what's on the path.
+
+MATLAB also maintains global state tracking which figure and axes are current (`gcf`, `gca`). Plotting commands like `plot`, `hold`, `title`, and `xlabel` implicitly target this state. Replicating the plotting model means replicating this stateful architecture.
+
+Any tool that calls itself "MATLAB compatible" is committing to all of this, plus package namespaces (`+pkg/` directories), the `MException` error hierarchy, function handles with closures, and dozens of other subsystems. The syntax is the easy part.
+
+A single function can exercise most of these surfaces at once:
+
+```matlab
+function [peak, idx] = find_peak(data, opts)
+    results = opts.filters{end};          % cell indexing + end arithmetic
+    [~, idx] = max(data(end-99:end, :));  % end arithmetic, multiple returns, ~ discard
+    peak = data(idx, :);
+
+    fig = figure;                         % implicit gcf state
+    plot(data); hold on                   % command syntax (unquoted string arg)
+    plot(idx, peak, 'ro');
+    title(sprintf('Peak at index %d', idx))
+end
+```
+
+Each line depends on a different subsystem. A compatible runtime has to get all of them right simultaneously.
+
+## Where Octave made choices that lasted
+
+Octave has been maintained for over three decades. A project that survives that long does so because of specific engineering decisions, not accident. Four of Octave's choices are worth examining because they defined what MATLAB compatibility means in practice.
+
+### MAT file support as a compatibility investment
+
+Octave has read/write support for `.mat` files from version 4 through version 7.3 (HDF5). Getting it right required tracking every revision MathWorks made to the binary format, including changes to compression behavior and Unicode string encoding, plus the complete shift to HDF5 in v7.3. The payoff is that engineers can move `.mat` files between MATLAB and Octave without conversion, and that interoperability has been one of Octave's strongest adoption drivers. Whether the `.mat` format remains the right long-term serialization choice is a separate question. HDF5 and Parquet are increasingly common in production pipelines, and newer runtimes may reasonably choose to prioritize those over a proprietary binary specification.
+
+### Octave Forge as a distribution model
+
+Before pip or Julia's `Pkg` existed, Octave Forge provided a curated set of MATLAB-toolbox equivalents with stable naming conventions: `signal`, `image`, `control`, `statistics`, `optim`. The system was never as polished as modern package managers. Installing packages involved downloading tarballs and running `pkg install`. But Octave Forge solved the distribution problem for scientific computing packages years before the rest of the open-source world converged on package management as a standard practice. [Octave 11](https://octave.org/NEWS-11.html) improved the experience in February 2026 with `pkg search` for finding packages by keyword and SHA256 verification for downloaded archives, removing the need for the old `-forge` flag.
+
+### A formal grammar via Bison
+
+Octave's parser is generated by GNU Bison from a formal grammar specification. This is a deliberate engineering choice with a clear trade-off. On the positive side, a formal grammar makes it possible to track MATLAB's syntax evolution predictably: when MathWorks adds new syntax, the Octave team can extend the grammar rules rather than patching an ad hoc parser. On the negative side, Bison-generated parsers produce error messages that read like compiler diagnostics, not like REPL feedback. For an interactive tool used by students and engineers who are not compiler specialists, that error quality trade-off is a real cost, and it is a cost Octave has paid for 30+ years in exchange for parser correctness.
+
+### GPL as a stability mechanism
+
+Eaton chose the GPL deliberately. In his [FSF interview](https://www.fsf.org/blogs/licensing/interview-with-john-w.-eaton-of-gnu-octave), he said the primary reason was preventing proprietary derivatives. In practice, the GPL has also served as a stability mechanism: Octave has never been acquired, rebranded, relicensed, or had its development redirected by a corporate sponsor. For engineering teams shipping multi-decade projects (defense and energy in particular), the confidence that the tool's license and governance will not change is itself a material property. Octave joined the GNU project in May 1997 and the license has been updated exactly once, from GPLv2 to GPLv3, when the new version was released.
+
+## Where MATLAB moved and Octave didn't follow
+
+Octave tracks a moving target. MATLAB has added major language and runtime features over the past decade, and Octave has not matched all of them. Five areas where the gap matters most:
+
+Octave's `classdef` support is partial. It handles properties, methods, inheritance, and basic handle classes. Events and metaclass queries via `?ClassName` remain incomplete, and some handle-class edge cases are missing entirely. For legacy procedural code this is irrelevant. For codebases built around MATLAB's OOP model after roughly R2014b, it is a real constraint.
+
+```matlab
+classdef Sensor < handle
+    properties
+        Name    string
+        Value   double {mustBeFinite}
+    end
+
+    events
+        ThresholdExceeded   % Octave cannot parse this block
+    end
+
+    methods
+        function update(obj, v)
+            obj.Value = v;
+            if v > 100
+                notify(obj, 'ThresholdExceeded');  % no-op in Octave
+            end
+        end
+    end
+end
+% Octave handles: properties, methods, handle inheritance
+% Octave cannot handle: events block, notify(), property validation
+```
+
+The JIT experiment did not ship. Octave added experimental JIT compilation using LLVM in version 3.8.0 (December 2013), based on Max Brister's GSoC 2012 work, but it was disabled by default and only accelerated simple loops. The [Octave wiki](https://wiki.octave.org/JIT) documents the history: LLVM's API kept breaking backward compatibility across minor releases, and the JIT never matured beyond a proof of concept. The code was [removed from the Octave source tree entirely in 2021](https://wiki.octave.org/JIT). As a result, Octave remains an interpreter, and loop-heavy code runs 10x to 100x slower than in MATLAB or Julia.
+
+GPU acceleration is absent. MATLAB added GPU support via the Parallel Computing Toolbox in 2010. Octave has not followed. Computations run on CPU only. For workloads where GPU offloading matters (large-scale Monte Carlo and image processing pipelines in particular), this is the gap that sends teams back to MATLAB or to Python's PyTorch/CuPy.
+
+Toolbox coverage has a ceiling. Octave Forge provides solid packages for signal processing, image processing, control systems, and statistics. But MathWorks sells roughly 80 specialized toolboxes and add-on products, and several of the most commercially important ones have no Octave equivalent at all: Simulink, Stateflow, Model-Based Design, Embedded Coder, MATLAB Compiler, Polyspace. These are the products that drive six-figure MATLAB site licenses, and no open-source project has replicated them. This is the gap that actually determines whether a team can leave MATLAB.
+
+The IDE trails MATLAB's. Octave's Qt-based GUI is functional: it has an editor, a file browser, a variable inspector, and a command window. It works. But MATLAB's Live Editor with inline plots, cell evaluation markers, integrated debugger, and documentation tooltips is a generation ahead in UX. For teams who use the IDE heavily, Octave feels dated.
+
+None of this diminishes what Octave is. A free, GPL-licensed, MATLAB-compatible interpreter that has been continuously maintained since 1993 is an extraordinary achievement. The gaps exist because MathWorks has had a billion-dollar revenue base funding development for decades, and Octave has had volunteers.
+
+| Capability | MATLAB | GNU Octave | RunMat |
+| :-- | :--: | :--: | :--: |
+| `classdef` OOP (properties, methods, events) | Full | Partial (no events, limited metaclass) | Full |
+| JIT compilation | Yes | No (experiment removed 2021) | Tiered (interpreter + Cranelift JIT) |
+| GPU acceleration | NVIDIA only (Parallel Computing Toolbox, extra license) | None | Automatic, cross-vendor (Metal, Vulkan, DX12, WebGPU) |
+| `.mat` file I/O (v4 through v7.3/HDF5) | Full | Full | Not yet (HDF5 and Parquet prioritized) |
+| Browser / WebAssembly | No | No | Yes (client-side via WASM + WebGPU) |
+| Toolbox breadth | ~80 toolboxes (Simulink, Stateflow, Embedded Coder, etc.) | Octave Forge (~70 packages) | Growing package system, 400+ builtins |
+| Async / non-blocking I/O | `parfeval` (Parallel Computing Toolbox) | No | Native (entire VM is async) |
+| Simulink / graphical modeling | Yes | No | No |
+| License | Proprietary, subscription (~$2,000+/seat) | GPL v3, free | MIT, free |
+
+## What changed about building a MATLAB runtime
+
+Several engineering constraints that shaped Octave's architecture have shifted since the project was designed. This is not a criticism of the decisions Octave made. A project started in 1992 and built in C++ with the tools available then was working within a different set of possibilities. Six changes matter:
+
+### Tiered JIT compilation is proven infrastructure
+
+When Octave experimented with JIT compilation in the early 2010s, the approach was still risky for highly dynamic languages. Since then, V8 (TurboFan), JavaScriptCore, LuaJIT, and Julia's type-inferring compiler have all demonstrated that interpret-first, profile-guided tiered compilation works reliably for languages with dynamic dispatch and runtime polymorphism. The key lesson from these systems is that the JIT has to be designed into the runtime from the start. Bolting a type-specialized compiler onto an existing untyped interpreter, which is roughly what Octave's JIT experiment attempted, is structurally harder than building the intermediate representation to carry shape and type information from day one. RunMat's architecture follows the same tiered model as V8: code starts in an interpreter, hot paths compile to optimized machine code via Cranelift, and the transition is invisible to the user. In practice this means a `for` loop over a million iterations runs [150x-180x faster](/blog/matlab-for-loop-performance) than the same loop in Octave.
+
+### GPU compute is no longer optional
+
+Both MATLAB and Octave were designed when compute meant CPU. MATLAB's original architecture dates to the 1980s. Octave's dates to 1992. In both, execution is single-threaded and synchronous: one operation finishes before the next one starts. MATLAB added GPU support in 2010 via the Parallel Computing Toolbox, but it requires explicit `gpuArray` calls, only works with NVIDIA hardware, and costs an additional license. Octave never added GPU support at all.
+
+The reason this matters for numerical computing specifically is that the workloads MATLAB users run (matrix multiplies, FFTs, Monte Carlo simulations, elementwise operations over large arrays) are exactly the kind of embarrassingly parallel, memory-bandwidth-bound work that GPUs were designed to accelerate. A CPU processes these operations sequentially or with a handful of SIMD lanes. A GPU processes thousands of elements simultaneously. For a 10-million-element array operation, the difference is not incremental. It can be 100x.
+
+The hardware is already there. Every laptop ships with a GPU. Apple Silicon unifies CPU and GPU memory. Cloud instances routinely come with accelerators. The bottleneck is not hardware availability. It is that MATLAB and Octave require the user to manually manage GPU transfers, or in Octave's case offer no GPU path at all.
+
+In 2010, GPU computing for engineers meant CUDA on NVIDIA hardware. In 2026, Metal (Apple), Vulkan (Linux/Windows/Android), DirectX 12 (Windows), and WebGPU (browsers) are all mature. A single abstraction layer like [wgpu](https://wgpu.rs/) (written in Rust, used by Firefox) can target all of them from one codebase. RunMat uses wgpu to offer [automatic GPU acceleration](/blog/how-to-use-gpu-in-matlab) on NVIDIA, AMD, Intel, and Apple hardware, including in the browser via WebGPU. The user writes the same MATLAB code they always wrote. The runtime decides what goes to the GPU, fuses elementwise chains into single kernels, and keeps data [resident on-device](/docs/accelerate/gpu-behavior) between operations. On memory-bound workloads the result is measurable: Monte Carlo simulations (5M paths) run [~2.8x faster than PyTorch and ~130x faster than NumPy](/blog/runmat-accelerate-fastest-runtime-for-your-math). Julia's Metal.jl and AMDGPU.jl take a per-vendor approach with separate packages for each backend; Octave has no GPU path at all.
+
+### Async-native execution changes what a runtime can do
+
+MATLAB and Octave both run code synchronously: call a function, wait for it to return, move to the next line. That model was fine when all compute was CPU-bound and local. It becomes a bottleneck when a script needs to fetch data from an API, write results to cloud storage, wait for a GPU kernel to finish, or coordinate multiple long-running tasks. In MATLAB, the answer is `parfeval` and the Parallel Computing Toolbox (another paid add-on). In Octave, there is no answer. The runtime blocks.
+
+RunMat's VM, all builtins, and the GPU provider run on an async substrate. Every evaluation is a Rust future under the hood, even synchronous code (which just completes immediately). This means I/O, GPU dispatch, and network calls are non-blocking by design. The runtime can overlap GPU kernel execution with CPU-side work, stream file reads while processing earlier chunks, and integrate naturally with the Tokio ecosystem for HTTP, websockets, and cloud storage. For existing MATLAB code, nothing changes. The code runs exactly as it always did. But the runtime is not stalling while the GPU finishes or the disk writes.
+
+### Memory-safe systems languages are mainstream
+
+Octave is written in C++, started before smart pointers were standardized and before memory sanitizers existed. This is not a criticism of the codebase. It is a statement about what was available. A runtime started in 2023 in Rust or modern C++20 has structurally different memory safety properties: null pointer dereferences and use-after-free bugs are caught at compile time rather than discovered in production. The Rust compiler's borrow checker eliminates entire categories of bugs that C++ projects spend significant testing effort to find. This changes the maintenance economics of a numerical runtime, especially one that ships to security-conscious environments.
+
+### WebAssembly is a real deployment target
+
+WebAssembly did not exist in any usable form during Octave's formative decades. WASM 1.0 shipped in browsers in 2017; WASI (the server-side standard) is still maturing. A runtime designed today can compile to WASM and run in the browser from day one, without installing anything or requesting administrator permissions. Octave has no production WebAssembly build. Pyodide brings Python to the browser via WASM but with real performance constraints and no GPU access. RunMat compiles to WASM and ships a full [browser IDE](https://runmat.com/sandbox) with editor, console, plotting, and GPU acceleration. No install, no account, startup in ~5 ms. For a MATLAB-compatible tool, that changes how engineers first encounter it: paste a `.m` file and run it before deciding whether to install anything.
+
+### Tolerance-checked numerical testing is standard practice
+
+QuickCheck-style property-based testing was introduced in 1999 but took roughly twenty years to become standard in numerical libraries. A 2026-era runtime can build its test suite from the start with tolerance-checked parity tests against LAPACK and BLAS references and GPU-vs-CPU parity fuzzing across SIMD widths, publishing per-builtin coverage tables alongside the code. Octave has tests, but retrofitting a 30-year-old test suite with modern numerical fuzzing methodology requires investment that competes with feature development for volunteer time. The result is a difference in how confidently users can evaluate correctness: RunMat publishes a [Correctness and Trust](/docs/correctness) page listing every numerical builtin with its implementation source and parity test; Octave's tests are in the source tree but not consolidated into a single auditable reference.
+
+The ceiling for what a MATLAB-compatible runtime can deliver is higher now than when Octave was designed. That ceiling keeps moving. And the argument for keeping MATLAB syntax specifically has only gotten stronger: millions of engineers already know it and decades of course material teach it. The cost of switching languages is not just rewriting code. It is retraining teams and losing the ability to hire someone who can be productive on day one. A modern engine under a familiar language avoids all of that.
+
+What has not changed is that compatibility is hard, the surface area is enormous, and any new entrant inherits both the prior art and the obligation to get the details right.
+
+## Where MATLAB still wins
+
+Neither Octave nor RunMat replicates Simulink's graphical block-diagram modeling, and neither is likely to. Simulink and Stateflow are distinct products with their own engineering complexity. Engineers who depend on graphical modeling still need MATLAB or need to rewrite their workflows as scripts. This is the single largest reason MATLAB renewals happen at the enterprise level.
+
+Full toolbox parity is also not a realistic goal. MathWorks sells roughly 80 toolboxes developed by domain specialists over decades. Neither project will replicate all of them. Both projects pick which toolboxes to cover based on user demand. The honest answer for any MATLAB user evaluating free alternatives is: check whether the specific functions your code calls are supported, rather than assuming blanket compatibility.
+
+The IDE story is more nuanced. MATLAB's Live Editor with inline output, cell evaluation, integrated profiler, and breakpoint debugging has had decades of iteration. Octave's Qt GUI is functional but dated. RunMat's editor takes a different approach with a modern [browser-based IDE](/docs/desktop-browser-guide), a first-party [VS Code / Cursor extension](https://marketplace.visualstudio.com/items?itemName=runmat.runmat) with LSP-powered diagnostics and completions, and a [cloud-based sandbox](https://runmat.com/sandbox) that runs entirely client-side. The tooling philosophy differs: rather than replicating MATLAB's monolithic IDE, RunMat integrates into the editors engineers already use.
+
+The advantage of choosing MATLAB syntax shows up most clearly in switching costs. MATLAB is taught in engineering programs worldwide, which means any engineer hired off a campus or out of a lab already knows the language. Moving a team to Python or Julia means retraining everyone on an entirely new language and toolchain. Moving a team to Octave or RunMat means the code they already know how to write runs as-is. The language-level friction is near zero. Toolbox gaps and Simulink dependencies are real migration costs, but the language itself is not one of them, and that is a deliberate design choice.
+
+Choosing a free MATLAB-compatible runtime in 2026 is a practical decision, not an ideological one. Use Octave or RunMat where they fit. Keep MATLAB where the toolbox dependency or Simulink requirement makes switching impractical.
+
+## Credit where it is due
+
+John W. Eaton built Octave because students were struggling with Fortran and his department needed a free tool that could run the same code as the commercial product the faculty used. That decision, made in 1992, produced a tool that has been continuously maintained for over three decades and is still shipping major releases in 2026. The Octave Forge maintainers built a package distribution system around it before that concept was mainstream. The project has survived changes in computing platforms and multiple generations of competing tools, all without corporate sponsorship or a change in license.
+
+Anyone building a MATLAB-compatible runtime today, including us, is working in a category that Octave defined. What has changed is the toolkit available to build with, not the difficulty of the problem or the value of solving it.
+
+RunMat is what we are building with that toolkit: a JIT-compiled, GPU-accelerated MATLAB-compatible runtime that runs in the browser and on every major OS, MIT-licensed, with 400+ builtins shipping today. If your `.m` files run, you get automatic GPU acceleration on any vendor's hardware and 150x+ speedups on loop-heavy code with zero code changes. [Try it in the sandbox](https://runmat.com/sandbox). For a broader comparison including Julia and Python, see the [full alternatives guide](/blog/free-matlab-alternatives).

--- a/website/content/docs.ts
+++ b/website/content/docs.ts
@@ -205,7 +205,8 @@ export const docsTree: DocsNode[] = [
       },
       // Lexer entry removed pending compiler docs rewrite; crate README was deleted in fbd1d97f (lexer crate split).
       { title: "Parser", slug: ["internals", "parser"], file: "crates/runmat-parser/README.md", seo: { description: "Precedence-based parser for MATLAB/Octave with statements, OOP, and command-form.", keywords: ["parser", "AST", "MATLAB", "Octave"] } },
-      { title: "HIR", slug: ["internals", "hir"], file: "crates/runmat-hir/README.md", seo: { description: "High-level IR with flow-sensitive inference and class/import validations.", keywords: ["HIR", "type inference", "SSA", "MATLAB"] } },
+      // HIR entry removed pending compiler docs rewrite; crate README was deleted during the HIR refactor.
+      // /docs/internals/hir redirects to /docs/architecture in next.config.ts.
       // Additional VM internals pages can be added here when dedicated docs are promoted.
       { title: "Garbage Collector", slug: ["internals", "garbage-collector"], file: "crates/runmat-gc/README.md", seo: { description: "Generational mark-and-sweep GC with handles, barriers, and promotion.", keywords: ["garbage collector", "GC", "generational", "write barrier"] } },
     ],

--- a/website/lib/seo.ts
+++ b/website/lib/seo.ts
@@ -26,9 +26,7 @@ export type PageSeoOptions = {
 export function buildPageMetadata(opts: PageSeoOptions): Metadata {
   const canonical = toAbsoluteUrl(opts.canonicalPath);
   const ogImagePath = opts.ogImagePath ?? DEFAULT_OG_IMAGE_PATH;
-  const ogImageAlt = opts.ogImagePath
-    ? opts.ogImageAlt
-    : (opts.ogImageAlt ?? DEFAULT_OG_IMAGE_ALT);
+  const ogImageAlt = opts.ogImageAlt ?? DEFAULT_OG_IMAGE_ALT;
   const ogImage = toAbsoluteUrl(ogImagePath);
   const ogType = opts.ogType ?? "website";
   const ogImageEntry = [{ url: ogImage, ...(ogImageAlt ? { alt: ogImageAlt } : {}) }];

--- a/website/lib/seo.ts
+++ b/website/lib/seo.ts
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 
 const SITE_ORIGIN = "https://runmat.com";
+const SITE_NAME = "RunMat";
+// Default OG image served from app/opengraph-image.tsx at the site root.
+const DEFAULT_OG_IMAGE_PATH = "/opengraph-image";
+const DEFAULT_OG_IMAGE_ALT = "RunMat — open-source MATLAB-compatible runtime";
 
 function toAbsoluteUrl(pathOrUrl: string): string {
   if (!pathOrUrl) return SITE_ORIGIN;
@@ -21,11 +25,13 @@ export type PageSeoOptions = {
 
 export function buildPageMetadata(opts: PageSeoOptions): Metadata {
   const canonical = toAbsoluteUrl(opts.canonicalPath);
-  const ogImage = opts.ogImagePath ? toAbsoluteUrl(opts.ogImagePath) : undefined;
+  const ogImagePath = opts.ogImagePath ?? DEFAULT_OG_IMAGE_PATH;
+  const ogImageAlt = opts.ogImagePath
+    ? opts.ogImageAlt
+    : (opts.ogImageAlt ?? DEFAULT_OG_IMAGE_ALT);
+  const ogImage = toAbsoluteUrl(ogImagePath);
   const ogType = opts.ogType ?? "website";
-  const ogImageEntry = ogImage
-    ? [{ url: ogImage, ...(opts.ogImageAlt ? { alt: opts.ogImageAlt } : {}) }]
-    : undefined;
+  const ogImageEntry = [{ url: ogImage, ...(ogImageAlt ? { alt: ogImageAlt } : {}) }];
 
   return {
     title: opts.title,
@@ -36,13 +42,14 @@ export function buildPageMetadata(opts: PageSeoOptions): Metadata {
       description: opts.description,
       type: ogType,
       url: canonical,
-      ...(ogImageEntry ? { images: ogImageEntry } : {}),
+      siteName: SITE_NAME,
+      images: ogImageEntry,
     },
     twitter: {
       card: "summary_large_image",
       title: opts.title,
       description: opts.description,
-      ...(ogImageEntry ? { images: ogImageEntry } : {}),
+      images: ogImageEntry,
     },
   };
 }

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -83,6 +83,14 @@ const nextConfig: NextConfig = {
         permanent: false,
       },
 
+      // HIR docs — crate README was removed during the HIR refactor and replacement is
+      // pending. Temporary redirect to /docs/architecture so the indexed URL stops 404ing.
+      {
+        source: '/docs/internals/hir',
+        destination: '/docs/architecture',
+        permanent: false,
+      },
+
       // Raw .md file URLs -> correct doc routes
       {
         source: '/CLI.md',

--- a/website/package.json
+++ b/website/package.json
@@ -50,6 +50,13 @@
     "tailwindcss": "^4.1.11",
     "tailwindcss-animate": "^1.0.7"
   },
+  "browserslist": [
+    "chrome >= 108",
+    "edge >= 108",
+    "firefox >= 108",
+    "safari >= 16",
+    "not dead"
+  ],
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@types/node": "^20",

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- Rename sections in GPU and Language compatibility documents for clarity.
- Add temporary redirect for HIR documentation to prevent 404 errors.
- Update browserslist in package.json for better compatibility.
- Change TypeScript target to ES2022 for modern features.
- Enhance image preload handling in layout for improved performance.
- Refactor SEO metadata handling to include default values and site name.
- Implement lazy loading for video components to optimize loading times.
- Dynamically import benchmark charts to improve initial load performance.
- Update documentation tree comments for clarity on pending changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes SEO/JSON-LD generation and Next.js static routing behavior, which could impact indexing or page rendering if IDs/metadata are wrong. Performance-oriented changes (lazy video posters, dynamic chart imports, preload tweaks) may affect LCP or client-only rendering edge cases.
> 
> **Overview**
> **Improves SEO + structured data across docs pages.** Built-in reference JSON-LD is refactored to use fully-qualified, per-page `@id`s and to only emit `SoftwareSourceCode`/`mainEntity` entries when a source URL exists; global `buildPageMetadata` now always provides default OG image + alt text and sets `openGraph.siteName`.
> 
> **Tightens Next.js routing and reduces initial load cost.** Builtin pages are made fully static (`dynamicParams = false`) and `notFound()` handling is adjusted; benchmark charts are switched to client-only dynamic imports; hero video is moved to `LazyVideo` with mobile-specific posters to avoid double poster downloads; and homepage image preloads are moved to responsive, high-priority preloads.
> 
> **Docs + marketing content updates.** Renames/clarifies top-level headers in `GPU_BEHAVIOR_NOTES.md` and `LANGUAGE.md`, removes the `HIR` internals doc entry and adds a temporary redirect from `/docs/internals/hir` to `/docs/architecture`, adds an unlisted `matlab-vs-octave` blog post, and updates several blog links/copy (including pricing/browser-version references).
> 
> **Build targeting updates.** Adds a `browserslist` and raises the website TypeScript target to `ES2022`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5030d245c3495486309ee6c58b0e76194d21107f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->