### PR TITLE
add format builtin to control numeric display mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5546,6 +5546,7 @@ dependencies = [
  "runmat-async",
  "runmat-gc-api",
  "runmat-macros",
+ "runmat-thread-local",
  "serde",
  "trybuild",
 ]

--- a/crates/runmat-builtins/Cargo.toml
+++ b/crates/runmat-builtins/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1.0", features = ["derive"] }
 runmat-accelerate-api = { workspace = true }
 runmat-async = { workspace = true }
 runmat-gc-api = { workspace = true }
+runmat-thread-local = { workspace = true }
 indexmap = { version = "1.9", features = ["std"] }
 once_cell = { workspace = true }
 

--- a/crates/runmat-builtins/src/lib.rs
+++ b/crates/runmat-builtins/src/lib.rs
@@ -1,5 +1,7 @@
 pub use inventory;
 use runmat_gc_api::GcPtr;
+use runmat_thread_local::runmat_thread_local;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
@@ -598,7 +600,7 @@ impl fmt::Display for Tensor {
                     if i > 0 {
                         write!(f, " ")?;
                     }
-                    write!(f, "{}", format_number_short_g(*v))?;
+                    write!(f, "{}", format_number(*v))?;
                 }
                 write!(f, "]")
             }
@@ -614,7 +616,7 @@ impl fmt::Display for Tensor {
                             write!(f, "  ")?;
                         }
                         let v = self.data[r + c * rows];
-                        write!(f, "{}", format_number_short_g(v))?;
+                        write!(f, "{}", format_number(v))?;
                     }
                 }
                 Ok(())
