### PR TITLE
docs: fix outdated directory references in DEVELOPING.md

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -10,8 +10,7 @@ cargo build
 
 - `crates/` - all library and binary crates
 - `docs/` - design documents like `ARCHITECTURE.md`
-- `examples/` - small `.m` and Rust examples (coming later)
-- `tests/` - language and performance test suites (coming later)
+- `tests/` - language and performance test suites
 
 ## Running the REPL
 


### PR DESCRIPTION
## Summary

Remove references to the non-existent `examples/` directory and the outdated "coming later" note for `tests/` in `DEVELOPING.md`.

## Changes

- `docs/DEVELOPING.md`:
  - Removed `examples/` line (directory does not exist)
  - Removed "(coming later)" from `tests/` (directory already exists with `.m` test files)

## Checklist

- [x] Single logical change-set
- [x] Based on and targeted for `main`
- [x] No test changes required (documentation only)
- [x] `cargo fmt` passes