### PR TITLE
feat(cli): respect NO_COLOR environment variable in REPL banner

### DIFF
--- a/crates/runmat-cli/src/commands/repl.rs
+++ b/crates/runmat-cli/src/commands/repl.rs
@@ -139,7 +139,9 @@ fn print_repl_banner(config: &RunMatConfig, engine: &RunMatSession) {
 }
 
 fn detect_banner_capabilities() -> BannerCapabilities {
-    let decorated = atty::is(atty::Stream::Stdout)
+    let no_color = std::env::var_os("NO_COLOR").is_some();
+    let decorated = !no_color
+        && atty::is(atty::Stream::Stdout)
         && std::env::var("TERM")
             .map(|term| term != "dumb")
             .unwrap_or(true);


### PR DESCRIPTION
## Summary

Add support for the standard [`NO_COLOR`](https://no-color.org/) convention in the REPL banner color detection.

When `NO_COLOR` is set (to any value), the REPL banner and all styled output are disabled regardless of TTY capabilities.

## Changes

- `crates/runmat-cli/src/commands/repl.rs`:
  - Added `NO_COLOR` environment variable check in `detect_banner_capabilities()`
  - Preserves existing `TERM=dumb` and non-TTY detection logic

## Checklist

- [x] Single logical change-set
- [x] Based on and targeted for `main`
- [x] No test changes required (follows existing env-var detection pattern)
- [x] `cargo fmt` passes
- [x] `cargo check -p runmat` passes