### PR TITLE
docs: remove non-existent PLAN.md reference from LIBRARY.md

### DIFF
--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -40,7 +40,6 @@ metadata can be added later without rewriting existing code.
 3. Implement the functions, annotating each with `#[matlab_fn(name = "...")]`.
 4. Provide comprehensive unit tests covering typical usage, error cases and edge
    conditions. Tests live in `crates/<name>/tests/`.
-5. Update `PLAN.md` with a short entry summarising the addition.
 
 ## Testing Guidelines
 


### PR DESCRIPTION
## Summary

Remove the instruction to update `PLAN.md` from `LIBRARY.md`, as `PLAN.md` does not exist in the repository.

## Changes

- `docs/LIBRARY.md`: Removed step 5 referencing `PLAN.md`

## Checklist

- [x] Single logical change-set
- [x] Based on and targeted for `main`
- [x] No test changes required (documentation only)
- [x] `cargo fmt` passes