### PR TITLE
Add fzero and fsolve root-finding builtins

### DIFF
--- a/crates/runmat-runtime/src/builtins/builtins-json/fsolve.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/fsolve.json
@@ -1,0 +1,53 @@
+{
+  "title": "fsolve",
+  "category": "math/optim",
+  "keywords": ["fsolve", "nonlinear solve", "root finding", "Jacobian", "Levenberg-Marquardt"],
+  "summary": "Solve scalar or vector nonlinear equation systems using finite-difference Levenberg-Marquardt iterations.",
+  "references": ["https://www.mathworks.com/help/optim/ug/fsolve.html"],
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [],
+    "broadcasting": "none",
+    "notes": "The nonlinear solver runs on the host. Callback functions may still call GPU-aware builtins."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 3,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::math::optim::fsolve::tests",
+    "integration": "runmat-vm/tests/closures.rs::fsolve_accepts_anonymous_vector_function"
+  },
+  "description": "`x = fsolve(fun, x0)` solves `fun(x) = 0` starting from `x0`. Scalar guesses return scalars; vector and matrix guesses return a result with the same shape as `x0`.",
+  "behaviors": [
+    "The function handle must return a finite real scalar or vector.",
+    "Jacobians are estimated with forward finite differences.",
+    "The step is chosen with a Levenberg-Marquardt damping parameter and accepted only when it reduces the residual norm.",
+    "Options are supplied as a struct, usually created with `optimset`. `TolX`, `TolFun`, `MaxIter`, `MaxFunEvals`, and `Display` are accepted."
+  ],
+  "examples": [
+    {
+      "description": "Solve a two-variable nonlinear system",
+      "input": "F = @(x) [x(1)^2 + x(2)^2 - 4; x(1)*x(2) - 1];\nx = fsolve(F, [1; 1])",
+      "output": "x =\n    1.9319\n    0.5176"
+    },
+    {
+      "description": "Solve a scalar equation",
+      "input": "x = fsolve(@sin, 3)",
+      "output": "x =\n    3.1416"
+    }
+  ],
+  "links": [
+    { "label": "fzero", "url": "./fzero" },
+    { "label": "optimset", "url": "./optimset" },
+    { "label": "linsolve", "url": "./linsolve" }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/math/optim/fsolve.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/math/optim/fsolve.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/builtins-json/fzero.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/fzero.json
@@ -1,0 +1,58 @@
+{
+  "title": "fzero",
+  "category": "math/optim",
+  "keywords": ["fzero", "root finding", "zero", "brent", "optimization"],
+  "summary": "Find a zero of a scalar nonlinear function using bracket expansion and Brent's method.",
+  "references": ["https://www.mathworks.com/help/matlab/ref/fzero.html"],
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [],
+    "broadcasting": "none",
+    "notes": "The solver runs on the host. Callback functions may still call GPU-aware builtins."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 3,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::math::optim::fzero::tests",
+    "integration": "runmat-vm/tests/closures.rs::fzero_accepts_anonymous_function"
+  },
+  "description": "`x = fzero(fun, x0)` searches near the scalar initial point `x0` for a sign-changing bracket, then refines the zero. `x = fzero(fun, [a b])` uses the supplied two-element bracket directly.",
+  "behaviors": [
+    "The function handle must return a finite real scalar.",
+    "Bracket endpoints must have opposite signs unless one endpoint is already a root.",
+    "Options are supplied as a struct, usually created with `optimset`. `TolX`, `MaxIter`, `MaxFunEvals`, and `Display` are accepted.",
+    "Anonymous functions, named function handles, and function-handle strings work through RunMat's existing `feval` dispatch path."
+  ],
+  "examples": [
+    {
+      "description": "Find the fixed point of cosine",
+      "input": "f = @(x) cos(x) - x;\nx = fzero(f, 0.5)",
+      "output": "x =\n    0.7391"
+    },
+    {
+      "description": "Use an explicit bracket",
+      "input": "x = fzero(@sin, [3 4])",
+      "output": "x =\n    3.1416"
+    },
+    {
+      "description": "Set a tighter tolerance",
+      "input": "opts = optimset('TolX', 1e-10, 'Display', 'off');\nx = fzero(@sin, [3 4], opts)",
+      "output": "x =\n    3.1416"
+    }
+  ],
+  "links": [
+    { "label": "fsolve", "url": "./fsolve" },
+    { "label": "optimset", "url": "./optimset" },
+    { "label": "roots", "url": "./roots" }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/math/optim/fzero.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/math/optim/fzero.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/builtins-json/optimset.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/optimset.json
@@ -1,0 +1,45 @@
+{
+  "title": "optimset",
+  "category": "math/optim",
+  "keywords": ["optimset", "options", "TolX", "TolFun", "MaxIter", "Display"],
+  "summary": "Create or update an optimization options structure for fzero and fsolve.",
+  "references": ["https://www.mathworks.com/help/matlab/ref/optimset.html"],
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [],
+    "broadcasting": "none",
+    "notes": "Options are host metadata."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 0,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::math::optim::optimset::tests"
+  },
+  "description": "`opts = optimset(name, value, ...)` creates a struct of optimization options. `opts = optimset(old, name, value, ...)` copies an existing options struct and applies overrides.",
+  "behaviors": [
+    "Option names are case-insensitive for the builtins that consume them.",
+    "`TolX`, `TolFun`, `MaxIter`, `MaxFunEvals`, and `Display` are canonicalized when constructed with `optimset`.",
+    "Unknown option names are preserved so future solvers can read them."
+  ],
+  "examples": [
+    {
+      "description": "Create options for fzero",
+      "input": "opts = optimset('TolX', 1e-10, 'Display', 'off');\nx = fzero(@sin, [3 4], opts)",
+      "output": "x =\n    3.1416"
+    }
+  ],
+  "links": [
+    { "label": "fzero", "url": "./fzero" },
+    { "label": "fsolve", "url": "./fsolve" }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/math/optim/optimset.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/math/optim/optimset.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/math/mod.rs
+++ b/crates/runmat-runtime/src/builtins/math/mod.rs
@@ -1,6 +1,7 @@
 pub mod elementwise;
 pub mod fft;
 pub mod linalg;
+pub mod optim;
 pub mod poly;
 pub mod reduction;
 pub mod rounding;

--- a/crates/runmat-runtime/src/builtins/math/optim/common.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/common.rs
@@ -1,0 +1,254 @@
+use runmat_builtins::{CharArray, StructValue, Tensor, Value};
+
+use crate::{build_runtime_error, BuiltinResult, RuntimeError};
+
+pub(crate) fn optim_error(name: &str, message: impl Into<String>) -> RuntimeError {
+    build_runtime_error(message).with_builtin(name).build()
+}
+
+pub(crate) async fn call_function(handle: &Value, args: Vec<Value>) -> BuiltinResult<Value> {
+    let mut call_args = Vec::with_capacity(args.len() + 1);
+    call_args.push(handle.clone());
+    call_args.extend(args);
+    crate::call_builtin_async("feval", &call_args).await
+}
+
+pub(crate) async fn call_scalar_function(name: &str, handle: &Value, x: f64) -> BuiltinResult<f64> {
+    let value = call_function(handle, vec![Value::Num(x)]).await?;
+    let value = crate::dispatcher::gather_if_needed_async(&value).await?;
+    value_to_scalar(name, value)
+}
+
+pub(crate) fn value_to_scalar(name: &str, value: Value) -> BuiltinResult<f64> {
+    match value {
+        Value::Num(n) => ensure_finite(name, n),
+        Value::Int(i) => ensure_finite(name, i.to_f64()),
+        Value::Bool(b) => Ok(if b { 1.0 } else { 0.0 }),
+        Value::Tensor(tensor) => {
+            if tensor.data.len() == 1 {
+                ensure_finite(name, tensor.data[0])
+            } else {
+                Err(optim_error(
+                    name,
+                    format!("{name}: function value must be a scalar"),
+                ))
+            }
+        }
+        Value::LogicalArray(logical) => {
+            if logical.data.len() == 1 {
+                Ok(if logical.data[0] != 0 { 1.0 } else { 0.0 })
+            } else {
+                Err(optim_error(
+                    name,
+                    format!("{name}: function value must be a scalar"),
+                ))
+            }
+        }
+        other => Err(optim_error(
+            name,
+            format!("{name}: function value must be real numeric, got {other:?}"),
+        )),
+    }
+}
+
+pub(crate) async fn value_to_real_vector(name: &str, value: Value) -> BuiltinResult<Vec<f64>> {
+    let value = crate::dispatcher::gather_if_needed_async(&value).await?;
+    match value {
+        Value::Num(n) => Ok(vec![ensure_finite(name, n)?]),
+        Value::Int(i) => Ok(vec![ensure_finite(name, i.to_f64())?]),
+        Value::Bool(b) => Ok(vec![if b { 1.0 } else { 0.0 }]),
+        Value::Tensor(tensor) => finite_vec(name, tensor.data),
+        Value::LogicalArray(logical) => Ok(logical
+            .data
+            .iter()
+            .map(|&v| if v != 0 { 1.0 } else { 0.0 })
+            .collect()),
+        other => Err(optim_error(
+            name,
+            format!("{name}: function value must be a real numeric vector, got {other:?}"),
+        )),
+    }
+}
+
+pub(crate) async fn initial_guess(name: &str, value: Value) -> BuiltinResult<InitialGuess> {
+    let value = crate::dispatcher::gather_if_needed_async(&value).await?;
+    match value {
+        Value::Num(n) => Ok(InitialGuess {
+            values: vec![ensure_finite(name, n)?],
+            shape: vec![1, 1],
+            scalar: true,
+        }),
+        Value::Int(i) => Ok(InitialGuess {
+            values: vec![ensure_finite(name, i.to_f64())?],
+            shape: vec![1, 1],
+            scalar: true,
+        }),
+        Value::Bool(b) => Ok(InitialGuess {
+            values: vec![if b { 1.0 } else { 0.0 }],
+            shape: vec![1, 1],
+            scalar: true,
+        }),
+        Value::Tensor(tensor) => {
+            if tensor.data.is_empty() {
+                return Err(optim_error(
+                    name,
+                    format!("{name}: initial guess cannot be empty"),
+                ));
+            }
+            Ok(InitialGuess {
+                values: finite_vec(name, tensor.data)?,
+                shape: tensor.shape,
+                scalar: false,
+            })
+        }
+        Value::LogicalArray(logical) => {
+            if logical.data.is_empty() {
+                return Err(optim_error(
+                    name,
+                    format!("{name}: initial guess cannot be empty"),
+                ));
+            }
+            Ok(InitialGuess {
+                values: logical
+                    .data
+                    .iter()
+                    .map(|&v| if v != 0 { 1.0 } else { 0.0 })
+                    .collect(),
+                shape: logical.shape,
+                scalar: false,
+            })
+        }
+        other => Err(optim_error(
+            name,
+            format!("{name}: initial guess must be real numeric, got {other:?}"),
+        )),
+    }
+}
+
+pub(crate) fn vector_to_value(
+    name: &str,
+    values: Vec<f64>,
+    shape: &[usize],
+    scalar: bool,
+) -> BuiltinResult<Value> {
+    if scalar {
+        Ok(Value::Num(values[0]))
+    } else {
+        Tensor::new(values, shape.to_vec())
+            .map(Value::Tensor)
+            .map_err(|e| optim_error(name, format!("{name}: {e}")))
+    }
+}
+
+pub(crate) fn field_name(value: &Value) -> BuiltinResult<String> {
+    match value {
+        Value::String(s) => Ok(s.clone()),
+        Value::StringArray(sa) if sa.data.len() == 1 => Ok(sa.data[0].clone()),
+        Value::CharArray(CharArray { data, rows: 1, .. }) => Ok(data.iter().collect()),
+        other => Err(optim_error(
+            "optimset",
+            format!("optimset: option names must be strings, got {other:?}"),
+        )),
+    }
+}
+
+pub(crate) fn lookup_option<'a>(options: &'a StructValue, name: &str) -> Option<&'a Value> {
+    options
+        .fields
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value)
+}
+
+pub(crate) fn option_f64(
+    builtin: &str,
+    options: Option<&StructValue>,
+    field: &str,
+    default: f64,
+) -> BuiltinResult<f64> {
+    let Some(options) = options else {
+        return Ok(default);
+    };
+    let Some(value) = lookup_option(options, field) else {
+        return Ok(default);
+    };
+    let parsed = match value {
+        Value::Num(n) => *n,
+        Value::Int(i) => i.to_f64(),
+        other => {
+            return Err(optim_error(
+                builtin,
+                format!("{builtin}: option {field} must be numeric, got {other:?}"),
+            ))
+        }
+    };
+    ensure_finite(builtin, parsed)
+}
+
+pub(crate) fn option_usize(
+    builtin: &str,
+    options: Option<&StructValue>,
+    field: &str,
+    default: usize,
+) -> BuiltinResult<usize> {
+    let value = option_f64(builtin, options, field, default as f64)?;
+    if value < 0.0 {
+        return Err(optim_error(
+            builtin,
+            format!("{builtin}: option {field} must be non-negative"),
+        ));
+    }
+    Ok(value.floor() as usize)
+}
+
+pub(crate) fn option_string(
+    options: Option<&StructValue>,
+    field: &str,
+    default: &str,
+) -> BuiltinResult<String> {
+    let Some(options) = options else {
+        return Ok(default.to_string());
+    };
+    let Some(value) = lookup_option(options, field) else {
+        return Ok(default.to_string());
+    };
+    match value {
+        Value::String(s) => Ok(s.to_ascii_lowercase()),
+        Value::StringArray(sa) if sa.data.len() == 1 => Ok(sa.data[0].to_ascii_lowercase()),
+        Value::CharArray(CharArray { data, rows: 1, .. }) => {
+            Ok(data.iter().collect::<String>().to_ascii_lowercase())
+        }
+        other => Err(optim_error(
+            "optim",
+            format!("optim option {field} must be a string, got {other:?}"),
+        )),
+    }
+}
+
+fn ensure_finite(name: &str, value: f64) -> BuiltinResult<f64> {
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err(optim_error(
+            name,
+            format!("{name}: function value must be finite"),
+        ))
+    }
+}
+
+fn finite_vec(name: &str, values: Vec<f64>) -> BuiltinResult<Vec<f64>> {
+    if values.iter().all(|value| value.is_finite()) {
+        Ok(values)
+    } else {
+        Err(optim_error(
+            name,
+            format!("{name}: function value must be finite"),
+        ))
+    }
+}
+
+pub(crate) struct InitialGuess {
+    pub values: Vec<f64>,
+    pub shape: Vec<usize>,
+    pub scalar: bool,
+}