@@ -622,7 +624,7 @@ impl fmt::Display for Tensor {
             _ => {
                 if should_expand_nd_display(&self.shape) {
                     write_nd_pages(f, &self.shape, |f, idx| {
-                        write!(f, "{}", format_number_short_g(self.data[idx]))
+                        write!(f, "{}", format_number(self.data[idx]))
                     })
                 } else {
                     write!(f, "Tensor(shape={:?})", self.shape)
@@ -1625,7 +1627,42 @@ pub fn builtin_docs() -> Vec<&'static BuiltinDoc> {
 // Display implementations
 // ----------------------
 
-fn format_number_short_g(value: f64) -> String {
+/// Controls how numeric values are displayed in the console, mirroring MATLAB's `format` command.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum FormatMode {
+    /// 4 decimal places, fixed or scientific (MATLAB default).
+    #[default]
+    Short,
+    /// 15 decimal places, fixed or scientific.
+    Long,
+    /// Always scientific notation, 4 decimal places.
+    ShortE,
+    /// Always scientific notation, 14 decimal places.
+    LongE,
+    /// Compact: shorter of fixed/scientific, 5 significant digits.
+    ShortG,
+    /// Compact: shorter of fixed/scientific, 15 significant digits.
+    LongG,
+    /// Rational approximation (p/q).
+    Rational,
+    /// IEEE 754 hexadecimal representation.
+    Hex,
+}
+
+runmat_thread_local! {
+    static DISPLAY_FORMAT: RefCell<FormatMode> = const { RefCell::new(FormatMode::Short) };
+}
+
+pub fn set_display_format(mode: FormatMode) {
+    DISPLAY_FORMAT.with(|c| *c.borrow_mut() = mode);
+}
+
+pub fn get_display_format() -> FormatMode {
+    DISPLAY_FORMAT.with(|c| *c.borrow())
+}
+
+/// Format a number using the current thread-local display format.
+pub fn format_number(value: f64) -> String {
     if value.is_nan() {
         return "NaN".to_string();
     }
@@ -1637,59 +1674,107 @@ fn format_number_short_g(value: f64) -> String {
         }
         .to_string();
     }
-    // Normalize -0.0 to 0
-    let mut v = value;
-    if v == 0.0 {
-        v = 0.0;
+    let v = if value == 0.0 { 0.0 } else { value };
+    match get_display_format() {
+        FormatMode::Short => fmt_short(v),
+        FormatMode::Long => fmt_long(v),
+        FormatMode::ShortE => fmt_sci(v, 4),
+        FormatMode::LongE => fmt_sci(v, 14),
+        FormatMode::ShortG => fmt_compact(v, 5),
+        FormatMode::LongG => fmt_compact(v, 15),
+        FormatMode::Rational => fmt_rational(v),
+        FormatMode::Hex => fmt_hex(v),
     }
+}
 
+/// Reformat Rust's `e`-notation exponent into MATLAB style (`e+02`, `e-03`).
+fn matlab_exp(s: &str) -> String {
+    if let Some(e_pos) = s.find('e') {
+        let mantissa = &s[..e_pos];
+        let exp: i32 = s[e_pos + 1..].parse().unwrap_or(0);
+        let sign = if exp >= 0 { '+' } else { '-' };
+        format!("{mantissa}e{sign}{:02}", exp.unsigned_abs())
+    } else {
+        s.to_string()
+    }
+}
+
+fn fmt_sci(v: f64, dec: usize) -> String {
+    if v == 0.0 {
+        return format!("0.{:0>dec$}e+00", 0, dec = dec);
+    }
+    let s = format!("{v:.dec$e}");
+    matlab_exp(&s)
+}
+
+fn fmt_short(v: f64) -> String {
     let abs = v.abs();
     if abs == 0.0 {
         return "0".to_string();
     }
-
-    // Decide between fixed and scientific notation roughly like short g
-    let use_scientific = !(1e-4..1e6).contains(&abs);
-
-    if use_scientific {
-        // 5 significant digits in scientific notation for short g style
-        let s = format!("{v:.4e}");
-        // Trim trailing zeros in fraction part
-        if let Some(idx) = s.find('e') {
-            let (mut mantissa, exp) = s.split_at(idx);
-            // mantissa like "-1.23450"
-            if let Some(dot_idx) = mantissa.find('.') {
-                // Trim trailing zeros
-                let mut end = mantissa.len();
-                while end > dot_idx + 1 && mantissa.as_bytes()[end - 1] == b'0' {
-                    end -= 1;
-                }
-                if end > 0 && mantissa.as_bytes()[end - 1] == b'.' {
-                    end -= 1;
-                }
-                mantissa = &mantissa[..end];
-            }
-            return format!("{mantissa}{exp}");
-        }
-        return s;
+    if v.fract() == 0.0 && abs < 1e15 {
+        return format!("{}", v as i64);
     }
+    if (0.001..10000.0).contains(&abs) {
+        format!("{:.4}", v)
+    } else {
+        fmt_sci(v, 4)
+    }
+}
 
-    // Fixed notation with up to 12 significant digits, trim trailing zeros
-    // Compute number of decimals to retain to reach ~12 significant digits
-    let exp10 = abs.log10().floor() as i32; // position of most significant digit
-    let sig_digits: i32 = 12;
-    let decimals = (sig_digits - 1 - exp10).clamp(0, 12) as usize;
-    // Round to that many decimals
+fn fmt_long(v: f64) -> String {
+    let abs = v.abs();
+    if abs == 0.0 {
+        return "0".to_string();
+    }
+    if v.fract() == 0.0 && abs < 1e15 {
+        return format!("{}", v as i64);
+    }
+    if (0.001..10000.0).contains(&abs) {
+        format!("{:.15}", v)
+    } else {
+        fmt_sci(v, 14)
+    }
+}
+
+fn fmt_compact(v: f64, sig_digits: usize) -> String {
+    let abs = v.abs();
+    if abs == 0.0 {
+        return "0".to_string();
+    }
+    let use_scientific = !(1e-4..1e6).contains(&abs);
+    if use_scientific {
+        let dec = sig_digits - 1;
+        let s = format!("{v:.dec$e}");
+        // trim trailing zeros in mantissa then reformat exponent
+        if let Some(e_pos) = s.find('e') {
+            let exp_part = &s[e_pos..];
+            let mut mantissa = s[..e_pos].to_string();
+            if let Some(dot) = mantissa.find('.') {
+                let mut end = mantissa.len();
+                while end > dot + 1 && mantissa.as_bytes()[end - 1] == b'0' {
+                    end -= 1;
+                }
+                if mantissa.as_bytes()[end - 1] == b'.' {
+                    end -= 1;
+                }
+                mantissa.truncate(end);
+            }
+            return matlab_exp(&format!("{mantissa}{exp_part}"));
+        }
+        return matlab_exp(&s);
+    }
+    let exp10 = abs.log10().floor() as i32;
+    let decimals = ((sig_digits as i32 - 1 - exp10).max(0)) as usize;
     let pow = 10f64.powi(decimals as i32);
     let rounded = (v * pow).round() / pow;
     let mut s = format!("{rounded:.decimals$}");
     if let Some(dot) = s.find('.') {
-        // Trim trailing zeros
         let mut end = s.len();
         while end > dot + 1 && s.as_bytes()[end - 1] == b'0' {
             end -= 1;
         }
-        if end > 0 && s.as_bytes()[end - 1] == b'.' {
+        if s.as_bytes()[end - 1] == b'.' {
             end -= 1;
         }
         s.truncate(end);
@@ -1698,6 +1783,60 @@ fn format_number_short_g(value: f64) -> String {
         s = "0".to_string();
     }
     s
+}
+
+fn fmt_rational(v: f64) -> String {
+    if v == 0.0 {
+        return "0".to_string();
+    }
+    let negative = v < 0.0;
+    let abs = v.abs();
+    if v.fract() == 0.0 && abs < 1e15 {
+        return format!("{}", v as i64);
+    }
+    // Continued fraction convergents; stop at the first one within MATLAB's
+    // 5e-7 relative tolerance (matches `format rational` behaviour for pi → 355/113).
+    let tol = 5e-7 * abs;
+    let max_d = 1_000_000i64;
+    let mut n0: i64 = 1;
+    let mut n1: i64 = abs.floor() as i64;
+    let mut d0: i64 = 0;
+    let mut d1: i64 = 1;
+    let mut a = abs;
+    let mut best_n = n1;
+    let mut best_d = d1;
+    for _ in 0..50 {
+        if (abs - best_n as f64 / best_d as f64).abs() <= tol {
+            break;
+        }
+        let f = a.fract();
+        if f < 1e-10 {
+            break;
+        }
+        a = 1.0 / f;
+        let q = a.floor() as i64;
+        let n2 = q * n1 + n0;
+        let d2 = q * d1 + d0;
+        if d2 > max_d {
+            break;
+        }
+        best_n = n2;
+        best_d = d2;
+        n0 = n1;
+        n1 = n2;
+        d0 = d1;
+        d1 = d2;
+    }
+    let sign = if negative { "-" } else { "" };
+    if best_d == 1 {
+        format!("{sign}{best_n}")
+    } else {
+        format!("{sign}{best_n}/{best_d}")
+    }
+}
+
+fn fmt_hex(v: f64) -> String {
+    format!("{:016x}", v.to_bits())
 }
 
 // -------- Exception type --------
@@ -1759,26 +1898,16 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Value::Int(i) => write!(f, "{}", i.to_i64()),
-            Value::Num(n) => write!(f, "{}", format_number_short_g(*n)),
+            Value::Num(n) => write!(f, "{}", format_number(*n)),
             Value::Complex(re, im) => {
                 if *im == 0.0 {
-                    write!(f, "{}", format_number_short_g(*re))
+                    write!(f, "{}", format_number(*re))
                 } else if *re == 0.0 {
-                    write!(f, "{}i", format_number_short_g(*im))
+                    write!(f, "{}i", format_number(*im))
                 } else if *im < 0.0 {
-                    write!(
-                        f,
-                        "{}-{}i",
-                        format_number_short_g(*re),
-                        format_number_short_g(im.abs())
-                    )
+                    write!(f, "{}-{}i", format_number(*re), format_number(im.abs()))
                 } else {
-                    write!(
-                        f,
-                        "{}+{}i",
-                        format_number_short_g(*re),
-                        format_number_short_g(*im)
-                    )
+                    write!(f, "{}+{}i", format_number(*re), format_number(*im))
                 }
             }
             Value::Bool(b) => write!(f, "{}", if *b { 1 } else { 0 }),

--- a/crates/runmat-builtins/src/lib.rs
+++ b/crates/runmat-builtins/src/lib.rs
@@ -1674,8 +1674,12 @@ pub fn format_number(value: f64) -> String {
         }
         .to_string();
     }
+    let mode = get_display_format();
+    if mode == FormatMode::Hex {
+        return fmt_hex(value);
+    }
     let v = if value == 0.0 { 0.0 } else { value };
-    match get_display_format() {
+    match mode {
         FormatMode::Short => fmt_short(v),
         FormatMode::Long => fmt_long(v),
         FormatMode::ShortE => fmt_sci(v, 4),
@@ -1683,7 +1687,7 @@ pub fn format_number(value: f64) -> String {
         FormatMode::ShortG => fmt_compact(v, 5),
         FormatMode::LongG => fmt_compact(v, 15),
         FormatMode::Rational => fmt_rational(v),
-        FormatMode::Hex => fmt_hex(v),
+        FormatMode::Hex => unreachable!("hex mode handled before zero normalization"),
     }
 }
 
@@ -2032,7 +2036,9 @@ impl fmt::Display for ComplexTensor {
 
 #[cfg(test)]
 mod display_tests {
-    use super::{ComplexTensor, LogicalArray, Tensor};
+    use super::{
+        format_number, set_display_format, ComplexTensor, FormatMode, LogicalArray, Tensor,
+    };
 
     #[test]
     fn tensor_nd_display_uses_page_headers() {
@@ -2075,6 +2081,14 @@ mod display_tests {
         let rendered = complex.to_string();
         assert!(rendered.contains("(:, :, 1) ="));
         assert!(rendered.contains("(:, :, 2) ="));
+    }
+
+    #[test]
+    fn format_hex_preserves_negative_zero_sign_bit() {
+        set_display_format(FormatMode::Hex);
+        assert_eq!(format_number(-0.0), "8000000000000000");
+        assert_eq!(format_number(0.0), "0000000000000000");
+        set_display_format(FormatMode::Short);
     }
 }
 

--- a/crates/runmat-core/src/session/mod.rs
+++ b/crates/runmat-core/src/session/mod.rs
@@ -101,6 +101,8 @@ pub struct RunMatSession {
     workspace_version: u64,
     emit_fusion_plan: bool,
     compat_mode: CompatMode,
+    /// Persisted numeric display format for this session (survives across executions).
+    format_mode: runmat_builtins::FormatMode,
 }
 
 pub(crate) struct PreparedExecution {

--- a/crates/runmat-core/src/session/run.rs
+++ b/crates/runmat-core/src/session/run.rs
@@ -27,6 +27,7 @@ impl RunMatSession {
         runmat_runtime::console::reset_thread_buffer();
         runmat_runtime::plotting_hooks::reset_recent_figures();
         runmat_runtime::warning_store::reset();
+        runmat_builtins::set_display_format(self.format_mode);
         reset_provider_telemetry();
         self.interrupt_flag.store(false, Ordering::Relaxed);
         let _interrupt_guard =
@@ -777,6 +778,7 @@ impl RunMatSession {
             result_value
         };
 
+        self.format_mode = runmat_builtins::get_display_format();
         Ok(ExecutionResult {
             value: public_value,
             execution_time_ms,

--- a/crates/runmat-core/src/session/snapshot.rs
+++ b/crates/runmat-core/src/session/snapshot.rs
@@ -121,6 +121,7 @@ impl RunMatSession {
             workspace_version: 0,
             emit_fusion_plan: false,
             compat_mode: CompatMode::Matlab,
+            format_mode: runmat_builtins::FormatMode::default(),
         };
 
         runmat_vm::set_call_stack_limit(session.callstack_limit);

--- a/crates/runmat-core/tests/fusion_regressions.rs
+++ b/crates/runmat-core/tests/fusion_regressions.rs
@@ -1,6 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use futures::executor::block_on;
+use runmat_builtins::Value;
 use runmat_core::RunMatSession;
 use runmat_gc::gc_test_context;
 use std::sync::Once;
@@ -17,11 +18,11 @@ fn ensure_fusion_regression_env() {
 
 fn read_scalar(engine: &mut RunMatSession, expr: &str) -> f64 {
     let result = block_on(engine.execute(expr)).expect("evaluate scalar expression");
-    let rendered = result
-        .value
-        .expect("scalar value should be available")
-        .to_string();
-    rendered.parse().expect("scalar should render as f64")
+    match result.value.expect("scalar value should be available") {
+        Value::Num(value) => value,
+        Value::Tensor(tensor) if tensor.data.len() == 1 => tensor.data[0],
+        other => panic!("expected scalar numeric value, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/runmat-parser/src/parser/command.rs
+++ b/crates/runmat-parser/src/parser/command.rs
@@ -97,6 +97,16 @@ const COMMAND_VERBS: &[CommandVerb] = &[
         name: "clear",
         arg_kind: CommandArgKind::StringifyWords,
     },
+    CommandVerb {
+        name: "format",
+        arg_kind: CommandArgKind::Keyword {
+            allowed: &[
+                "short", "long", "shortE", "longE", "shortG", "longG", "rat", "rational", "hex",
+                "compact", "loose",
+            ],
+            optional: true,
+        },
+    },
 ];
 
 impl Parser {
@@ -142,12 +152,7 @@ impl Parser {
 
         let mut i = 1;
         let mut saw_arg = false;
-        while matches!(
-            self.peek_token_at(i),
-            Some(Token::Newline | Token::Ellipsis)
-        ) {
-            i += 1;
-        }
+        self.skip_command_continuations(&mut i);
 
         if !matches!(
             self.peek_token_at(i),
@@ -166,9 +171,7 @@ impl Parser {
                     saw_arg = true;
                     i += 1;
                 }
-                Some(Token::Newline | Token::Ellipsis) => {
-                    i += 1;
-                }
+                Some(Token::Ellipsis) => self.skip_command_continuations(&mut i),
                 _ => break,
             }
         }
@@ -191,10 +194,12 @@ impl Parser {
     fn parse_command_args(&mut self) -> Vec<Expr> {
         let mut args = Vec::new();
         loop {
-            if self.consume(&Token::Newline) {
-                continue;
+            if matches!(self.peek_token(), Some(Token::Newline)) {
+                break;
             }
             if self.consume(&Token::Ellipsis) {
+                // `...` is a line-continuation; skip the following newline and keep parsing.
+                self.consume(&Token::Newline);
                 continue;
             }
             match self.peek_token() {
@@ -234,6 +239,15 @@ impl Parser {
             }
         }
         args
+    }
+
+    fn skip_command_continuations(&self, offset: &mut usize) {
+        while matches!(self.peek_token_at(*offset), Some(Token::Ellipsis)) {
+            *offset += 1;
+            if matches!(self.peek_token_at(*offset), Some(Token::Newline)) {
+                *offset += 1;
+            }
+        }
     }
 
     fn lookup_command(&self, name: &str) -> Option<&'static CommandVerb> {

--- a/crates/runmat-parser/tests/command_syntax.rs
+++ b/crates/runmat-parser/tests/command_syntax.rs
@@ -33,6 +33,27 @@ fn command_form_with_quoted_and_ellipsis() {
 }
 
 #[test]
+fn command_form_does_not_continue_on_bare_newline() {
+    let program = parse("foo\nbar").unwrap();
+    assert_eq!(program.body.len(), 2);
+    match &program.body[0] {
+        Stmt::ExprStmt(Expr::Ident(name, _), _, _) => assert_eq!(name, "foo"),
+        other => panic!("statement 0: expected identifier, got {other:?}"),
+    }
+    match &program.body[1] {
+        Stmt::ExprStmt(Expr::Ident(name, _), _, _) => assert_eq!(name, "bar"),
+        other => panic!("statement 1: expected identifier, got {other:?}"),
+    }
+
+    let known_command = parse("grid\non").unwrap();
+    assert_eq!(known_command.body.len(), 2);
+    match &known_command.body[0] {
+        Stmt::ExprStmt(Expr::Ident(name, _), _, _) => assert_eq!(name, "grid"),
+        other => panic!("statement 0: expected identifier, got {other:?}"),
+    }
+}
+
+#[test]
 fn command_form_with_end_token_as_arg() {
     // end appears as a bare token in command-form; parser should treat it as an identifier literal
     let program = parse("foo end bar").unwrap();

--- a/crates/runmat-parser/tests/format_command.rs
+++ b/crates/runmat-parser/tests/format_command.rs
@@ -1,0 +1,125 @@
+use runmat_parser::{Expr, Stmt};
+
+mod parse;
+use parse::parse;
+
+#[test]
+fn format_long_command_syntax_produces_string_arg() {
+    let program = parse("format long").unwrap();
+    match &program.body[0] {
+        Stmt::ExprStmt(Expr::FuncCall(name, args, _), _, _) => {
+            assert_eq!(name, "format");
+            assert_eq!(args.len(), 1);
+            assert!(
+                matches!(&args[0], Expr::String(s, _) if s.trim_matches('"') == "long"),
+                "expected string arg \"long\", got {:?}",
+                args[0]
+            );
+        }
+        other => panic!("expected ExprStmt(FuncCall), got {other:?}"),
+    }
+}
+
+#[test]
+fn format_short_command_syntax_produces_string_arg() {
+    let program = parse("format short").unwrap();
+    match &program.body[0] {
+        Stmt::ExprStmt(Expr::FuncCall(name, args, _), _, _) => {
+            assert_eq!(name, "format");
+            assert_eq!(args.len(), 1);
+            assert!(
+                matches!(&args[0], Expr::String(s, _) if s.trim_matches('"') == "short"),
+                "expected string arg \"short\", got {:?}",
+                args[0]
+            );
+        }
+        other => panic!("expected ExprStmt(FuncCall), got {other:?}"),
+    }
+}
+
+#[test]
+fn format_no_args_command_syntax_parses() {
+    let program = parse("format").unwrap();
+    match &program.body[0] {
+        Stmt::ExprStmt(Expr::FuncCall(name, args, _), _, _) => {
+            assert_eq!(name, "format");
+            assert_eq!(args.len(), 0);
+        }
+        other => panic!("expected ExprStmt(FuncCall), got {other:?}"),
+    }
+}
+
+#[test]
+fn format_all_numeric_modes_parse() {
+    // "rat" is the MATLAB-canonical keyword; "rational" is accepted as an alias.
+    for mode in &[
+        "shortE", "longE", "shortG", "longG", "rat", "rational", "hex",
+    ] {
+        let src = format!("format {mode}");
+        let program = parse(&src).unwrap();
+        match &program.body[0] {
+            Stmt::ExprStmt(Expr::FuncCall(name, args, _), _, _) => {
+                assert_eq!(name, "format");
+                assert_eq!(args.len(), 1, "mode '{mode}' should produce 1 arg");
+            }
+            other => panic!("format {mode}: expected FuncCall, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn format_rat_is_the_matlab_canonical_keyword() {
+    // Verify "format rat" parses (not "format rational").
+    let program = parse("format rat").unwrap();
+    match &program.body[0] {
+        Stmt::ExprStmt(Expr::FuncCall(name, args, _), _, _) => {
+            assert_eq!(name, "format");
+            assert!(
+                matches!(&args[0], Expr::String(s, _) if s.trim_matches('"') == "rat"),
+                "expected string arg \"rat\""
+            );
+        }
+        other => panic!("expected ExprStmt(FuncCall), got {other:?}"),
+    }
+}
+
+#[test]
+fn format_spacing_modes_parse_without_error() {
+    // compact/loose are spacing modes; not yet implemented but should not be syntax errors.
+    for mode in &["compact", "loose"] {
+        let src = format!("format {mode}");
+        assert!(
+            parse(&src).is_ok(),
+            "format {mode} should parse without error"
+        );
+    }
+}
+
+#[test]
+fn format_truly_unknown_mode_is_a_parse_error() {
+    assert!(
+        parse("format bank").is_err(),
+        "expected parse error for unknown mode 'bank'"
+    );
+}
+
+#[test]
+fn format_long_newline_pi_is_two_statements_not_two_args() {
+    // In MATLAB a newline terminates command-form argument parsing.
+    // "format long\npi" must produce two statements, not format("long", pi).
+    let program = parse("format long\npi").unwrap();
+    assert_eq!(program.body.len(), 2, "expected 2 statements");
+    match &program.body[0] {
+        Stmt::ExprStmt(Expr::FuncCall(name, args, _), _, _) => {
+            assert_eq!(name, "format");
+            assert_eq!(args.len(), 1);
+        }
+        other => panic!("statement 0: expected format FuncCall, got {other:?}"),
+    }
+    match &program.body[1] {
+        Stmt::ExprStmt(Expr::Ident(name, _), _, _) => {
+            assert_eq!(name, "pi");
+        }
+        other => panic!("statement 1: expected pi Ident, got {other:?}"),
+    }
+}

--- a/crates/runmat-runtime/src/builtins/builtins-json/format.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/format.json
@@ -1,0 +1,137 @@
+{
+  "title": "format",
+  "category": "io",
+  "keywords": [
+    "format",
+    "display",
+    "precision",
+    "numeric",
+    "short",
+    "long",
+    "scientific",
+    "rational",
+    "hex"
+  ],
+  "summary": "Set the numeric display format for console output, controlling how floating-point numbers are shown.",
+  "references": [
+    "https://www.mathworks.com/help/matlab/ref/format.html"
+  ],
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [],
+    "broadcasting": "none",
+    "notes": "format is a display-only setting; it has no effect on GPU computation or residency."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 0,
+    "constants": "none"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::io::format::tests",
+    "integration": null
+  },
+  "description": "`format` controls how numeric values appear in the Command Window. The setting is session-wide and persists until changed. Supported numeric precision modes: `short` (default), `long`, `shortE`, `longE`, `shortG`, `longG`, `rat`, and `hex`. Spacing modes `compact` and `loose` are accepted without error but are not yet implemented. Calling `format` without arguments resets to `short`.",
+  "behaviors": [
+    "Calling `format` with no arguments resets to the default `short` mode.",
+    "`format short` displays 4 decimal places in fixed notation for values in [0.001, 10000); uses scientific notation outside that range.",
+    "`format long` displays 15 decimal places in fixed notation for values in [0.001, 10000); uses 14-decimal scientific notation outside that range.",
+    "`format shortE` always uses scientific notation with 4 decimal places (e.g., `3.1416e+00`).",
+    "`format longE` always uses scientific notation with 14 decimal places.",
+    "`format shortG` uses the more compact of fixed/scientific notation with 5 significant digits, trimming trailing zeros.",
+    "`format longG` uses the more compact of fixed/scientific notation with 15 significant digits, trimming trailing zeros.",
+    "`format rat` approximates values as ratios of small integers using a tolerance of 5×10⁻⁷ (e.g., `355/113` for pi). `format rational` is accepted as an alias.",
+    "`format hex` displays the IEEE 754 double-precision hexadecimal bit pattern (e.g., `400921fb54442d18` for pi).",
+    "`format compact` and `format loose` are accepted without error for script compatibility but do not yet change output spacing.",
+    "The format setting applies to auto-print results and `disp` output. `fprintf`/`sprintf` use their own explicit format specifiers and are not affected.",
+    "Mode names are case-insensitive."
+  ],
+  "examples": [
+    {
+      "description": "Default short format",
+      "input": "format short\npi",
+      "output": "ans = 3.1416"
+    },
+    {
+      "description": "Long format for full precision",
+      "input": "format long\npi",
+      "output": "ans = 3.141592653589793"
+    },
+    {
+      "description": "Scientific notation with short precision",
+      "input": "format shortE\npi",
+      "output": "ans = 3.1416e+00"
+    },
+    {
+      "description": "Scientific notation with full precision",
+      "input": "format longE\npi",
+      "output": "ans = 3.14159265358979e+00"
+    },
+    {
+      "description": "Rational approximation",
+      "input": "format rat\npi",
+      "output": "ans = 355/113"
+    },
+    {
+      "description": "Hexadecimal IEEE 754 representation",
+      "input": "format hex\npi",
+      "output": "ans = 400921fb54442d18"
+    },
+    {
+      "description": "Resetting to default",
+      "input": "format\npi",
+      "output": "ans = 3.1416"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Does `format` affect computation results?",
+      "answer": "No. `format` only changes how values are displayed. Internal precision is always IEEE 754 double."
+    },
+    {
+      "question": "Is the format setting persistent across cells?",
+      "answer": "Yes. The setting is stored per-session thread and remains active until changed by another `format` call."
+    },
+    {
+      "question": "What is the default format?",
+      "answer": "`format short` — 4 decimal places in fixed notation, falling back to scientific for very large or very small values."
+    },
+    {
+      "question": "Does `format` affect `disp`?",
+      "answer": "Yes. `disp` and auto-print both use the active format setting. `fprintf` and `sprintf` use their own explicit format specifiers and ignore this setting."
+    },
+    {
+      "question": "Are format mode names case-sensitive?",
+      "answer": "No. `format SHORT`, `format Short`, and `format short` are all equivalent."
+    },
+    {
+      "question": "What does `format rat` do for integers?",
+      "answer": "Integers are displayed as-is without a denominator (e.g., `42` rather than `42/1`). `format rational` is accepted as an alias for `format rat`."
+    }
+  ],
+  "links": [
+    {
+      "label": "disp",
+      "url": "./disp"
+    },
+    {
+      "label": "fprintf",
+      "url": "./fprintf"
+    },
+    {
+      "label": "sprintf",
+      "url": "./sprintf"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/io/format.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/io/format.rs"
+  },
+  "gpu_residency": "`format` is a display-only setting with no effect on GPU residency or acceleration.",
+  "gpu_behavior": [
+    "`format` does not interact with GPU tensors. It only affects how values are rendered after being gathered to the host for display."
+  ]
+}

--- a/crates/runmat-runtime/src/builtins/common/format.rs
+++ b/crates/runmat-runtime/src/builtins/common/format.rs
@@ -795,6 +795,35 @@ fn value_to_f64(value: &Value) -> BuiltinResult<f64> {
     }
 }
 
+fn number_to_string(value: f64) -> String {
+    if value.is_nan() {
+        return "NaN".to_string();
+    }
+    if value.is_infinite() {
+        return if value.is_sign_negative() {
+            "-Inf".to_string()
+        } else {
+            "Inf".to_string()
+        };
+    }
+    if value == 0.0 {
+        return "0".to_string();
+    }
+    value.to_string()
+}
+
+fn complex_to_string(re: f64, im: f64) -> String {
+    if im == 0.0 {
+        number_to_string(re)
+    } else if re == 0.0 {
+        format!("{}i", number_to_string(im))
+    } else if im < 0.0 {
+        format!("{}-{}i", number_to_string(re), number_to_string(im.abs()))
+    } else {
+        format!("{}+{}i", number_to_string(re), number_to_string(im))
+    }
+}
+
 fn value_to_string(value: &Value) -> BuiltinResult<String> {
     match value {
         Value::String(s) => Ok(s.clone()),
@@ -806,10 +835,10 @@ fn value_to_string(value: &Value) -> BuiltinResult<String> {
             Ok(s)
         }
         Value::StringArray(sa) if sa.data.len() == 1 => Ok(sa.data[0].clone()),
-        Value::Num(n) => Ok(Value::Num(*n).to_string()),
+        Value::Num(n) => Ok(number_to_string(*n)),
         Value::Int(i) => Ok(i.to_i64().to_string()),
         Value::Bool(b) => Ok(if *b { "true" } else { "false" }.to_string()),
-        Value::Complex(re, im) => Ok(Value::Complex(*re, *im).to_string()),
+        Value::Complex(re, im) => Ok(complex_to_string(*re, *im)),
         other => Err(format_error(format!(
             "sprintf: expected text or scalar value for %s conversion, got {other:?}"
         ))),
@@ -1106,6 +1135,7 @@ async fn flatten_value(value: Value, output: &mut Vec<Value>, context: &str) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use runmat_builtins::{get_display_format, set_display_format, FormatMode};
 
     #[test]
     fn format_variadic_supports_thousands_grouping_flag() {
@@ -1119,5 +1149,19 @@ mod tests {
         let out = format_variadic("%Id", &[Value::Int(IntValue::I32(42))])
             .expect("I flag should be accepted as compatibility no-op");
         assert_eq!(out, "42");
+    }
+
+    #[test]
+    fn percent_s_numeric_and_complex_ignore_display_format() {
+        let previous = get_display_format();
+        set_display_format(FormatMode::Hex);
+        let result = format_variadic(
+            "%s %s",
+            &[Value::Num(std::f64::consts::PI), Value::Complex(1.5, -2.0)],
+        );
+        set_display_format(previous);
+
+        let out = result.expect("%s formatting should succeed");
+        assert_eq!(out, "3.141592653589793 1.5-2i");
     }
 }

--- a/crates/runmat-runtime/src/builtins/common/format.rs
+++ b/crates/runmat-runtime/src/builtins/common/format.rs
@@ -795,7 +795,7 @@ fn value_to_f64(value: &Value) -> BuiltinResult<f64> {
     }
 }
 
-fn number_to_string(value: f64) -> String {
+pub(crate) fn number_to_string(value: f64) -> String {
     if value.is_nan() {
         return "NaN".to_string();
     }
@@ -812,7 +812,7 @@ fn number_to_string(value: f64) -> String {
     value.to_string()
 }
 
-fn complex_to_string(re: f64, im: f64) -> String {
+pub(crate) fn complex_to_string(re: f64, im: f64) -> String {
     if im == 0.0 {
         number_to_string(re)
     } else if re == 0.0 {

--- a/crates/runmat-runtime/src/builtins/io/disp.rs
+++ b/crates/runmat-runtime/src/builtins/io/disp.rs
@@ -770,8 +770,8 @@ pub(crate) mod tests {
                 "     2       4".to_string(),
                 String::new(),
                 "(:,:,2) =".to_string(),
-                "5+0.5i  7+0.5i".to_string(),
-                "6+0.5i  8+0.5i".to_string()
+                "5+0.5000i  7+0.5000i".to_string(),
+                "6+0.5000i  8+0.5000i".to_string()
             ]
         );
     }

--- a/crates/runmat-runtime/src/builtins/io/format.rs
+++ b/crates/runmat-runtime/src/builtins/io/format.rs
@@ -1,0 +1,221 @@
+//! MATLAB-compatible `format` builtin for controlling numeric display precision.
+
+use runmat_builtins::{set_display_format, FormatMode, Tensor, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::{build_runtime_error, BuiltinResult};
+
+#[runtime_builtin(
+    name = "format",
+    category = "io",
+    summary = "Set the numeric display format for console output (format short, format long, etc.).",
+    keywords = "format,display,precision,numeric,short,long,scientific",
+    sink = true,
+    suppress_auto_output = true,
+    builtin_path = "crate::builtins::io::format"
+)]
+async fn format_builtin(args: Vec<Value>) -> BuiltinResult<Value> {
+    let keyword =
+        match args.as_slice() {
+            [] => {
+                set_display_format(FormatMode::Short);
+                return Ok(empty_value());
+            }
+            [Value::String(s)] => s.to_lowercase(),
+            [Value::CharArray(ca)] => ca.to_string().to_lowercase(),
+            _ => return Err(build_runtime_error(
+                "format: unrecognized argument; expected a format name such as 'short' or 'long'",
+            )
+            .with_builtin("format")
+            .build()),
+        };
+    // Spacing modes: accepted for MATLAB compatibility but not yet implemented.
+    // Crucially, they must NOT change the active numeric format.
+    if matches!(keyword.trim(), "compact" | "loose") {
+        return Ok(empty_value());
+    }
+    set_display_format(parse_numeric_mode(keyword.trim())?);
+    Ok(empty_value())
+}
+
+fn parse_numeric_mode(s: &str) -> BuiltinResult<FormatMode> {
+    match s {
+        "short" => Ok(FormatMode::Short),
+        "long" => Ok(FormatMode::Long),
+        "shorte" => Ok(FormatMode::ShortE),
+        "longe" => Ok(FormatMode::LongE),
+        "shortg" => Ok(FormatMode::ShortG),
+        "longg" => Ok(FormatMode::LongG),
+        "rat" | "rational" => Ok(FormatMode::Rational),
+        "hex" => Ok(FormatMode::Hex),
+        other => Err(build_runtime_error(format!(
+            "format: unknown format '{other}'; numeric modes: short, long, shortE, longE, shortG, longG, rat, hex"
+        ))
+        .with_builtin("format")
+        .build()),
+    }
+}
+
+fn empty_value() -> Value {
+    Value::Tensor(Tensor::zeros(vec![0, 0]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::{format_number, get_display_format, FormatMode};
+    use std::f64::consts::PI;
+
+    fn with_format<F: FnOnce()>(mode: FormatMode, f: F) {
+        let prev = get_display_format();
+        set_display_format(mode);
+        f();
+        set_display_format(prev);
+    }
+
+    #[test]
+    fn test_parse_numeric_mode_case_insensitive() {
+        // parse_numeric_mode receives an already-lowercased string from the builtin.
+        assert_eq!(parse_numeric_mode("short").unwrap(), FormatMode::Short);
+        assert_eq!(parse_numeric_mode("long").unwrap(), FormatMode::Long);
+        assert_eq!(parse_numeric_mode("shorte").unwrap(), FormatMode::ShortE);
+        assert_eq!(parse_numeric_mode("longe").unwrap(), FormatMode::LongE);
+        assert_eq!(parse_numeric_mode("shortg").unwrap(), FormatMode::ShortG);
+        assert_eq!(parse_numeric_mode("longg").unwrap(), FormatMode::LongG);
+        assert_eq!(parse_numeric_mode("rat").unwrap(), FormatMode::Rational);
+        assert_eq!(
+            parse_numeric_mode("rational").unwrap(),
+            FormatMode::Rational
+        );
+        assert_eq!(parse_numeric_mode("hex").unwrap(), FormatMode::Hex);
+    }
+
+    #[test]
+    fn test_parse_numeric_mode_unknown() {
+        assert!(parse_numeric_mode("bank").is_err());
+        assert!(parse_numeric_mode("").is_err());
+        // Spacing modes are handled before parse_numeric_mode is called.
+        assert!(parse_numeric_mode("compact").is_err());
+        assert!(parse_numeric_mode("loose").is_err());
+    }
+
+    #[test]
+    fn test_spacing_modes_do_not_change_numeric_format() {
+        block_on(async {
+            format_builtin(vec![Value::String("long".to_string())])
+                .await
+                .unwrap();
+            assert_eq!(get_display_format(), FormatMode::Long);
+
+            format_builtin(vec![Value::String("compact".to_string())])
+                .await
+                .unwrap();
+            assert_eq!(
+                get_display_format(),
+                FormatMode::Long,
+                "compact must not reset numeric format"
+            );
+
+            format_builtin(vec![Value::String("loose".to_string())])
+                .await
+                .unwrap();
+            assert_eq!(
+                get_display_format(),
+                FormatMode::Long,
+                "loose must not reset numeric format"
+            );
+
+            set_display_format(FormatMode::Short);
+        });
+    }
+
+    #[test]
+    fn test_set_display_format() {
+        with_format(FormatMode::Long, || {
+            assert_eq!(get_display_format(), FormatMode::Long);
+        });
+    }
+
+    // --- Behavioral tests: format_builtin + display output ---
+
+    #[test]
+    fn format_builtin_long_sets_mode_and_pi_displays_full_precision() {
+        block_on(async {
+            format_builtin(vec![Value::String("long".to_string())])
+                .await
+                .unwrap();
+            assert_eq!(format_number(PI), "3.141592653589793");
+            set_display_format(FormatMode::Short);
+        });
+    }
+
+    #[test]
+    fn format_builtin_short_pi_displays_four_decimal_places() {
+        block_on(async {
+            format_builtin(vec![Value::String("short".to_string())])
+                .await
+                .unwrap();
+            assert_eq!(format_number(PI), "3.1416");
+            assert_eq!(format_number(0.5), "0.5000");
+            assert_eq!(format_number(1.0), "1");
+        });
+    }
+
+    #[test]
+    fn format_builtin_short_e_always_scientific() {
+        block_on(async {
+            format_builtin(vec![Value::String("shortE".to_string())])
+                .await
+                .unwrap();
+            assert_eq!(format_number(PI), "3.1416e+00");
+            assert_eq!(format_number(1000.0), "1.0000e+03");
+            set_display_format(FormatMode::Short);
+        });
+    }
+
+    #[test]
+    fn format_builtin_no_args_resets_to_short() {
+        block_on(async {
+            format_builtin(vec![Value::String("long".to_string())])
+                .await
+                .unwrap();
+            format_builtin(vec![]).await.unwrap();
+            assert_eq!(get_display_format(), FormatMode::Short);
+        });
+    }
+
+    #[test]
+    fn format_builtin_rational_pi_approximation() {
+        block_on(async {
+            // Use MATLAB's canonical keyword "rat" (not "rational").
+            format_builtin(vec![Value::String("rat".to_string())])
+                .await
+                .unwrap();
+            // 355/113 is the classic rational approximation of pi
+            assert_eq!(format_number(PI), "355/113");
+            set_display_format(FormatMode::Short);
+        });
+    }
+
+    #[test]
+    fn format_builtin_hex_pi() {
+        block_on(async {
+            format_builtin(vec![Value::String("hex".to_string())])
+                .await
+                .unwrap();
+            assert_eq!(format_number(PI), "400921fb54442d18");
+            set_display_format(FormatMode::Short);
+        });
+    }
+
+    #[test]
+    fn format_builtin_small_value_goes_scientific_in_short() {
+        block_on(async {
+            format_builtin(vec![Value::String("short".to_string())])
+                .await
+                .unwrap();
+            assert_eq!(format_number(1e-5), "1.0000e-05");
+        });
+    }
+}

--- a/crates/runmat-runtime/src/builtins/io/mod.rs
+++ b/crates/runmat-runtime/src/builtins/io/mod.rs
@@ -2,6 +2,7 @@ pub mod clc;
 pub mod data;
 pub mod disp;
 pub mod filetext;
+pub mod format;
 pub mod http;
 pub mod input;
 pub mod json;

--- a/crates/runmat-runtime/src/builtins/strings/core/sprintf.rs
+++ b/crates/runmat-runtime/src/builtins/strings/core/sprintf.rs
@@ -303,7 +303,7 @@ pub(crate) mod tests {
             vec![Value::Complex(1.5, -2.0)],
         )
         .expect("sprintf");
-        assert_eq!(char_value_to_string(result), "1.5-2i");
+        assert_eq!(char_value_to_string(result), "1.5000-2i");
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/runmat-runtime/src/builtins/strings/core/sprintf.rs
+++ b/crates/runmat-runtime/src/builtins/strings/core/sprintf.rs
@@ -303,7 +303,7 @@ pub(crate) mod tests {
             vec![Value::Complex(1.5, -2.0)],
         )
         .expect("sprintf");
-        assert_eq!(char_value_to_string(result), "1.5000-2i");
+        assert_eq!(char_value_to_string(result), "1.5-2i");
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/runmat-runtime/src/builtins/strings/core/string.rs
+++ b/crates/runmat-runtime/src/builtins/strings/core/string.rs
@@ -5,7 +5,7 @@ use runmat_builtins::{
 };
 use runmat_macros::runtime_builtin;
 
-use crate::builtins::common::format::format_variadic;
+use crate::builtins::common::format::{complex_to_string, format_variadic, number_to_string};
 use crate::builtins::common::map_control_flow_with_builtin;
 use crate::builtins::common::spec::{
     BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
@@ -742,35 +742,6 @@ fn cell_element_to_string(value: &Value) -> BuiltinResult<String> {
             "string: unsupported cell element type {:?}; expected text or scalar values",
             other
         ))),
-    }
-}
-
-fn number_to_string(value: f64) -> String {
-    if value.is_nan() {
-        return "NaN".to_string();
-    }
-    if value.is_infinite() {
-        return if value.is_sign_negative() {
-            "-Inf".to_string()
-        } else {
-            "Inf".to_string()
-        };
-    }
-    if value == 0.0 {
-        return "0".to_string();
-    }
-    value.to_string()
-}
-
-fn complex_to_string(re: f64, im: f64) -> String {
-    if im == 0.0 {
-        number_to_string(re)
-    } else if re == 0.0 {
-        format!("{}i", number_to_string(im))
-    } else if im < 0.0 {
-        format!("{}-{}i", number_to_string(re), number_to_string(im.abs()))
-    } else {
-        format!("{}+{}i", number_to_string(re), number_to_string(im))
     }
 }
 

--- a/crates/runmat-runtime/src/builtins/strings/core/string.rs
+++ b/crates/runmat-runtime/src/builtins/strings/core/string.rs
@@ -441,14 +441,14 @@ async fn extract_argument_data(value: Value) -> BuiltinResult<ArgumentData> {
             shape: t.shape,
         }),
         Value::Complex(re, im) => Ok(ArgumentData {
-            values: vec![Value::String(Value::Complex(re, im).to_string())],
+            values: vec![Value::String(complex_to_string(re, im))],
             shape: vec![1, 1],
         }),
         Value::ComplexTensor(t) => Ok(ArgumentData {
             values: t
                 .data
                 .into_iter()
-                .map(|(re, im)| Value::String(Value::Complex(re, im).to_string()))
+                .map(|(re, im)| Value::String(complex_to_string(re, im)))
                 .collect(),
             shape: t.shape,
         }),
@@ -506,9 +506,7 @@ async fn extract_argument_data(value: Value) -> BuiltinResult<ArgumentData> {
                             }
                             Value::Num(if la.data[0] != 0 { 1.0 } else { 0.0 })
                         }
-                        Value::Complex(re, im) => {
-                            Value::String(Value::Complex(re, im).to_string())
-                        }
+                        Value::Complex(re, im) => Value::String(complex_to_string(re, im)),
                         Value::ComplexTensor(t) => {
                             if t.data.len() != 1 {
                                 return Err(string_flow(
@@ -516,7 +514,7 @@ async fn extract_argument_data(value: Value) -> BuiltinResult<ArgumentData> {
                                 ));
                             }
                             let (re, im) = t.data[0];
-                            Value::String(Value::Complex(re, im).to_string())
+                            Value::String(complex_to_string(re, im))
                         }
                         other => {
                             return Err(string_flow(format!(
@@ -573,10 +571,10 @@ async fn convert_to_string_array(
         Value::ComplexTensor(tensor) => complex_tensor_to_string_array(tensor),
         Value::LogicalArray(logical) => logical_array_to_string_array(logical),
         Value::Cell(cell) => cell_array_to_string_array(cell, encoding).await,
-        Value::Num(n) => string_scalar(Value::Num(n).to_string()),
+        Value::Num(n) => string_scalar(number_to_string(n)),
         Value::Int(i) => string_scalar(int_value_to_string(&i)),
         Value::Bool(b) => string_scalar(bool_to_string(b).to_string()),
-        Value::Complex(re, im) => string_scalar(Value::Complex(re, im).to_string()),
+        Value::Complex(re, im) => string_scalar(complex_to_string(re, im)),
         Value::GpuTensor(handle) => {
             // Defensive fallback: gather and retry.
             let gathered = gather_if_needed_async(&Value::GpuTensor(handle))
@@ -636,7 +634,7 @@ fn char_array_to_string_array(
 fn tensor_to_string_array(tensor: Tensor) -> BuiltinResult<StringArray> {
     let mut strings = Vec::with_capacity(tensor.data.len());
     for &value in &tensor.data {
-        strings.push(Value::Num(value).to_string());
+        strings.push(number_to_string(value));
     }
     StringArray::new(strings, tensor.shape).map_err(|e| string_flow(format!("string: {e}")))
 }
@@ -644,7 +642,7 @@ fn tensor_to_string_array(tensor: Tensor) -> BuiltinResult<StringArray> {
 fn complex_tensor_to_string_array(tensor: ComplexTensor) -> BuiltinResult<StringArray> {
     let mut strings = Vec::with_capacity(tensor.data.len());
     for &(re, im) in &tensor.data {
-        strings.push(Value::Complex(re, im).to_string());
+        strings.push(complex_to_string(re, im));
     }
     StringArray::new(strings, tensor.shape).map_err(|e| string_flow(format!("string: {e}")))
 }
@@ -714,7 +712,7 @@ fn cell_element_to_string(value: &Value) -> BuiltinResult<String> {
                 ))
             }
         }
-        Value::Num(n) => Ok(Value::Num(*n).to_string()),
+        Value::Num(n) => Ok(number_to_string(*n)),
         Value::Int(i) => Ok(int_value_to_string(i)),
         Value::Bool(b) => Ok(bool_to_string(*b).to_string()),
         Value::LogicalArray(array) => {
@@ -726,16 +724,16 @@ fn cell_element_to_string(value: &Value) -> BuiltinResult<String> {
         }
         Value::Tensor(t) => {
             if t.data.len() == 1 {
-                Ok(Value::Num(t.data[0]).to_string())
+                Ok(number_to_string(t.data[0]))
             } else {
                 Err(string_flow("string: cell numeric values must be scalar"))
             }
         }
-        Value::Complex(re, im) => Ok(Value::Complex(*re, *im).to_string()),
+        Value::Complex(re, im) => Ok(complex_to_string(*re, *im)),
         Value::ComplexTensor(t) => {
             if t.data.len() == 1 {
                 let (re, im) = t.data[0];
-                Ok(Value::Complex(re, im).to_string())
+                Ok(complex_to_string(re, im))
             } else {
                 Err(string_flow("string: cell complex values must be scalar"))
             }
@@ -744,6 +742,35 @@ fn cell_element_to_string(value: &Value) -> BuiltinResult<String> {
             "string: unsupported cell element type {:?}; expected text or scalar values",
             other
         ))),
+    }
+}
+
+fn number_to_string(value: f64) -> String {
+    if value.is_nan() {
+        return "NaN".to_string();
+    }
+    if value.is_infinite() {
+        return if value.is_sign_negative() {
+            "-Inf".to_string()
+        } else {
+            "Inf".to_string()
+        };
+    }
+    if value == 0.0 {
+        return "0".to_string();
+    }
+    value.to_string()
+}
+
+fn complex_to_string(re: f64, im: f64) -> String {
+    if im == 0.0 {
+        number_to_string(re)
+    } else if re == 0.0 {
+        format!("{}i", number_to_string(im))
+    } else if im < 0.0 {
+        format!("{}-{}i", number_to_string(re), number_to_string(im.abs()))
+    } else {
+        format!("{}+{}i", number_to_string(re), number_to_string(im))
     }
 }
 


### PR DESCRIPTION
  Implements MATLAB's format command (short, long, shortE, longE, shortG, longG, rat, hex), persisting the chosen mode across executions within a
  session via a thread-local FormatMode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core value display/printing behavior and adds session-persisted state, which may affect golden outputs and user-visible formatting across the REPL and `disp`.
> 
> **Overview**
> Implements MATLAB-style numeric display control via a new `format` builtin, including command-form parsing (`format long`, etc.), docs (`builtins-json/format.json`), and runtime plumbing.
> 
> Numeric rendering is refactored into a thread-local `FormatMode` in `runmat-builtins` and all `Value`/`Tensor` display paths now use `format_number`, with the active mode persisted across executions in `RunMatSession` (set at start of run, captured at end). Related tests are updated/added, and `sprintf`/`string` conversions are adjusted so `%s` and stringification continue to use stable, non-`format`-dependent numeric/complex formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 973f46b17e313fe8ce2523c3af8e1f9b5cd6c61d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->