--- a/crates/runmat-runtime/src/builtins/math/optim/fsolve.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/fsolve.rs
@@ -1,0 +1,323 @@
+//! MATLAB-compatible `fsolve` builtin for nonlinear systems.
+
+use nalgebra::{DMatrix, DVector};
+use runmat_builtins::{StructValue, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ShapeRequirements,
+};
+use crate::builtins::math::optim::common::{
+    call_function, initial_guess, optim_error, option_f64, option_string, option_usize,
+    value_to_real_vector, vector_to_value,
+};
+use crate::builtins::math::optim::type_resolvers::nonlinear_solve_type;
+use crate::BuiltinResult;
+
+const NAME: &str = "fsolve";
+const DEFAULT_TOL_X: f64 = 1.0e-6;
+const DEFAULT_TOL_FUN: f64 = 1.0e-6;
+const DEFAULT_MAX_ITER: usize = 400;
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::math::optim::fsolve")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: "fsolve",
+    op_kind: GpuOpKind::Custom("nonlinear-solve"),
+    supported_precisions: &[],
+    broadcast: BroadcastSemantics::None,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::GatherImmediately,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "Host finite-difference Levenberg-Marquardt solver. Callback computations may use GPU-aware builtins.",
+};
+
+#[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::math::optim::fsolve")]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: "fsolve",
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: false,
+    notes: "Nonlinear solving repeatedly invokes user code and terminates fusion planning.",
+};
+
+#[runtime_builtin(
+    name = "fsolve",
+    category = "math/optim",
+    summary = "Solve a scalar or vector nonlinear equation system using finite-difference Levenberg-Marquardt iterations.",
+    keywords = "fsolve,nonlinear solve,root finding,levenberg-marquardt,jacobian",
+    accel = "sink",
+    type_resolver(nonlinear_solve_type),
+    builtin_path = "crate::builtins::math::optim::fsolve"
+)]
+async fn fsolve_builtin(function: Value, x0: Value, rest: Vec<Value>) -> BuiltinResult<Value> {
+    if rest.len() > 1 {
+        return Err(optim_error(NAME, "fsolve: too many input arguments"));
+    }
+    let options = parse_options(rest.first())?;
+    let opts = FsolveOptions::from_struct(options.as_ref())?;
+    let guess = initial_guess(NAME, x0).await?;
+    let solution = solve(&function, guess.values, &opts).await?;
+    vector_to_value(NAME, solution, &guess.shape, guess.scalar)
+}
+
+fn parse_options(value: Option<&Value>) -> BuiltinResult<Option<StructValue>> {
+    match value {
+        None => Ok(None),
+        Some(Value::Struct(options)) => Ok(Some(options.clone())),
+        Some(other) => Err(optim_error(
+            NAME,
+            format!("fsolve: options must be a struct, got {other:?}"),
+        )),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct FsolveOptions {
+    tol_x: f64,
+    tol_fun: f64,
+    max_iter: usize,
+    max_fun_evals: usize,
+}
+
+impl FsolveOptions {
+    fn from_struct(options: Option<&StructValue>) -> BuiltinResult<Self> {
+        let display = option_string(options, "Display", "off")?;
+        if !matches!(display.as_str(), "off" | "none" | "final" | "iter") {
+            return Err(optim_error(
+                NAME,
+                "fsolve: option Display must be 'off', 'none', 'final', or 'iter'",
+            ));
+        }
+        let tol_x = option_f64(NAME, options, "TolX", DEFAULT_TOL_X)?;
+        let tol_fun = option_f64(NAME, options, "TolFun", DEFAULT_TOL_FUN)?;
+        if tol_x <= 0.0 || tol_fun <= 0.0 {
+            return Err(optim_error(
+                NAME,
+                "fsolve: options TolX and TolFun must be positive",
+            ));
+        }
+        let max_iter = option_usize(NAME, options, "MaxIter", DEFAULT_MAX_ITER)?.max(1);
+        let max_fun_evals = option_usize(NAME, options, "MaxFunEvals", 100 * max_iter)?.max(1);
+        Ok(Self {
+            tol_x,
+            tol_fun,
+            max_iter,
+            max_fun_evals,
+        })
+    }
+}
+
+async fn solve(
+    function: &Value,
+    mut x: Vec<f64>,
+    options: &FsolveOptions,
+) -> BuiltinResult<Vec<f64>> {
+    let n = x.len();
+    if n == 0 {
+        return Err(optim_error(NAME, "fsolve: initial guess cannot be empty"));
+    }
+
+    let mut residual = eval_residual(function, &x).await?;
+    let mut evals = 1usize;
+    let mut lambda = 1.0e-3;
+
+    if residual_norm_inf(&residual) <= options.tol_fun {
+        return Ok(x);
+    }
+
+    for _ in 0..options.max_iter {
+        if evals >= options.max_fun_evals {
+            return Err(optim_error(
+                NAME,
+                "fsolve: exceeded maximum function evaluations",
+            ));
+        }
+        let jacobian =
+            finite_difference_jacobian(function, &x, &residual, &mut evals, options).await?;
+        let j = DMatrix::from_row_slice(residual.len(), n, &jacobian);
+        let f = DVector::from_column_slice(&residual);
+        let gradient = j.transpose() * &f;
+        let mut accepted = false;
+
+        for _ in 0..8 {
+            let normal = j.transpose() * &j + DMatrix::<f64>::identity(n, n) * lambda;
+            let rhs = -&gradient;
+            let Some(delta) = normal.lu().solve(&rhs) else {
+                lambda *= 10.0;
+                continue;
+            };
+            let trial = x
+                .iter()
+                .zip(delta.iter())
+                .map(|(xi, di)| xi + di)
+                .collect::<Vec<_>>();
+            let trial_residual = eval_residual(function, &trial).await?;
+            evals += 1;
+
+            if norm2(&trial_residual) < norm2(&residual) {
+                let step_norm = delta
+                    .iter()
+                    .fold(0.0_f64, |acc, value| acc.max(value.abs()));
+                let x_norm = x.iter().fold(0.0_f64, |acc, value| acc.max(value.abs()));
+                x = trial;
+                residual = trial_residual;
+                lambda = (lambda * 0.3).max(1.0e-12);
+                accepted = true;
+                if residual_norm_inf(&residual) <= options.tol_fun
+                    || step_norm <= options.tol_x * (1.0 + x_norm)
+                {
+                    return Ok(x);
+                }
+                break;
+            }
+
+            lambda *= 10.0;
+            if evals >= options.max_fun_evals {
+                return Err(optim_error(
+                    NAME,
+                    "fsolve: exceeded maximum function evaluations",
+                ));
+            }
+        }
+
+        if !accepted {
+            return Err(optim_error(
+                NAME,
+                "fsolve: iteration stalled before convergence",
+            ));
+        }
+    }
+
+    Err(optim_error(NAME, "fsolve: exceeded maximum iterations"))
+}
+
+async fn eval_residual(function: &Value, x: &[f64]) -> BuiltinResult<Vec<f64>> {
+    let arg = if x.len() == 1 {
+        Value::Num(x[0])
+    } else {
+        Value::Tensor(
+            runmat_builtins::Tensor::new(x.to_vec(), vec![x.len(), 1])
+                .map_err(|e| optim_error(NAME, format!("fsolve: {e}")))?,
+        )
+    };
+    let value = call_function(function, vec![arg]).await?;
+    let residual = value_to_real_vector(NAME, value).await?;
+    if residual.is_empty() {
+        Err(optim_error(
+            NAME,
+            "fsolve: function value must not be empty",
+        ))
+    } else {
+        Ok(residual)
+    }
+}
+
+async fn finite_difference_jacobian(
+    function: &Value,
+    x: &[f64],
+    residual: &[f64],
+    evals: &mut usize,
+    options: &FsolveOptions,
+) -> BuiltinResult<Vec<f64>> {
+    let m = residual.len();
+    let n = x.len();
+    let mut jacobian = vec![0.0; m * n];
+
+    for col in 0..n {
+        if *evals >= options.max_fun_evals {
+            return Err(optim_error(
+                NAME,
+                "fsolve: exceeded maximum function evaluations",
+            ));
+        }
+        let mut perturbed = x.to_vec();
+        let step = f64::EPSILON.sqrt() * (x[col].abs() + 1.0);
+        perturbed[col] += step;
+        let next = eval_residual(function, &perturbed).await?;
+        *evals += 1;
+        if next.len() != m {
+            return Err(optim_error(
+                NAME,
+                "fsolve: function output size changed during finite differencing",
+            ));
+        }
+        for row in 0..m {
+            jacobian[row * n + col] = (next[row] - residual[row]) / step;
+        }
+    }
+
+    Ok(jacobian)
+}
+
+fn norm2(values: &[f64]) -> f64 {
+    values.iter().map(|value| value * value).sum::<f64>().sqrt()
+}
+
+fn residual_norm_inf(values: &[f64]) -> f64 {
+    values
+        .iter()
+        .fold(0.0_f64, |acc, value| acc.max(value.abs()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::Tensor;
+
+    #[test]
+    fn fsolve_scalar_builtin_handle() {
+        let root = block_on(fsolve_builtin(
+            Value::FunctionHandle("sin".into()),
+            Value::Num(3.0),
+            Vec::new(),
+        ))
+        .unwrap();
+        match root {
+            Value::Num(n) => assert!((n - std::f64::consts::PI).abs() < 1.0e-5),
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fsolve_vector_system_via_named_user_invoker() {
+        let _guard = crate::user_functions::install_user_function_invoker(Some(
+            std::sync::Arc::new(|_name, args| {
+                let x = match &args[0] {
+                    Value::Tensor(t) => t.data.clone(),
+                    _ => panic!("expected tensor input"),
+                };
+                Box::pin(async move {
+                    Ok(Value::Tensor(
+                        Tensor::new(
+                            vec![x[0] * x[0] + x[1] * x[1] - 4.0, x[0] * x[1] - 1.0],
+                            vec![2, 1],
+                        )
+                        .unwrap(),
+                    ))
+                })
+            }),
+        ));
+        let x0 = Tensor::new(vec![1.0, 1.0], vec![2, 1]).unwrap();
+        let root = block_on(fsolve_builtin(
+            Value::FunctionHandle("system".into()),
+            Value::Tensor(x0),
+            Vec::new(),
+        ))
+        .unwrap();
+        match root {
+            Value::Tensor(t) => {
+                assert!((t.data[0] * t.data[0] + t.data[1] * t.data[1] - 4.0).abs() < 1.0e-5);
+                assert!((t.data[0] * t.data[1] - 1.0).abs() < 1.0e-5);
+            }
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/optim/fsolve.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/fsolve.rs
@@ -63,7 +63,7 @@ async fn fsolve_builtin(function: Value, x0: Value, rest: Vec<Value>) -> Builtin
     let options = parse_options(rest.first())?;
     let opts = FsolveOptions::from_struct(options.as_ref())?;
     let guess = initial_guess(NAME, x0).await?;
-    let solution = solve(&function, guess.values, &opts).await?;
+    let solution = solve(&function, guess.values, &guess.shape, guess.scalar, &opts).await?;
     vector_to_value(NAME, solution, &guess.shape, guess.scalar)
 }
 
@@ -117,6 +117,8 @@ impl FsolveOptions {
 async fn solve(
     function: &Value,
     mut x: Vec<f64>,
+    shape: &[usize],
+    scalar: bool,
     options: &FsolveOptions,
 ) -> BuiltinResult<Vec<f64>> {
     let n = x.len();
@@ -124,7 +126,7 @@ async fn solve(
         return Err(optim_error(NAME, "fsolve: initial guess cannot be empty"));
     }
 
-    let mut residual = eval_residual(function, &x).await?;
+    let mut residual = eval_residual(function, &x, shape, scalar).await?;
     let mut evals = 1usize;
     let mut lambda = 1.0e-3;
 
@@ -140,7 +142,8 @@ async fn solve(
             ));
         }
         let jacobian =
-            finite_difference_jacobian(function, &x, &residual, &mut evals, options).await?;
+            finite_difference_jacobian(function, &x, shape, scalar, &residual, &mut evals, options)
+                .await?;
         let j = DMatrix::from_row_slice(residual.len(), n, &jacobian);
         let f = DVector::from_column_slice(&residual);
         let gradient = j.transpose() * &f;
@@ -158,7 +161,7 @@ async fn solve(
                 .zip(delta.iter())
                 .map(|(xi, di)| xi + di)
                 .collect::<Vec<_>>();
-            let trial_residual = eval_residual(function, &trial).await?;
+            let trial_residual = eval_residual(function, &trial, shape, scalar).await?;
             evals += 1;
 
             if norm2(&trial_residual) < norm2(&residual) {
@@ -198,12 +201,17 @@ async fn solve(
     Err(optim_error(NAME, "fsolve: exceeded maximum iterations"))
 }
 
-async fn eval_residual(function: &Value, x: &[f64]) -> BuiltinResult<Vec<f64>> {
-    let arg = if x.len() == 1 {
+async fn eval_residual(
+    function: &Value,
+    x: &[f64],
+    shape: &[usize],
+    scalar: bool,
+) -> BuiltinResult<Vec<f64>> {
+    let arg = if scalar {
         Value::Num(x[0])
     } else {
         Value::Tensor(
-            runmat_builtins::Tensor::new(x.to_vec(), vec![x.len(), 1])
+            runmat_builtins::Tensor::new(x.to_vec(), shape.to_vec())
                 .map_err(|e| optim_error(NAME, format!("fsolve: {e}")))?,
         )
     };
@@ -222,6 +230,8 @@ async fn eval_residual(function: &Value, x: &[f64]) -> BuiltinResult<Vec<f64>> {
 async fn finite_difference_jacobian(
     function: &Value,
     x: &[f64],
+    shape: &[usize],
+    scalar: bool,
     residual: &[f64],
     evals: &mut usize,
     options: &FsolveOptions,
@@ -240,7 +250,7 @@ async fn finite_difference_jacobian(
         let mut perturbed = x.to_vec();
         let step = f64::EPSILON.sqrt() * (x[col].abs() + 1.0);
         perturbed[col] += step;
-        let next = eval_residual(function, &perturbed).await?;
+        let next = eval_residual(function, &perturbed, shape, scalar).await?;
         *evals += 1;
         if next.len() != m {
             return Err(optim_error(
@@ -271,6 +281,7 @@ mod tests {
     use super::*;
     use futures::executor::block_on;
     use runmat_builtins::Tensor;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn fsolve_scalar_builtin_handle() {
@@ -319,5 +330,82 @@ mod tests {
             }
             other => panic!("unexpected value {other:?}"),
         }
+    }
+
+    #[test]
+    fn fsolve_preserves_row_vector_shape_for_callback() {
+        let seen_shapes = Arc::new(Mutex::new(Vec::new()));
+        let seen_shapes_for_invoker = Arc::clone(&seen_shapes);
+        let _guard = crate::user_functions::install_user_function_invoker(Some(Arc::new(
+            move |_name, args| {
+                let (x, shape) = match &args[0] {
+                    Value::Tensor(t) => (t.data.clone(), t.shape.clone()),
+                    other => panic!("expected tensor input, got {other:?}"),
+                };
+                assert_eq!(shape, vec![1, 2]);
+                seen_shapes_for_invoker.lock().unwrap().push(shape.clone());
+                Box::pin(async move {
+                    Ok(Value::Tensor(
+                        Tensor::new(vec![x[0] - 3.0, x[1] - 4.0], shape).unwrap(),
+                    ))
+                })
+            },
+        )));
+        let x0 = Tensor::new(vec![0.0, 0.0], vec![1, 2]).unwrap();
+        let root = block_on(fsolve_builtin(
+            Value::FunctionHandle("row_system".into()),
+            Value::Tensor(x0),
+            Vec::new(),
+        ))
+        .unwrap();
+        match root {
+            Value::Tensor(t) => {
+                assert_eq!(t.shape, vec![1, 2]);
+                assert!((t.data[0] - 3.0).abs() < 1.0e-5);
+                assert!((t.data[1] - 4.0).abs() < 1.0e-5);
+            }
+            other => panic!("unexpected value {other:?}"),
+        }
+        assert!(!seen_shapes.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn fsolve_preserves_matrix_shape_for_callback() {
+        let seen_shapes = Arc::new(Mutex::new(Vec::new()));
+        let seen_shapes_for_invoker = Arc::clone(&seen_shapes);
+        let _guard = crate::user_functions::install_user_function_invoker(Some(Arc::new(
+            move |_name, args| {
+                let (x, shape) = match &args[0] {
+                    Value::Tensor(t) => (t.data.clone(), t.shape.clone()),
+                    other => panic!("expected tensor input, got {other:?}"),
+                };
+                assert_eq!(shape, vec![2, 2]);
+                seen_shapes_for_invoker.lock().unwrap().push(shape.clone());
+                Box::pin(async move {
+                    Ok(Value::Tensor(
+                        Tensor::new(vec![x[0] - 1.0, x[1] - 2.0, x[2] - 3.0, x[3] - 4.0], shape)
+                            .unwrap(),
+                    ))
+                })
+            },
+        )));
+        let x0 = Tensor::new(vec![0.0, 0.0, 0.0, 0.0], vec![2, 2]).unwrap();
+        let root = block_on(fsolve_builtin(
+            Value::FunctionHandle("matrix_system".into()),
+            Value::Tensor(x0),
+            Vec::new(),
+        ))
+        .unwrap();
+        match root {
+            Value::Tensor(t) => {
+                assert_eq!(t.shape, vec![2, 2]);
+                assert!((t.data[0] - 1.0).abs() < 1.0e-5);
+                assert!((t.data[1] - 2.0).abs() < 1.0e-5);
+                assert!((t.data[2] - 3.0).abs() < 1.0e-5);
+                assert!((t.data[3] - 4.0).abs() < 1.0e-5);
+            }
+            other => panic!("unexpected value {other:?}"),
+        }
+        assert!(!seen_shapes.lock().unwrap().is_empty());
     }
 }

--- a/crates/runmat-runtime/src/builtins/math/optim/fzero.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/fzero.rs
@@ -292,9 +292,7 @@ async fn brent(function: &Value, bracket: Bracket, options: &FzeroOptions) -> Bu
                 q = -q;
             }
             p = p.abs();
-            let min_a = 3.0 * midpoint * q.abs() - (tol * q).abs();
-            let min_b = (e * q).abs();
-            if 2.0 * p < min_a.min(min_b) {
+            if interpolation_step_accepted(p, q, midpoint, tol, e) {
                 e = d;
                 d = p / q;
             } else {
@@ -320,6 +318,12 @@ async fn brent(function: &Value, bracket: Bracket, options: &FzeroOptions) -> Bu
     }
 
     Err(optim_error(NAME, "fzero: exceeded maximum iterations"))
+}
+
+fn interpolation_step_accepted(p: f64, q: f64, midpoint: f64, tol: f64, e: f64) -> bool {
+    let min_a = 3.0 * midpoint * q - (tol * q).abs();
+    let min_b = (e * q).abs();
+    2.0 * p < min_a.min(min_b)
 }
 
 #[cfg(test)]
@@ -355,5 +359,11 @@ mod tests {
             Value::Num(n) => assert!((n - std::f64::consts::FRAC_PI_2).abs() < 1.0e-6),
             other => panic!("unexpected value {other:?}"),
         }
+    }
+
+    #[test]
+    fn brent_interpolation_acceptance_uses_signed_q() {
+        assert!(!interpolation_step_accepted(1.0, -2.0, 1.0, 0.1, 10.0));
+        assert!(interpolation_step_accepted(1.0, -2.0, -1.0, 0.1, 10.0));
     }
 }

--- a/crates/runmat-runtime/src/builtins/math/optim/fzero.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/fzero.rs
@@ -210,6 +210,24 @@ async fn expand_bracket(
                 evals,
             });
         }
+        if fa.signum() != f0.signum() {
+            return Ok(Bracket {
+                a,
+                b: x0,
+                fa,
+                fb: f0,
+                evals,
+            });
+        }
+        if fb.signum() != f0.signum() {
+            return Ok(Bracket {
+                a: x0,
+                b,
+                fa: f0,
+                fb,
+                evals,
+            });
+        }
         if fb == 0.0 || fa.signum() != fb.signum() {
             return Ok(Bracket {
                 a,
@@ -357,6 +375,20 @@ mod tests {
         .unwrap();
         match root {
             Value::Num(n) => assert!((n - std::f64::consts::FRAC_PI_2).abs() < 1.0e-6),
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fzero_scalar_initial_guess_uses_center_sign_for_bracket() {
+        let root = block_on(fzero_builtin(
+            Value::FunctionHandle("sin".into()),
+            Value::Num(std::f64::consts::FRAC_PI_2),
+            Vec::new(),
+        ))
+        .unwrap();
+        match root {
+            Value::Num(n) => assert!(n.abs() < 1.0e-6),
             other => panic!("unexpected value {other:?}"),
         }
     }

--- a/crates/runmat-runtime/src/builtins/math/optim/fzero.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/fzero.rs
@@ -1,0 +1,359 @@
+//! MATLAB-compatible `fzero` builtin for scalar nonlinear root finding.
+
+use runmat_builtins::{StructValue, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ShapeRequirements,
+};
+use crate::builtins::math::optim::common::{
+    call_scalar_function, optim_error, option_f64, option_string, option_usize,
+};
+use crate::builtins::math::optim::type_resolvers::scalar_root_type;
+use crate::BuiltinResult;
+
+const NAME: &str = "fzero";
+const DEFAULT_TOL_X: f64 = 1.0e-6;
+const DEFAULT_MAX_ITER: usize = 400;
+const DEFAULT_MAX_FUN_EVALS: usize = 500;
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::math::optim::fzero")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: "fzero",
+    op_kind: GpuOpKind::Custom("scalar-root-find"),
+    supported_precisions: &[],
+    broadcast: BroadcastSemantics::None,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::GatherImmediately,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "Host iterative solver. Callback values may use GPU-aware builtins, but the root search runs on the CPU.",
+};
+
+#[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::math::optim::fzero")]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: "fzero",
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: false,
+    notes: "Root finding repeatedly invokes user code and terminates fusion planning.",
+};
+
+#[runtime_builtin(
+    name = "fzero",
+    category = "math/optim",
+    summary = "Find a zero of a scalar nonlinear function using bracket expansion and Brent's method.",
+    keywords = "fzero,root finding,zero,brent,optimization",
+    accel = "sink",
+    type_resolver(scalar_root_type),
+    builtin_path = "crate::builtins::math::optim::fzero"
+)]
+async fn fzero_builtin(function: Value, x: Value, rest: Vec<Value>) -> BuiltinResult<Value> {
+    if rest.len() > 1 {
+        return Err(optim_error(NAME, "fzero: too many input arguments"));
+    }
+    let options = parse_options(rest.first())?;
+    let opts = FzeroOptions::from_struct(options.as_ref())?;
+    let bracket = initial_bracket(&function, x, &opts).await?;
+    let root = brent(&function, bracket, &opts).await?;
+    Ok(Value::Num(root))
+}
+
+fn parse_options(value: Option<&Value>) -> BuiltinResult<Option<StructValue>> {
+    match value {
+        None => Ok(None),
+        Some(Value::Struct(options)) => Ok(Some(options.clone())),
+        Some(other) => Err(optim_error(
+            NAME,
+            format!("fzero: options must be a struct, got {other:?}"),
+        )),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct FzeroOptions {
+    tol_x: f64,
+    max_iter: usize,
+    max_fun_evals: usize,
+}
+
+impl FzeroOptions {
+    fn from_struct(options: Option<&StructValue>) -> BuiltinResult<Self> {
+        let display = option_string(options, "Display", "off")?;
+        if !matches!(display.as_str(), "off" | "none" | "final" | "iter") {
+            return Err(optim_error(
+                NAME,
+                "fzero: option Display must be 'off', 'none', 'final', or 'iter'",
+            ));
+        }
+        let tol_x = option_f64(NAME, options, "TolX", DEFAULT_TOL_X)?;
+        if tol_x <= 0.0 {
+            return Err(optim_error(NAME, "fzero: option TolX must be positive"));
+        }
+        let max_iter = option_usize(NAME, options, "MaxIter", DEFAULT_MAX_ITER)?;
+        let max_fun_evals = option_usize(NAME, options, "MaxFunEvals", DEFAULT_MAX_FUN_EVALS)?;
+        Ok(Self {
+            tol_x,
+            max_iter: max_iter.max(1),
+            max_fun_evals: max_fun_evals.max(1),
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Bracket {
+    a: f64,
+    b: f64,
+    fa: f64,
+    fb: f64,
+    evals: usize,
+}
+
+async fn initial_bracket(
+    function: &Value,
+    x: Value,
+    options: &FzeroOptions,
+) -> BuiltinResult<Bracket> {
+    let x = crate::dispatcher::gather_if_needed_async(&x).await?;
+    match x {
+        Value::Tensor(tensor) if tensor.data.len() == 2 => {
+            let a = tensor.data[0];
+            let b = tensor.data[1];
+            bracket_from_endpoints(function, a, b).await
+        }
+        Value::Tensor(tensor) if tensor.data.len() == 1 => {
+            expand_bracket(function, tensor.data[0], options).await
+        }
+        Value::Num(n) => expand_bracket(function, n, options).await,
+        Value::Int(i) => expand_bracket(function, i.to_f64(), options).await,
+        Value::Bool(b) => expand_bracket(function, if b { 1.0 } else { 0.0 }, options).await,
+        other => Err(optim_error(
+            NAME,
+            format!("fzero: initial point must be a scalar or two-element bracket, got {other:?}"),
+        )),
+    }
+}
+
+async fn bracket_from_endpoints(function: &Value, a: f64, b: f64) -> BuiltinResult<Bracket> {
+    if !a.is_finite() || !b.is_finite() || a == b {
+        return Err(optim_error(
+            NAME,
+            "fzero: bracket endpoints must be finite and distinct",
+        ));
+    }
+    let fa = call_scalar_function(NAME, function, a).await?;
+    if fa == 0.0 {
+        return Ok(Bracket {
+            a,
+            b: a,
+            fa,
+            fb: fa,
+            evals: 1,
+        });
+    }
+    let fb = call_scalar_function(NAME, function, b).await?;
+    if fb == 0.0 || fa.signum() != fb.signum() {
+        Ok(Bracket {
+            a,
+            b,
+            fa,
+            fb,
+            evals: 2,
+        })
+    } else {
+        Err(optim_error(
+            NAME,
+            "fzero: function values at bracket endpoints must differ in sign",
+        ))
+    }
+}
+
+async fn expand_bracket(
+    function: &Value,
+    x0: f64,
+    options: &FzeroOptions,
+) -> BuiltinResult<Bracket> {
+    if !x0.is_finite() {
+        return Err(optim_error(NAME, "fzero: initial point must be finite"));
+    }
+    let f0 = call_scalar_function(NAME, function, x0).await?;
+    if f0 == 0.0 {
+        return Ok(Bracket {
+            a: x0,
+            b: x0,
+            fa: f0,
+            fb: f0,
+            evals: 1,
+        });
+    }
+
+    let mut evals = 1usize;
+    let mut step = (x0.abs() * 0.01).max(0.01);
+    while evals + 2 <= options.max_fun_evals {
+        let a = x0 - step;
+        let b = x0 + step;
+        let fa = call_scalar_function(NAME, function, a).await?;
+        let fb = call_scalar_function(NAME, function, b).await?;
+        evals += 2;
+        if fa == 0.0 {
+            return Ok(Bracket {
+                a,
+                b: a,
+                fa,
+                fb: fa,
+                evals,
+            });
+        }
+        if fb == 0.0 || fa.signum() != fb.signum() {
+            return Ok(Bracket {
+                a,
+                b,
+                fa,
+                fb,
+                evals,
+            });
+        }
+        step *= 1.6;
+    }
+
+    Err(optim_error(
+        NAME,
+        "fzero: could not find a sign-changing bracket around the initial point",
+    ))
+}
+
+async fn brent(function: &Value, bracket: Bracket, options: &FzeroOptions) -> BuiltinResult<f64> {
+    if bracket.fa == 0.0 || bracket.a == bracket.b {
+        return Ok(bracket.a);
+    }
+    if bracket.fb == 0.0 {
+        return Ok(bracket.b);
+    }
+
+    let mut a = bracket.a;
+    let mut b = bracket.b;
+    let mut c = a;
+    let mut fa = bracket.fa;
+    let mut fb = bracket.fb;
+    let mut fc = fa;
+    let mut d = b - a;
+    let mut e = d;
+    let mut evals = bracket.evals;
+
+    for _ in 0..options.max_iter {
+        if fb.signum() == fc.signum() {
+            c = a;
+            fc = fa;
+            d = b - a;
+            e = d;
+        }
+        if fc.abs() < fb.abs() {
+            let old_b = b;
+            let old_fb = fb;
+            a = b;
+            fa = fb;
+            b = c;
+            fb = fc;
+            c = old_b;
+            fc = old_fb;
+        }
+
+        let tol = 2.0 * f64::EPSILON * b.abs() + 0.5 * options.tol_x;
+        let midpoint = 0.5 * (c - b);
+        if midpoint.abs() <= tol || fb == 0.0 {
+            return Ok(b);
+        }
+        if evals >= options.max_fun_evals {
+            return Err(optim_error(
+                NAME,
+                "fzero: exceeded maximum function evaluations",
+            ));
+        }
+
+        if e.abs() >= tol && fa.abs() > fb.abs() {
+            let s = fb / fa;
+            let (mut p, mut q) = if a == c {
+                (2.0 * midpoint * s, 1.0 - s)
+            } else {
+                let q = fa / fc;
+                let r = fb / fc;
+                (
+                    s * (2.0 * midpoint * q * (q - r) - (b - a) * (r - 1.0)),
+                    (q - 1.0) * (r - 1.0) * (s - 1.0),
+                )
+            };
+            if p > 0.0 {
+                q = -q;
+            }
+            p = p.abs();
+            let min_a = 3.0 * midpoint * q.abs() - (tol * q).abs();
+            let min_b = (e * q).abs();
+            if 2.0 * p < min_a.min(min_b) {
+                e = d;
+                d = p / q;
+            } else {
+                d = midpoint;
+                e = d;
+            }
+        } else {
+            d = midpoint;
+            e = d;
+        }
+
+        a = b;
+        fa = fb;
+        b += if d.abs() > tol {
+            d
+        } else if midpoint >= 0.0 {
+            tol
+        } else {
+            -tol
+        };
+        fb = call_scalar_function(NAME, function, b).await?;
+        evals += 1;
+    }
+
+    Err(optim_error(NAME, "fzero: exceeded maximum iterations"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::Tensor;
+
+    #[test]
+    fn fzero_bracketed_builtin_handle() {
+        let bracket = Tensor::new(vec![3.0, 4.0], vec![1, 2]).unwrap();
+        let root = block_on(fzero_builtin(
+            Value::FunctionHandle("sin".into()),
+            Value::Tensor(bracket),
+            Vec::new(),
+        ))
+        .unwrap();
+        match root {
+            Value::Num(n) => assert!((n - std::f64::consts::PI).abs() < 1.0e-6),
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fzero_scalar_initial_guess_expands_bracket() {
+        let root = block_on(fzero_builtin(
+            Value::FunctionHandle("cos".into()),
+            Value::Num(1.0),
+            Vec::new(),
+        ))
+        .unwrap();
+        match root {
+            Value::Num(n) => assert!((n - std::f64::consts::FRAC_PI_2).abs() < 1.0e-6),
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/optim/mod.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/mod.rs
@@ -1,0 +1,7 @@
+//! Optimization and nonlinear equation solving builtins.
+
+pub(crate) mod common;
+pub mod fsolve;
+pub mod fzero;
+pub mod optimset;
+pub(crate) mod type_resolvers;

--- a/crates/runmat-runtime/src/builtins/math/optim/optimset.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/optimset.rs
@@ -1,0 +1,119 @@
+//! Minimal MATLAB-compatible `optimset` options struct builder.
+
+use runmat_builtins::{StructValue, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ShapeRequirements,
+};
+use crate::builtins::math::optim::common::{field_name, optim_error};
+use crate::builtins::math::optim::type_resolvers::optim_options_type;
+use crate::BuiltinResult;
+
+const NAME: &str = "optimset";
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::math::optim::optimset")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: "optimset",
+    op_kind: GpuOpKind::Custom("options"),
+    supported_precisions: &[],
+    broadcast: BroadcastSemantics::None,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::InheritInputs,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "Host metadata construction. GPU values used as option payloads are preserved without gathering.",
+};
+
+#[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::math::optim::optimset")]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: "optimset",
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: false,
+    notes: "Option struct construction is host metadata work and does not fuse.",
+};
+
+#[runtime_builtin(
+    name = "optimset",
+    category = "math/optim",
+    summary = "Create or update an optimization options structure for fzero and fsolve.",
+    keywords = "optimset,options,TolX,TolFun,MaxIter,Display",
+    type_resolver(optim_options_type),
+    builtin_path = "crate::builtins::math::optim::optimset"
+)]
+async fn optimset_builtin(rest: Vec<Value>) -> BuiltinResult<Value> {
+    let mut fields = StructValue::new();
+    let mut args = rest.into_iter();
+
+    if let Some(first) = args.next() {
+        match first {
+            Value::Struct(existing) => fields = existing,
+            other => {
+                let second = args.next().ok_or_else(|| {
+                    optim_error(NAME, "optimset: expected option name/value pairs")
+                })?;
+                let name = field_name(&other)?;
+                fields.insert(canonical_option_name(&name), second);
+            }
+        }
+    }
+
+    let remaining = args.collect::<Vec<_>>();
+    if remaining.len() % 2 != 0 {
+        return Err(optim_error(
+            NAME,
+            "optimset: expected option name/value pairs",
+        ));
+    }
+    for pair in remaining.chunks(2) {
+        let name = field_name(&pair[0])?;
+        fields.insert(canonical_option_name(&name), pair[1].clone());
+    }
+
+    Ok(Value::Struct(fields))
+}
+
+fn canonical_option_name(name: &str) -> String {
+    match name.to_ascii_lowercase().as_str() {
+        "tolx" => "TolX".to_string(),
+        "tolfun" => "TolFun".to_string(),
+        "maxiter" => "MaxIter".to_string(),
+        "maxfunevals" => "MaxFunEvals".to_string(),
+        "display" => "Display".to_string(),
+        _ => name.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+
+    #[test]
+    fn optimset_builds_struct_from_pairs() {
+        let value = block_on(optimset_builtin(vec![
+            Value::from("TolX"),
+            Value::Num(1.0e-8),
+            Value::from("Display"),
+            Value::from("off"),
+        ]))
+        .unwrap();
+        match value {
+            Value::Struct(options) => {
+                assert!(matches!(options.fields.get("TolX"), Some(Value::Num(_))));
+                assert!(matches!(
+                    options.fields.get("Display"),
+                    Some(Value::String(_))
+                ));
+            }
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/optim/type_resolvers.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/type_resolvers.rs
@@ -1,0 +1,22 @@
+use runmat_builtins::{ResolveContext, Type};
+
+pub fn scalar_root_type(_args: &[Type], _context: &ResolveContext) -> Type {
+    Type::Num
+}
+
+pub fn nonlinear_solve_type(args: &[Type], _context: &ResolveContext) -> Type {
+    match args.get(1) {
+        Some(Type::Tensor { shape }) => Type::Tensor {
+            shape: shape.clone(),
+        },
+        Some(Type::Num | Type::Int | Type::Bool) => Type::Num,
+        Some(Type::Logical { shape }) => Type::Tensor {
+            shape: shape.clone(),
+        },
+        _ => Type::tensor(),
+    }
+}
+
+pub fn optim_options_type(_args: &[Type], _context: &ResolveContext) -> Type {
+    Type::Struct { known_fields: None }
+}

--- a/crates/runmat-vm/tests/closures.rs
+++ b/crates/runmat-vm/tests/closures.rs
@@ -45,3 +45,42 @@ fn feval_with_string_handle() {
         .iter()
         .any(|v| matches!(v, runmat_builtins::Value::Num(n) if (*n - 5.0).abs() < 1e-9)));
 }
+
+#[test]
+fn fzero_accepts_anonymous_function() {
+    let ast = parse("f = @(x) cos(x) - x; r = fzero(f, 0.5);").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert!(vars
+        .iter()
+        .any(|v| matches!(v, runmat_builtins::Value::Num(n) if (*n - 0.7390851332).abs() < 1e-6)));
+}
+
+#[test]
+fn fzero_accepts_optimset_options() {
+    let ast =
+        parse("opts = optimset('TolX', 1e-10, 'Display', 'off'); r = fzero(@sin, [3 4], opts);")
+            .unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert!(vars.iter().any(
+        |v| matches!(v, runmat_builtins::Value::Num(n) if (*n - std::f64::consts::PI).abs() < 1e-8)
+    ));
+}
+
+#[test]
+fn fsolve_accepts_anonymous_vector_function() {
+    let ast =
+        parse("F = @(x) [x(1)^2 + x(2)^2 - 4; x(1)*x(2) - 1]; x = fsolve(F, [1; 1]);").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert!(vars.iter().any(|v| {
+        if let runmat_builtins::Value::Tensor(t) = v {
+            t.data.len() == 2
+                && (t.data[0] * t.data[0] + t.data[1] * t.data[1] - 4.0).abs() < 1e-5
+                && (t.data[0] * t.data[1] - 1.0).abs() < 1e-5
+        } else {
+            false
+        }
+    }));
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new iterative solvers that repeatedly execute user callbacks and enforce option/shape validation, which can affect runtime behavior and performance but does not touch security-sensitive paths.
> 
> **Overview**
> Adds a new `math/optim` builtin module implementing MATLAB-style nonlinear solvers: `fzero` (scalar root finding via bracket expansion + Brent’s method) and `fsolve` (scalar/vector systems via finite-difference Levenberg–Marquardt), both dispatching user callbacks through `feval` and preserving input/output shapes.
> 
> Introduces `optimset` to build/canonicalize solver options structs and shared option/value parsing helpers (`common.rs`), wires the new `optim` module into `builtins::math`, and adds builtin metadata JSON plus VM closure tests to validate anonymous functions and options flow end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4764d507609cc30118d3756bcbcec1bd629c7b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->