### PR TITLE
Add interpolation builtins (interp1, interp2, spline, pchip)

### DIFF
--- a/crates/runmat-runtime/src/builtins/builtins-json/interp1.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/interp1.json
@@ -1,0 +1,79 @@
+{
+  "title": "interp1",
+  "category": "math/interpolation",
+  "keywords": [
+    "interp1",
+    "interpolation",
+    "linear",
+    "nearest",
+    "spline",
+    "pchip"
+  ],
+  "summary": "Interpolate one-dimensional sampled data at query points.",
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [
+      "f32",
+      "f64"
+    ],
+    "broadcasting": "matlab",
+    "notes": "GPU inputs are gathered to the CPU reference implementation in this release. Linear and nearest interpolation are good future provider-kernel candidates."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 3,
+    "constants": "inline"
+  },
+  "description": "`interp1(x, y, xq)` estimates values of a one-dimensional data set at query points `xq`. The default method is linear interpolation; `nearest`, `spline`, and `pchip` are also accepted.",
+  "behaviors": [
+    "`interp1(y, xq)` uses implicit sample points `1:numel(y)`.",
+    "`interp1(x, y, xq, method)` supports `linear`, `nearest`, `spline`, and `pchip`.",
+    "Out-of-range query points return `NaN` unless an extrapolation value or `'extrap'` is supplied.",
+    "Dense real numeric arrays are supported. GPU inputs gather to the host reference path."
+  ],
+  "examples": [
+    {
+      "description": "Linear interpolation",
+      "input": "x = [1 2 3];\ny = [10 20 40];\nyq = interp1(x, y, [1.5 2.5])",
+      "output": "yq = [15 30]"
+    },
+    {
+      "description": "Spline interpolation",
+      "input": "x = [1 2 3];\ny = [1 4 9];\nyq = interp1(x, y, [1.5 2.5], 'spline')",
+      "output": "yq = [2.25 6.25]"
+    }
+  ],
+  "syntax": {
+    "example": {
+      "description": "Syntax",
+      "input": "yq = interp1(y, xq)\nyq = interp1(x, y, xq)\nyq = interp1(x, y, xq, method)\nyq = interp1(x, y, xq, method, 'extrap')"
+    },
+    "points": [
+      "`x` is a strictly increasing vector of sample locations. When omitted, RunMat uses `1:numel(y)`.",
+      "`y` contains the sampled values. Vector inputs produce vector outputs; matrix inputs are interpolated along the sample dimension.",
+      "`xq` contains query points. Scalar queries return scalars, and array queries preserve their shape.",
+      "`method` may be `linear`, `nearest`, `spline`, or `pchip`. The default is `linear`.",
+      "Out-of-range queries return `NaN` by default. Pass `'extrap'` to extrapolate or pass a scalar fill value."
+    ]
+  },
+  "links": [
+    {
+      "label": "spline",
+      "url": "./spline"
+    },
+    {
+      "label": "pchip",
+      "url": "./pchip"
+    },
+    {
+      "label": "interp2",
+      "url": "./interp2"
+    }
+  ],
+  "source": {
+    "label": "Open an issue",
+    "url": "https://github.com/runmat-org/runmat/issues/new/choose"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/builtins-json/interp2.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/interp2.json
@@ -1,0 +1,77 @@
+{
+  "title": "interp2",
+  "category": "math/interpolation",
+  "keywords": [
+    "interp2",
+    "2-D interpolation",
+    "bilinear",
+    "nearest",
+    "meshgrid"
+  ],
+  "summary": "Interpolate values over a two-dimensional gridded surface.",
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [
+      "f32",
+      "f64"
+    ],
+    "broadcasting": "matlab",
+    "notes": "GPU inputs are gathered to the CPU reference implementation in this release. Bilinear and nearest interpolation are intended future provider-kernel targets."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 5,
+    "constants": "inline"
+  },
+  "description": "`interp2(X, Y, Z, Xq, Yq)` estimates surface values at query points from gridded data. Vector axes and meshgrid-style coordinate matrices are accepted. `interp2(Z, Xq, Yq)` uses implicit axes based on the rows and columns of `Z`.",
+  "behaviors": [
+    "Supports `linear` and `nearest` methods in the initial implementation.",
+    "Out-of-range query points return `NaN` unless an extrapolation value or `'extrap'` is supplied.",
+    "Dense real numeric inputs are supported. GPU inputs gather to the host reference path."
+  ],
+  "examples": [
+    {
+      "description": "Bilinear interpolation with implicit axes",
+      "input": "Z = [1 2; 3 4];\nzq = interp2(Z, 1.5, 1.5)",
+      "output": "zq = 2.5"
+    },
+    {
+      "description": "Interpolation with meshgrid axes",
+      "input": "[X, Y] = meshgrid([10 20], [100 200]);\nZ = [1 2; 3 4];\nzq = interp2(X, Y, Z, 15, 150)",
+      "output": "zq = 2.5"
+    }
+  ],
+  "syntax": {
+    "example": {
+      "description": "Syntax",
+      "input": "Zq = interp2(Z, Xq, Yq)\nZq = interp2(X, Y, Z, Xq, Yq)\nZq = interp2(X, Y, Z, Xq, Yq, method)"
+    },
+    "points": [
+      "`Z` is a dense 2-D matrix of sampled surface values.",
+      "`X` and `Y` may be vector axes or meshgrid-style coordinate matrices matching `Z`. When omitted, implicit column and row axes are used.",
+      "`Xq` and `Yq` are scalar or same-size query arrays. Scalar queries broadcast against array queries.",
+      "`method` may be `linear` or `nearest` in the initial implementation. The default is `linear`.",
+      "Out-of-range queries return `NaN` by default. Pass `'extrap'` to extrapolate or pass a scalar fill value."
+    ]
+  },
+  "links": [
+    {
+      "label": "interp1",
+      "url": "./interp1"
+    },
+    {
+      "label": "meshgrid",
+      "url": "./meshgrid"
+    },
+    {
+      "label": "peaks",
+      "url": "./peaks"
+    }
+  ],
+  "source": {
+    "label": "Open an issue",
+    "url": "https://github.com/runmat-org/runmat/issues/new/choose"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/builtins-json/pchip.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/pchip.json
@@ -1,0 +1,67 @@
+{
+  "title": "pchip",
+  "category": "math/interpolation",
+  "keywords": [
+    "pchip",
+    "piecewise cubic hermite",
+    "shape preserving",
+    "interpolation"
+  ],
+  "summary": "Shape-preserving piecewise cubic Hermite interpolation.",
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [
+      "f32",
+      "f64"
+    ],
+    "broadcasting": "matlab",
+    "notes": "GPU inputs are gathered to the CPU reference implementation."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 3,
+    "constants": "inline"
+  },
+  "description": "`pchip(x, y)` builds a shape-preserving cubic Hermite interpolant. `pchip(x, y, xq)` evaluates it at query points.",
+  "behaviors": [
+    "Returns the same pp-structure shape used by `spline`.",
+    "Uses monotonicity-preserving slopes so monotone data does not overshoot between samples.",
+    "Dense real numeric inputs are supported in the initial implementation."
+  ],
+  "examples": [
+    {
+      "description": "Shape-preserving interpolation",
+      "input": "x = [1 2 3];\ny = [1 4 9];\nyq = pchip(x, y, [1.5 2.5])",
+      "output": "yq = [2.21875 6.21875]"
+    }
+  ],
+  "syntax": {
+    "example": {
+      "description": "Syntax",
+      "input": "pp = pchip(x, y)\nyq = pchip(x, y, xq)"
+    },
+    "points": [
+      "`x` is a strictly increasing vector of sample locations.",
+      "`y` contains the sampled values to interpolate.",
+      "`pchip(x, y)` returns a piecewise-polynomial structure compatible with `ppval`.",
+      "`pchip(x, y, xq)` evaluates the shape-preserving interpolant directly at query points.",
+      "PCHIP is usually preferred over spline interpolation when monotonicity and avoiding overshoot matter."
+    ]
+  },
+  "links": [
+    {
+      "label": "interp1",
+      "url": "./interp1"
+    },
+    {
+      "label": "ppval",
+      "url": "./ppval"
+    }
+  ],
+  "source": {
+    "label": "Open an issue",
+    "url": "https://github.com/runmat-org/runmat/issues/new/choose"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/builtins-json/ppval.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/ppval.json
@@ -1,0 +1,66 @@
+{
+  "title": "ppval",
+  "category": "math/interpolation",
+  "keywords": [
+    "ppval",
+    "piecewise polynomial",
+    "spline",
+    "pchip"
+  ],
+  "summary": "Evaluate a piecewise-polynomial structure.",
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [
+      "f32",
+      "f64"
+    ],
+    "broadcasting": "matlab",
+    "notes": "GPU query points are gathered to the CPU reference implementation."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 2,
+    "constants": "uniform"
+  },
+  "description": "`ppval(pp, xq)` evaluates a piecewise-polynomial structure produced by `spline` or `pchip` at query points `xq`.",
+  "behaviors": [
+    "Accepts pp structures with `form`, `breaks`, `coefs`, `pieces`, `order`, and `dim` fields.",
+    "Uses Horner evaluation within each interval.",
+    "Extrapolates outside the break range, matching MATLAB pp evaluation behavior."
+  ],
+  "examples": [
+    {
+      "description": "Evaluate a spline pp structure",
+      "input": "pp = spline([1 2 3], [1 4 9]);\nyq = ppval(pp, [1.5 2.5])",
+      "output": "yq = [2.25 6.25]"
+    }
+  ],
+  "syntax": {
+    "example": {
+      "description": "Syntax",
+      "input": "yq = ppval(pp, xq)"
+    },
+    "points": [
+      "`pp` is a piecewise-polynomial structure, typically returned by `spline` or `pchip`.",
+      "`xq` contains query points. Scalar queries return scalars, and array queries preserve their shape.",
+      "RunMat evaluates each interval with Horner's method using the pp coefficient table.",
+      "Queries outside the break range are extrapolated from the first or last polynomial piece."
+    ]
+  },
+  "links": [
+    {
+      "label": "spline",
+      "url": "./spline"
+    },
+    {
+      "label": "pchip",
+      "url": "./pchip"
+    }
+  ],
+  "source": {
+    "label": "Open an issue",
+    "url": "https://github.com/runmat-org/runmat/issues/new/choose"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/builtins-json/spline.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/spline.json
@@ -1,0 +1,73 @@
+{
+  "title": "spline",
+  "category": "math/interpolation",
+  "keywords": [
+    "spline",
+    "cubic spline",
+    "interpolation",
+    "pp",
+    "ppval"
+  ],
+  "summary": "Construct or evaluate a cubic spline interpolant.",
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [
+      "f32",
+      "f64"
+    ],
+    "broadcasting": "matlab",
+    "notes": "GPU inputs are gathered to the CPU reference implementation."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 3,
+    "constants": "inline"
+  },
+  "description": "`spline(x, y)` returns a piecewise-polynomial structure for cubic spline interpolation. `spline(x, y, xq)` evaluates that spline directly at query points.",
+  "behaviors": [
+    "Returns a pp structure with `form`, `breaks`, `coefs`, `pieces`, `order`, and `dim` fields.",
+    "The direct evaluation form extrapolates outside the sample range, matching MATLAB's standalone `spline` behavior.",
+    "Dense real numeric inputs are supported in the initial implementation."
+  ],
+  "examples": [
+    {
+      "description": "Build and evaluate a spline",
+      "input": "x = [1 2 3];\ny = [1 4 9];\npp = spline(x, y);\nyq = ppval(pp, [1.5 2.5])",
+      "output": "yq = [2.25 6.25]"
+    },
+    {
+      "description": "Direct evaluation",
+      "input": "x = [1 2 3];\ny = [1 4 9];\nyq = spline(x, y, 1.5)",
+      "output": "yq = 2.25"
+    }
+  ],
+  "syntax": {
+    "example": {
+      "description": "Syntax",
+      "input": "pp = spline(x, y)\nyq = spline(x, y, xq)"
+    },
+    "points": [
+      "`x` is a strictly increasing vector of sample locations.",
+      "`y` contains the sampled values to interpolate.",
+      "`spline(x, y)` returns a piecewise-polynomial structure compatible with `ppval`.",
+      "`spline(x, y, xq)` evaluates the cubic spline directly at query points.",
+      "Standalone `spline` extrapolates outside the sample range using the first or last polynomial piece."
+    ]
+  },
+  "links": [
+    {
+      "label": "interp1",
+      "url": "./interp1"
+    },
+    {
+      "label": "ppval",
+      "url": "./ppval"
+    }
+  ],
+  "source": {
+    "label": "Open an issue",
+    "url": "https://github.com/runmat-org/runmat/issues/new/choose"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/math/interpolation/interp1.rs
+++ b/crates/runmat-runtime/src/builtins/math/interpolation/interp1.rs
@@ -1,0 +1,227 @@
+//! MATLAB-compatible `interp1` builtin for dense real numeric data.
+
+use runmat_builtins::{ResolveContext, Type, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ScalarType, ShapeRequirements,
+};
+
+use super::pp::{
+    build_pchip_pp, build_spline_pp, evaluate_linear_or_nearest, evaluate_pp,
+    implicit_series_from_values, interp_error, parse_extrapolation, parse_method, query_points,
+    series_from_values, Extrapolation, InterpMethod,
+};
+
+const NAME: &str = "interp1";
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::math::interpolation::interp1")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: NAME,
+    op_kind: GpuOpKind::Custom("interpolation-1d"),
+    supported_precisions: &[ScalarType::F32, ScalarType::F64],
+    broadcast: BroadcastSemantics::Matlab,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::GatherImmediately,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "Initial implementation gathers GPU inputs to the CPU reference path. Provider kernels can later accelerate linear and nearest evaluation.",
+};
+
+#[runmat_macros::register_fusion_spec(
+    builtin_path = "crate::builtins::math::interpolation::interp1"
+)]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: NAME,
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: true,
+    notes: "Interpolation is currently a runtime sink.",
+};
+
+fn interp1_type(args: &[Type], _ctx: &ResolveContext) -> Type {
+    let query = match args.len() {
+        0 | 1 => return Type::tensor(),
+        2 => args.get(1),
+        _ => args.get(2),
+    };
+    match query {
+        Some(Type::Num | Type::Int | Type::Bool) => Type::Num,
+        Some(Type::Tensor { shape }) | Some(Type::Logical { shape }) => Type::Tensor {
+            shape: shape.clone(),
+        },
+        _ => Type::tensor(),
+    }
+}
+
+#[runtime_builtin(
+    name = "interp1",
+    category = "math/interpolation",
+    summary = "One-dimensional interpolation for sampled data.",
+    keywords = "interp1,interpolation,linear,nearest,spline,pchip",
+    accel = "sink",
+    sink = true,
+    type_resolver(interp1_type),
+    builtin_path = "crate::builtins::math::interpolation::interp1"
+)]
+async fn interp1_builtin(args: Vec<Value>) -> crate::BuiltinResult<Value> {
+    let parsed = ParsedInterp1::parse(args).await?;
+    match parsed.method {
+        InterpMethod::Linear | InterpMethod::Nearest => evaluate_linear_or_nearest(
+            &parsed.series,
+            &parsed.query,
+            parsed.method,
+            &parsed.extrap,
+            NAME,
+        ),
+        InterpMethod::Spline => {
+            let pp = build_spline_pp(&parsed.series, NAME)?;
+            evaluate_pp(&pp, &parsed.query, &parsed.extrap_for_cubic(), NAME)
+        }
+        InterpMethod::Pchip => {
+            let pp = build_pchip_pp(&parsed.series, NAME)?;
+            evaluate_pp(&pp, &parsed.query, &parsed.extrap_for_cubic(), NAME)
+        }
+    }
+}
+
+struct ParsedInterp1 {
+    series: super::pp::NumericSeries,
+    query: super::pp::QueryPoints,
+    method: InterpMethod,
+    extrap: Extrapolation,
+}
+
+impl ParsedInterp1 {
+    async fn parse(args: Vec<Value>) -> crate::BuiltinResult<Self> {
+        if args.len() < 2 {
+            return Err(interp_error(
+                NAME,
+                "interp1: expected at least Y and Xq arguments",
+            ));
+        }
+
+        let mut method = InterpMethod::Linear;
+        let mut extrap = Extrapolation::Nan;
+        let (series, query, options) = if args.len() == 2 || third_arg_is_option(&args) {
+            let mut iter = args.into_iter();
+            let y = iter.next().expect("Y argument");
+            let xq = iter.next().expect("Xq argument");
+            let series = implicit_series_from_values(y, NAME).await?;
+            let query = query_points(xq, NAME).await?;
+            (series, query, iter.collect::<Vec<_>>())
+        } else {
+            let mut iter = args.into_iter();
+            let x = iter.next().expect("X argument");
+            let y = iter.next().expect("Y argument");
+            let xq = iter.next().expect("Xq argument");
+            let series = series_from_values(x, y, NAME).await?;
+            let query = query_points(xq, NAME).await?;
+            (series, query, iter.collect::<Vec<_>>())
+        };
+
+        for option in &options {
+            if let Some(parsed) = parse_extrapolation(option, NAME).await? {
+                extrap = parsed;
+                continue;
+            }
+            if let Some(parsed) = parse_method(option, NAME)? {
+                method = parsed;
+                continue;
+            }
+            return Err(interp_error(
+                NAME,
+                "interp1: unsupported interpolation option",
+            ));
+        }
+
+        Ok(Self {
+            series,
+            query,
+            method,
+            extrap,
+        })
+    }
+
+    fn extrap_for_cubic(&self) -> Extrapolation {
+        self.extrap.clone()
+    }
+}
+
+fn third_arg_is_option(args: &[Value]) -> bool {
+    args.get(2)
+        .and_then(|value| crate::builtins::common::random_args::keyword_of(value))
+        .is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::Tensor;
+
+    fn row(values: &[f64]) -> Value {
+        Value::Tensor(Tensor::new(values.to_vec(), vec![1, values.len()]).expect("tensor"))
+    }
+
+    fn run(args: Vec<Value>) -> crate::BuiltinResult<Value> {
+        block_on(interp1_builtin(args))
+    }
+
+    #[test]
+    fn interp1_linear_midpoints() {
+        let result = run(vec![
+            row(&[1.0, 2.0, 3.0]),
+            row(&[10.0, 20.0, 40.0]),
+            row(&[1.5, 2.5]),
+        ])
+        .expect("interp1");
+        let Value::Tensor(tensor) = result else {
+            panic!("expected tensor");
+        };
+        assert_eq!(tensor.data, vec![15.0, 30.0]);
+    }
+
+    #[test]
+    fn interp1_nearest() {
+        let result = run(vec![
+            row(&[1.0, 2.0, 3.0]),
+            row(&[10.0, 20.0, 40.0]),
+            row(&[1.2, 2.8]),
+            Value::String("nearest".to_string()),
+        ])
+        .expect("interp1");
+        let Value::Tensor(tensor) = result else {
+            panic!("expected tensor");
+        };
+        assert_eq!(tensor.data, vec![10.0, 40.0]);
+    }
+
+    #[test]
+    fn interp1_default_out_of_range_is_nan() {
+        let result =
+            run(vec![row(&[1.0, 2.0]), row(&[10.0, 20.0]), Value::Num(0.0)]).expect("interp1");
+        let Value::Num(value) = result else {
+            panic!("expected scalar");
+        };
+        assert!(value.is_nan());
+    }
+
+    #[test]
+    fn interp1_extrapolates_when_requested() {
+        let result = run(vec![
+            row(&[1.0, 2.0]),
+            row(&[10.0, 20.0]),
+            Value::Num(0.0),
+            Value::String("extrap".to_string()),
+        ])
+        .expect("interp1");
+        assert_eq!(result, Value::Num(0.0));
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/interpolation/interp2.rs
+++ b/crates/runmat-runtime/src/builtins/math/interpolation/interp2.rs
@@ -1,0 +1,418 @@
+//! MATLAB-compatible `interp2` builtin for gridded dense real data.
+
+use runmat_builtins::{ResolveContext, Tensor, Type, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ScalarType, ShapeRequirements,
+};
+use crate::builtins::common::tensor;
+use crate::dispatcher;
+
+use super::pp::{
+    interp_error, parse_extrapolation, parse_method, query_points, vector_from_value,
+    Extrapolation, InterpMethod,
+};
+
+const NAME: &str = "interp2";
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::math::interpolation::interp2")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: NAME,
+    op_kind: GpuOpKind::Custom("interpolation-2d"),
+    supported_precisions: &[ScalarType::F32, ScalarType::F64],
+    broadcast: BroadcastSemantics::Matlab,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::GatherImmediately,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "Initial implementation gathers GPU inputs to the CPU reference path. Bilinear and nearest kernels are good future provider candidates.",
+};
+
+#[runmat_macros::register_fusion_spec(
+    builtin_path = "crate::builtins::math::interpolation::interp2"
+)]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: NAME,
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: true,
+    notes: "interp2 is currently a runtime sink.",
+};
+
+fn interp2_type(args: &[Type], _ctx: &ResolveContext) -> Type {
+    let query = match args.len() {
+        0..=2 => return Type::tensor(),
+        3 | 4 => args.get(1),
+        _ => args.get(3),
+    };
+    match query {
+        Some(Type::Num | Type::Int | Type::Bool) => Type::Num,
+        Some(Type::Tensor { shape }) | Some(Type::Logical { shape }) => Type::Tensor {
+            shape: shape.clone(),
+        },
+        _ => Type::tensor(),
+    }
+}
+
+#[runtime_builtin(
+    name = "interp2",
+    category = "math/interpolation",
+    summary = "Two-dimensional interpolation on gridded data.",
+    keywords = "interp2,interpolation,bilinear,nearest,grid,meshgrid",
+    accel = "sink",
+    sink = true,
+    type_resolver(interp2_type),
+    builtin_path = "crate::builtins::math::interpolation::interp2"
+)]
+async fn interp2_builtin(args: Vec<Value>) -> crate::BuiltinResult<Value> {
+    let parsed = ParsedInterp2::parse(args).await?;
+    let data = evaluate_grid(&parsed)?;
+    if data.len() == 1 {
+        return Ok(Value::Num(data[0]));
+    }
+    let tensor = Tensor::new(data, parsed.output_shape)
+        .map_err(|err| interp_error(NAME, format!("{NAME}: {err}")))?;
+    Ok(Value::Tensor(tensor))
+}
+
+struct ParsedInterp2 {
+    x_axis: Vec<f64>,
+    y_axis: Vec<f64>,
+    z: Tensor,
+    xq: Vec<f64>,
+    yq: Vec<f64>,
+    output_shape: Vec<usize>,
+    method: InterpMethod,
+    extrap: Extrapolation,
+}
+
+impl ParsedInterp2 {
+    async fn parse(args: Vec<Value>) -> crate::BuiltinResult<Self> {
+        if args.len() < 3 {
+            return Err(interp_error(
+                NAME,
+                "interp2: expected Z, Xq, and Yq or X, Y, Z, Xq, and Yq",
+            ));
+        }
+
+        let mut method = InterpMethod::Linear;
+        let mut extrap = Extrapolation::Nan;
+        let explicit_axes = args.len() >= 5 && !is_option_arg(&args[3]);
+        let (x_axis, y_axis, z, xq_value, yq_value, options) = if explicit_axes {
+            let mut iter = args.into_iter();
+            let x = iter.next().expect("X");
+            let y = iter.next().expect("Y");
+            let z_value = iter.next().expect("Z");
+            let z = z_tensor(z_value).await?;
+            let (x_axis, y_axis) = axes_from_values(x, y, z.rows, z.cols).await?;
+            let xq = iter.next().expect("Xq");
+            let yq = iter.next().expect("Yq");
+            (x_axis, y_axis, z, xq, yq, iter.collect::<Vec<_>>())
+        } else {
+            let mut iter = args.into_iter();
+            let z_value = iter.next().expect("Z");
+            let z = z_tensor(z_value).await?;
+            let x_axis: Vec<f64> = (1..=z.cols).map(|v| v as f64).collect();
+            let y_axis: Vec<f64> = (1..=z.rows).map(|v| v as f64).collect();
+            let xq = iter.next().expect("Xq");
+            let yq = iter.next().expect("Yq");
+            (x_axis, y_axis, z, xq, yq, iter.collect::<Vec<_>>())
+        };
+
+        validate_axis(&x_axis, "X")?;
+        validate_axis(&y_axis, "Y")?;
+        let xq = query_points(xq_value, NAME).await?;
+        let yq = query_points(yq_value, NAME).await?;
+        let (xq_values, yq_values, output_shape) = align_queries(xq, yq)?;
+
+        for option in &options {
+            if let Some(parsed) = parse_extrapolation(option, NAME).await? {
+                extrap = parsed;
+                continue;
+            }
+            if let Some(parsed) = parse_method(option, NAME)? {
+                match parsed {
+                    InterpMethod::Linear | InterpMethod::Nearest => method = parsed,
+                    _ => {
+                        return Err(interp_error(
+                            NAME,
+                            "interp2: only linear and nearest methods are supported",
+                        ))
+                    }
+                }
+                continue;
+            }
+            return Err(interp_error(
+                NAME,
+                "interp2: unsupported interpolation option",
+            ));
+        }
+
+        Ok(Self {
+            x_axis,
+            y_axis,
+            z,
+            xq: xq_values,
+            yq: yq_values,
+            output_shape,
+            method,
+            extrap,
+        })
+    }
+}
+
+fn is_option_arg(value: &Value) -> bool {
+    crate::builtins::common::random_args::keyword_of(value).is_some()
+}
+
+async fn z_tensor(value: Value) -> crate::BuiltinResult<Tensor> {
+    let gathered = dispatcher::gather_if_needed_async(&value).await?;
+    let z = tensor::value_into_tensor_for(NAME, gathered)
+        .map_err(|err| interp_error(NAME, format!("{NAME}: {err}")))?;
+    if z.shape.len() > 2 {
+        return Err(interp_error(NAME, "interp2: Z must be a 2-D matrix"));
+    }
+    if z.rows < 2 || z.cols < 2 {
+        return Err(interp_error(
+            NAME,
+            "interp2: Z must have at least two rows and two columns",
+        ));
+    }
+    Ok(z)
+}
+
+async fn axes_from_values(
+    x: Value,
+    y: Value,
+    rows: usize,
+    cols: usize,
+) -> crate::BuiltinResult<(Vec<f64>, Vec<f64>)> {
+    let x_axis = axis_from_value(x, rows, cols, true).await?;
+    let y_axis = axis_from_value(y, rows, cols, false).await?;
+    Ok((x_axis, y_axis))
+}
+
+async fn axis_from_value(
+    value: Value,
+    rows: usize,
+    cols: usize,
+    is_x: bool,
+) -> crate::BuiltinResult<Vec<f64>> {
+    let gathered = dispatcher::gather_if_needed_async(&value).await?;
+    let tensor_value = tensor::value_into_tensor_for(NAME, gathered.clone());
+    if let Ok(t) = tensor_value {
+        if is_vector_shape(&t.shape) {
+            let expected = if is_x { cols } else { rows };
+            if t.data.len() != expected {
+                return Err(interp_error(
+                    NAME,
+                    format!("{NAME}: axis vector length must match Z dimensions"),
+                ));
+            }
+            return Ok(t.data);
+        }
+        if t.rows == rows && t.cols == cols {
+            return if is_x {
+                Ok((0..cols).map(|col| t.data[col * rows]).collect())
+            } else {
+                Ok((0..rows).map(|row| t.data[row]).collect())
+            };
+        }
+    }
+    let label = if is_x { "X" } else { "Y" };
+    vector_from_value(gathered, label, NAME).await
+}
+
+fn is_vector_shape(shape: &[usize]) -> bool {
+    match shape {
+        [] | [_] => true,
+        [rows, cols] => *rows == 1 || *cols == 1,
+        dims => dims.iter().filter(|&&dim| dim > 1).count() <= 1,
+    }
+}
+
+fn validate_axis(axis: &[f64], label: &str) -> crate::BuiltinResult<()> {
+    if axis.len() < 2 {
+        return Err(interp_error(
+            NAME,
+            format!("{NAME}: {label} axis must contain at least two points"),
+        ));
+    }
+    if axis.iter().any(|v| !v.is_finite()) {
+        return Err(interp_error(
+            NAME,
+            format!("{NAME}: {label} axis must be finite"),
+        ));
+    }
+    for pair in axis.windows(2) {
+        if pair[1] <= pair[0] {
+            return Err(interp_error(
+                NAME,
+                format!("{NAME}: {label} axis must be strictly increasing"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn align_queries(
+    xq: super::pp::QueryPoints,
+    yq: super::pp::QueryPoints,
+) -> crate::BuiltinResult<(Vec<f64>, Vec<f64>, Vec<usize>)> {
+    match (xq.values.len(), yq.values.len()) {
+        (1, 1) => Ok((xq.values, yq.values, vec![1, 1])),
+        (1, len) => Ok((vec![xq.values[0]; len], yq.values, yq.shape)),
+        (len, 1) => Ok((xq.values, vec![yq.values[0]; len], xq.shape)),
+        (left, right) if left == right && xq.shape == yq.shape => {
+            Ok((xq.values, yq.values, xq.shape))
+        }
+        _ => Err(interp_error(
+            NAME,
+            "interp2: Xq and Yq must be scalar or matching-size arrays",
+        )),
+    }
+}
+
+fn evaluate_grid(parsed: &ParsedInterp2) -> crate::BuiltinResult<Vec<f64>> {
+    let mut out = Vec::with_capacity(parsed.xq.len());
+    for (&xq, &yq) in parsed.xq.iter().zip(parsed.yq.iter()) {
+        let value = match parsed.method {
+            InterpMethod::Linear => eval_bilinear(parsed, xq, yq),
+            InterpMethod::Nearest => eval_nearest(parsed, xq, yq),
+            _ => unreachable!("interp2 parse rejects cubic methods"),
+        };
+        out.push(value);
+    }
+    Ok(out)
+}
+
+fn eval_bilinear(parsed: &ParsedInterp2, xq: f64, yq: f64) -> f64 {
+    if !xq.is_finite() || !yq.is_finite() {
+        return f64::NAN;
+    }
+    let allow = matches!(parsed.extrap, Extrapolation::Extrapolate);
+    let Some(col) = interval_index(&parsed.x_axis, xq, allow) else {
+        return out_of_range(&parsed.extrap);
+    };
+    let Some(row) = interval_index(&parsed.y_axis, yq, allow) else {
+        return out_of_range(&parsed.extrap);
+    };
+    let x0 = parsed.x_axis[col];
+    let x1 = parsed.x_axis[col + 1];
+    let y0 = parsed.y_axis[row];
+    let y1 = parsed.y_axis[row + 1];
+    let tx = (xq - x0) / (x1 - x0);
+    let ty = (yq - y0) / (y1 - y0);
+    let z00 = z_at(&parsed.z, row, col);
+    let z10 = z_at(&parsed.z, row, col + 1);
+    let z01 = z_at(&parsed.z, row + 1, col);
+    let z11 = z_at(&parsed.z, row + 1, col + 1);
+    (1.0 - tx) * (1.0 - ty) * z00 + tx * (1.0 - ty) * z10 + (1.0 - tx) * ty * z01 + tx * ty * z11
+}
+
+fn eval_nearest(parsed: &ParsedInterp2, xq: f64, yq: f64) -> f64 {
+    if !xq.is_finite() || !yq.is_finite() {
+        return f64::NAN;
+    }
+    let Some(col) = nearest_index(&parsed.x_axis, xq, &parsed.extrap) else {
+        return out_of_range(&parsed.extrap);
+    };
+    let Some(row) = nearest_index(&parsed.y_axis, yq, &parsed.extrap) else {
+        return out_of_range(&parsed.extrap);
+    };
+    z_at(&parsed.z, row, col)
+}
+
+fn z_at(z: &Tensor, row: usize, col: usize) -> f64 {
+    z.data[row + col * z.rows]
+}
+
+fn interval_index(axis: &[f64], q: f64, allow_extrapolation: bool) -> Option<usize> {
+    if q < axis[0] {
+        return allow_extrapolation.then_some(0);
+    }
+    let last = axis.len() - 1;
+    if q > axis[last] {
+        return allow_extrapolation.then_some(last - 1);
+    }
+    if q == axis[last] {
+        return Some(last - 1);
+    }
+    match axis.binary_search_by(|probe| probe.partial_cmp(&q).unwrap()) {
+        Ok(index) => Some(index.min(last - 1)),
+        Err(index) if index > 0 && index < axis.len() => Some(index - 1),
+        _ => None,
+    }
+}
+
+fn nearest_index(axis: &[f64], q: f64, extrap: &Extrapolation) -> Option<usize> {
+    if q < axis[0] {
+        return matches!(extrap, Extrapolation::Extrapolate).then_some(0);
+    }
+    let last = axis.len() - 1;
+    if q > axis[last] {
+        return matches!(extrap, Extrapolation::Extrapolate).then_some(last);
+    }
+    match axis.binary_search_by(|probe| probe.partial_cmp(&q).unwrap()) {
+        Ok(index) => Some(index),
+        Err(index) => {
+            let left = index.saturating_sub(1);
+            let right = index.min(last);
+            if (q - axis[left]).abs() <= (axis[right] - q).abs() {
+                Some(left)
+            } else {
+                Some(right)
+            }
+        }
+    }
+}
+
+fn out_of_range(extrap: &Extrapolation) -> f64 {
+    match extrap {
+        Extrapolation::Value(value) => *value,
+        Extrapolation::Nan | Extrapolation::Extrapolate => f64::NAN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+
+    fn row(values: &[f64]) -> Value {
+        Value::Tensor(Tensor::new(values.to_vec(), vec![1, values.len()]).expect("tensor"))
+    }
+
+    #[test]
+    fn interp2_implicit_axes_bilinear_scalar() {
+        let z = Value::Tensor(Tensor::new(vec![1.0, 3.0, 2.0, 4.0], vec![2, 2]).expect("tensor"));
+        let value =
+            block_on(interp2_builtin(vec![z, Value::Num(1.5), Value::Num(1.5)])).expect("interp2");
+        let Value::Num(result) = value else {
+            panic!("expected scalar");
+        };
+        assert!((result - 2.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn interp2_vector_axes_nearest() {
+        let z = Value::Tensor(Tensor::new(vec![1.0, 3.0, 2.0, 4.0], vec![2, 2]).expect("tensor"));
+        let value = block_on(interp2_builtin(vec![
+            row(&[10.0, 20.0]),
+            row(&[100.0, 200.0]),
+            z,
+            Value::Num(18.0),
+            Value::Num(120.0),
+            Value::String("nearest".to_string()),
+        ]))
+        .expect("interp2");
+        assert_eq!(value, Value::Num(2.0));
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/interpolation/interp2.rs
+++ b/crates/runmat-runtime/src/builtins/math/interpolation/interp2.rs
@@ -11,8 +11,8 @@ use crate::builtins::common::tensor;
 use crate::dispatcher;
 
 use super::pp::{
-    interp_error, parse_extrapolation, parse_method, query_points, vector_from_value,
-    Extrapolation, InterpMethod,
+    interp_error, interval_index, is_vector_shape, out_of_range_value, parse_extrapolation,
+    parse_method, query_points, vector_from_value, Extrapolation, InterpMethod,
 };
 
 const NAME: &str = "interp2";
@@ -230,14 +230,6 @@ async fn axis_from_value(
     vector_from_value(gathered, label, NAME).await
 }
 
-fn is_vector_shape(shape: &[usize]) -> bool {
-    match shape {
-        [] | [_] => true,
-        [rows, cols] => *rows == 1 || *cols == 1,
-        dims => dims.iter().filter(|&&dim| dim > 1).count() <= 1,
-    }
-}
-
 fn validate_axis(axis: &[f64], label: &str) -> crate::BuiltinResult<()> {
     if axis.len() < 2 {
         return Err(interp_error(
@@ -299,10 +291,10 @@ fn eval_bilinear(parsed: &ParsedInterp2, xq: f64, yq: f64) -> f64 {
     }
     let allow = matches!(parsed.extrap, Extrapolation::Extrapolate);
     let Some(col) = interval_index(&parsed.x_axis, xq, allow) else {
-        return out_of_range(&parsed.extrap);
+        return out_of_range_value(&parsed.extrap);
     };
     let Some(row) = interval_index(&parsed.y_axis, yq, allow) else {
-        return out_of_range(&parsed.extrap);
+        return out_of_range_value(&parsed.extrap);
     };
     let x0 = parsed.x_axis[col];
     let x1 = parsed.x_axis[col + 1];
@@ -322,34 +314,16 @@ fn eval_nearest(parsed: &ParsedInterp2, xq: f64, yq: f64) -> f64 {
         return f64::NAN;
     }
     let Some(col) = nearest_index(&parsed.x_axis, xq, &parsed.extrap) else {
-        return out_of_range(&parsed.extrap);
+        return out_of_range_value(&parsed.extrap);
     };
     let Some(row) = nearest_index(&parsed.y_axis, yq, &parsed.extrap) else {
-        return out_of_range(&parsed.extrap);
+        return out_of_range_value(&parsed.extrap);
     };
     z_at(&parsed.z, row, col)
 }
 
 fn z_at(z: &Tensor, row: usize, col: usize) -> f64 {
     z.data[row + col * z.rows]
-}
-
-fn interval_index(axis: &[f64], q: f64, allow_extrapolation: bool) -> Option<usize> {
-    if q < axis[0] {
-        return allow_extrapolation.then_some(0);
-    }
-    let last = axis.len() - 1;
-    if q > axis[last] {
-        return allow_extrapolation.then_some(last - 1);
-    }
-    if q == axis[last] {
-        return Some(last - 1);
-    }
-    match axis.binary_search_by(|probe| probe.partial_cmp(&q).unwrap()) {
-        Ok(index) => Some(index.min(last - 1)),
-        Err(index) if index > 0 && index < axis.len() => Some(index - 1),
-        _ => None,
-    }
 }
 
 fn nearest_index(axis: &[f64], q: f64, extrap: &Extrapolation) -> Option<usize> {
@@ -371,13 +345,6 @@ fn nearest_index(axis: &[f64], q: f64, extrap: &Extrapolation) -> Option<usize> 
                 Some(right)
             }
         }
-    }
-}
-
-fn out_of_range(extrap: &Extrapolation) -> f64 {
-    match extrap {
-        Extrapolation::Value(value) => *value,
-        Extrapolation::Nan | Extrapolation::Extrapolate => f64::NAN,
     }
 }
 

--- a/crates/runmat-runtime/src/builtins/math/interpolation/mod.rs
+++ b/crates/runmat-runtime/src/builtins/math/interpolation/mod.rs
@@ -1,0 +1,9 @@
+//! Interpolation builtins and shared piecewise-polynomial helpers.
+
+pub mod interp1;
+pub mod interp2;
+pub mod pchip;
+pub mod ppval;
+pub mod spline;
+
+mod pp;

--- a/crates/runmat-runtime/src/builtins/math/interpolation/pchip.rs
+++ b/crates/runmat-runtime/src/builtins/math/interpolation/pchip.rs
@@ -1,0 +1,105 @@
+//! MATLAB-compatible `pchip` builtin for shape-preserving cubic interpolation.
+
+use runmat_builtins::{ResolveContext, Type, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ScalarType, ShapeRequirements,
+};
+
+use super::pp::{
+    build_pchip_pp, evaluate_pp, interp_error, pp_to_value, query_points, series_from_values,
+    Extrapolation,
+};
+
+const NAME: &str = "pchip";
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::math::interpolation::pchip")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: NAME,
+    op_kind: GpuOpKind::Custom("pchip"),
+    supported_precisions: &[ScalarType::F32, ScalarType::F64],
+    broadcast: BroadcastSemantics::Matlab,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::GatherImmediately,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "PCHIP coefficient construction and evaluation currently run on the CPU reference path after gathering GPU inputs.",
+};
+
+#[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::math::interpolation::pchip")]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: NAME,
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: false,
+    notes: "PCHIP builds a piecewise-polynomial representation and is not fused.",
+};
+
+fn pchip_type(args: &[Type], _ctx: &ResolveContext) -> Type {
+    match args.len() {
+        0 | 1 => Type::Unknown,
+        2 => Type::Struct { known_fields: None },
+        _ => match args.get(2) {
+            Some(Type::Num | Type::Int | Type::Bool) => Type::Num,
+            Some(Type::Tensor { shape }) | Some(Type::Logical { shape }) => Type::Tensor {
+                shape: shape.clone(),
+            },
+            _ => Type::tensor(),
+        },
+    }
+}
+
+#[runtime_builtin(
+    name = "pchip",
+    category = "math/interpolation",
+    summary = "Shape-preserving piecewise cubic Hermite interpolation.",
+    keywords = "pchip,shape preserving,cubic hermite,interpolation,ppval",
+    accel = "sink",
+    sink = true,
+    type_resolver(pchip_type),
+    builtin_path = "crate::builtins::math::interpolation::pchip"
+)]
+async fn pchip_builtin(x: Value, y: Value, rest: Vec<Value>) -> crate::BuiltinResult<Value> {
+    let series = series_from_values(x, y, NAME).await?;
+    let pp = build_pchip_pp(&series, NAME)?;
+    match rest.len() {
+        0 => pp_to_value(pp, NAME),
+        1 => {
+            let query = query_points(rest.into_iter().next().expect("query"), NAME).await?;
+            evaluate_pp(&pp, &query, &Extrapolation::Extrapolate, NAME)
+        }
+        _ => Err(interp_error(NAME, "pchip: too many input arguments")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::Tensor;
+
+    fn row(values: &[f64]) -> Value {
+        Value::Tensor(Tensor::new(values.to_vec(), vec![1, values.len()]).expect("tensor"))
+    }
+
+    #[test]
+    fn pchip_three_arg_evaluates_monotone_data() {
+        let value = block_on(pchip_builtin(
+            row(&[1.0, 2.0, 3.0, 4.0]),
+            row(&[0.0, 1.0, 1.5, 1.75]),
+            vec![row(&[1.5, 2.5, 3.5])],
+        ))
+        .expect("pchip");
+        let Value::Tensor(tensor) = value else {
+            panic!("expected tensor");
+        };
+        assert!(tensor.data.windows(2).all(|pair| pair[1] >= pair[0]));
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/interpolation/pp.rs
+++ b/crates/runmat-runtime/src/builtins/math/interpolation/pp.rs
@@ -459,7 +459,7 @@ fn first_non_singleton_len(tensor: &Tensor) -> Option<usize> {
         .find(|&dim| dim > 1)
 }
 
-fn is_vector_shape(shape: &[usize]) -> bool {
+pub(super) fn is_vector_shape(shape: &[usize]) -> bool {
     match shape {
         [] => true,
         [_] => true,
@@ -528,7 +528,7 @@ fn eval_pp_scalar(pp: &PiecewisePolynomial, series: usize, xq: f64, extrap: &Ext
     acc
 }
 
-fn interval_index(x: &[f64], xq: f64, allow_extrapolation: bool) -> Option<usize> {
+pub(super) fn interval_index(x: &[f64], xq: f64, allow_extrapolation: bool) -> Option<usize> {
     if xq < x[0] {
         return allow_extrapolation.then_some(0);
     }
@@ -546,7 +546,7 @@ fn interval_index(x: &[f64], xq: f64, allow_extrapolation: bool) -> Option<usize
     }
 }
 
-fn out_of_range_value(extrap: &Extrapolation) -> f64 {
+pub(super) fn out_of_range_value(extrap: &Extrapolation) -> f64 {
     match extrap {
         Extrapolation::Nan => f64::NAN,
         Extrapolation::Extrapolate => f64::NAN,

--- a/crates/runmat-runtime/src/builtins/math/interpolation/pp.rs
+++ b/crates/runmat-runtime/src/builtins/math/interpolation/pp.rs
@@ -1,0 +1,771 @@
+use runmat_builtins::{StructValue, Tensor, Value};
+
+use crate::builtins::common::random_args::keyword_of;
+use crate::builtins::common::tensor;
+use crate::{build_runtime_error, dispatcher, BuiltinResult, RuntimeError};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InterpMethod {
+    Linear,
+    Nearest,
+    Spline,
+    Pchip,
+}
+
+#[derive(Clone, Debug)]
+pub enum Extrapolation {
+    Nan,
+    Extrapolate,
+    Value(f64),
+}
+
+impl Default for Extrapolation {
+    fn default() -> Self {
+        Self::Nan
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct NumericSeries {
+    pub x: Vec<f64>,
+    pub y: Vec<f64>,
+    pub series: usize,
+    pub trailing_shape: Vec<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub struct QueryPoints {
+    pub values: Vec<f64>,
+    pub shape: Vec<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PiecewisePolynomial {
+    pub breaks: Vec<f64>,
+    pub coefs: Vec<f64>,
+    pub pieces: usize,
+    pub order: usize,
+    pub dim: usize,
+}
+
+pub fn interp_error(name: &'static str, message: impl Into<String>) -> RuntimeError {
+    build_runtime_error(message).with_builtin(name).build()
+}
+
+pub fn parse_method(value: &Value, name: &'static str) -> BuiltinResult<Option<InterpMethod>> {
+    let Some(keyword) = keyword_of(value) else {
+        return Ok(None);
+    };
+    let method = match keyword.as_str() {
+        "linear" => InterpMethod::Linear,
+        "nearest" => InterpMethod::Nearest,
+        "spline" => InterpMethod::Spline,
+        "pchip" | "cubic" => InterpMethod::Pchip,
+        _ => {
+            return Err(interp_error(
+                name,
+                format!("{name}: unsupported interpolation method '{keyword}'"),
+            ))
+        }
+    };
+    Ok(Some(method))
+}
+
+pub async fn parse_extrapolation(
+    value: &Value,
+    name: &'static str,
+) -> BuiltinResult<Option<Extrapolation>> {
+    if let Some(keyword) = keyword_of(value) {
+        return match keyword.as_str() {
+            "extrap" => Ok(Some(Extrapolation::Extrapolate)),
+            _ => Ok(None),
+        };
+    }
+    let gathered = dispatcher::gather_if_needed_async(value).await?;
+    let Some(scalar) = tensor::scalar_f64_from_value_async(&gathered)
+        .await
+        .map_err(|err| interp_error(name, format!("{name}: {err}")))?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(Extrapolation::Value(scalar)))
+}
+
+pub async fn query_points(value: Value, name: &'static str) -> BuiltinResult<QueryPoints> {
+    let gathered = dispatcher::gather_if_needed_async(&value).await?;
+    let tensor = tensor::value_into_tensor_for(name, gathered)
+        .map_err(|err| interp_error(name, format!("{name}: {err}")))?;
+    let shape = canonical_shape(&tensor.shape, tensor.data.len());
+    Ok(QueryPoints {
+        values: tensor.data,
+        shape,
+    })
+}
+
+pub async fn vector_from_value(
+    value: Value,
+    label: &str,
+    name: &'static str,
+) -> BuiltinResult<Vec<f64>> {
+    let gathered = dispatcher::gather_if_needed_async(&value).await?;
+    let tensor = tensor::value_into_tensor_for(name, gathered)
+        .map_err(|err| interp_error(name, format!("{name}: {err}")))?;
+    if !is_vector_shape(&tensor.shape) && tensor.data.len() > 1 {
+        return Err(interp_error(
+            name,
+            format!("{name}: {label} must be a vector"),
+        ));
+    }
+    Ok(tensor.data)
+}
+
+pub async fn series_from_values(
+    x_value: Value,
+    y_value: Value,
+    name: &'static str,
+) -> BuiltinResult<NumericSeries> {
+    let x = vector_from_value(x_value, "X", name).await?;
+    let y_host = dispatcher::gather_if_needed_async(&y_value).await?;
+    let y_tensor = tensor::value_into_tensor_for(name, y_host)
+        .map_err(|err| interp_error(name, format!("{name}: {err}")))?;
+    series_from_tensor(x, y_tensor, name)
+}
+
+pub async fn implicit_series_from_values(
+    y_value: Value,
+    name: &'static str,
+) -> BuiltinResult<NumericSeries> {
+    let y_host = dispatcher::gather_if_needed_async(&y_value).await?;
+    let y_tensor = tensor::value_into_tensor_for(name, y_host)
+        .map_err(|err| interp_error(name, format!("{name}: {err}")))?;
+    let n = first_non_singleton_len(&y_tensor).unwrap_or(y_tensor.data.len());
+    let x: Vec<f64> = (1..=n).map(|value| value as f64).collect();
+    series_from_tensor(x, y_tensor, name)
+}
+
+fn series_from_tensor(
+    x: Vec<f64>,
+    y_tensor: Tensor,
+    name: &'static str,
+) -> BuiltinResult<NumericSeries> {
+    validate_breaks(&x, name)?;
+    let n = x.len();
+    if y_tensor.data.len() != n && !y_tensor.data.len().is_multiple_of(n) {
+        return Err(interp_error(
+            name,
+            format!("{name}: Y length must match X or have X as its first dimension"),
+        ));
+    }
+
+    let y_shape = canonical_shape(&y_tensor.shape, y_tensor.data.len());
+    let (series, trailing_shape) = if y_tensor.data.len() == n && is_vector_shape(&y_shape) {
+        (1, Vec::new())
+    } else if y_shape.first().copied() == Some(n) {
+        let series = y_tensor.data.len() / n;
+        let trailing = if y_shape.len() > 1 {
+            y_shape[1..].to_vec()
+        } else {
+            vec![series]
+        };
+        (series, trailing)
+    } else if y_tensor.data.len() == n {
+        (1, Vec::new())
+    } else {
+        return Err(interp_error(
+            name,
+            format!("{name}: size of Y must be compatible with X"),
+        ));
+    };
+
+    Ok(NumericSeries {
+        x,
+        y: y_tensor.data,
+        series,
+        trailing_shape,
+    })
+}
+
+pub fn validate_breaks(x: &[f64], name: &'static str) -> BuiltinResult<()> {
+    if x.len() < 2 {
+        return Err(interp_error(
+            name,
+            format!("{name}: X must contain at least two points"),
+        ));
+    }
+    if x.iter().any(|v| !v.is_finite()) {
+        return Err(interp_error(name, format!("{name}: X must be finite")));
+    }
+    for pair in x.windows(2) {
+        if pair[1] <= pair[0] {
+            return Err(interp_error(
+                name,
+                format!("{name}: X must be strictly increasing"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn evaluate_linear_or_nearest(
+    series: &NumericSeries,
+    query: &QueryPoints,
+    method: InterpMethod,
+    extrap: &Extrapolation,
+    name: &'static str,
+) -> BuiltinResult<Value> {
+    let mut out = vec![0.0; query.values.len() * series.series];
+    for s in 0..series.series {
+        let y = &series.y[s * series.x.len()..(s + 1) * series.x.len()];
+        for (q_index, &xq) in query.values.iter().enumerate() {
+            out[q_index + s * query.values.len()] = match method {
+                InterpMethod::Linear => eval_linear(&series.x, y, xq, extrap),
+                InterpMethod::Nearest => eval_nearest(&series.x, y, xq, extrap),
+                _ => unreachable!("only direct methods are accepted here"),
+            };
+        }
+    }
+    tensor_from_query_output(out, query, series, name)
+}
+
+pub fn build_spline_pp(
+    series: &NumericSeries,
+    name: &'static str,
+) -> BuiltinResult<PiecewisePolynomial> {
+    let n = series.x.len();
+    let pieces = n - 1;
+    let order = 4;
+    let rows = pieces * series.series;
+    let mut coefs = vec![0.0; rows * order];
+    for s in 0..series.series {
+        let y = &series.y[s * n..(s + 1) * n];
+        let local = spline_coefs_for_series(&series.x, y)?;
+        for piece in 0..pieces {
+            let row = s * pieces + piece;
+            for col in 0..order {
+                coefs[row + col * rows] = local[piece][col];
+            }
+        }
+    }
+    validate_finite_coefs(&coefs, name)?;
+    Ok(PiecewisePolynomial {
+        breaks: series.x.clone(),
+        coefs,
+        pieces,
+        order,
+        dim: series.series,
+    })
+}
+
+pub fn build_pchip_pp(
+    series: &NumericSeries,
+    name: &'static str,
+) -> BuiltinResult<PiecewisePolynomial> {
+    let n = series.x.len();
+    let pieces = n - 1;
+    let order = 4;
+    let rows = pieces * series.series;
+    let mut coefs = vec![0.0; rows * order];
+    for s in 0..series.series {
+        let y = &series.y[s * n..(s + 1) * n];
+        let local = pchip_coefs_for_series(&series.x, y);
+        for piece in 0..pieces {
+            let row = s * pieces + piece;
+            for col in 0..order {
+                coefs[row + col * rows] = local[piece][col];
+            }
+        }
+    }
+    validate_finite_coefs(&coefs, name)?;
+    Ok(PiecewisePolynomial {
+        breaks: series.x.clone(),
+        coefs,
+        pieces,
+        order,
+        dim: series.series,
+    })
+}
+
+pub fn pp_to_value(pp: PiecewisePolynomial, name: &'static str) -> BuiltinResult<Value> {
+    let breaks = Tensor::new(pp.breaks.clone(), vec![1, pp.breaks.len()])
+        .map_err(|err| interp_error(name, format!("{name}: {err}")))?;
+    let coefs = Tensor::new(pp.coefs.clone(), vec![pp.pieces * pp.dim, pp.order])
+        .map_err(|err| interp_error(name, format!("{name}: {err}")))?;
+    let mut st = StructValue::new();
+    st.insert("form", Value::String("pp".to_string()));
+    st.insert("breaks", Value::Tensor(breaks));
+    st.insert("coefs", Value::Tensor(coefs));
+    st.insert("pieces", Value::Num(pp.pieces as f64));
+    st.insert("order", Value::Num(pp.order as f64));
+    st.insert("dim", Value::Num(pp.dim as f64));
+    Ok(Value::Struct(st))
+}
+
+pub async fn pp_from_value(value: Value, name: &'static str) -> BuiltinResult<PiecewisePolynomial> {
+    let gathered = dispatcher::gather_if_needed_async(&value).await?;
+    let Value::Struct(st) = gathered else {
+        return Err(interp_error(
+            name,
+            format!("{name}: first argument must be a pp struct"),
+        ));
+    };
+    let form = st
+        .fields
+        .get("form")
+        .and_then(keyword_of)
+        .ok_or_else(|| interp_error(name, format!("{name}: pp struct is missing form")))?;
+    if form != "pp" {
+        return Err(interp_error(
+            name,
+            format!("{name}: struct form must be 'pp'"),
+        ));
+    }
+    let breaks_value = st
+        .fields
+        .get("breaks")
+        .ok_or_else(|| interp_error(name, format!("{name}: pp struct is missing breaks")))?
+        .clone();
+    let breaks = vector_from_value(breaks_value, "breaks", name).await?;
+    validate_breaks(&breaks, name)?;
+
+    let coefs_value = st
+        .fields
+        .get("coefs")
+        .ok_or_else(|| interp_error(name, format!("{name}: pp struct is missing coefs")))?
+        .clone();
+    let coefs_host = dispatcher::gather_if_needed_async(&coefs_value).await?;
+    let coefs_tensor = tensor::value_into_tensor_for(name, coefs_host)
+        .map_err(|err| interp_error(name, format!("{name}: {err}")))?;
+
+    let pieces = scalar_field(&st, "pieces", name).await? as usize;
+    let order = scalar_field(&st, "order", name).await? as usize;
+    let dim = scalar_field(&st, "dim", name).await? as usize;
+    if pieces + 1 != breaks.len() {
+        return Err(interp_error(name, format!("{name}: malformed pp breaks")));
+    }
+    if order == 0 || dim == 0 {
+        return Err(interp_error(
+            name,
+            format!("{name}: malformed pp dimensions"),
+        ));
+    }
+    if coefs_tensor.data.len() != pieces * dim * order {
+        return Err(interp_error(
+            name,
+            format!("{name}: malformed pp coefficients"),
+        ));
+    }
+    Ok(PiecewisePolynomial {
+        breaks,
+        coefs: coefs_tensor.data,
+        pieces,
+        order,
+        dim,
+    })
+}
+
+async fn scalar_field(st: &StructValue, field: &str, name: &'static str) -> BuiltinResult<f64> {
+    let value = st
+        .fields
+        .get(field)
+        .ok_or_else(|| interp_error(name, format!("{name}: pp struct is missing {field}")))?;
+    let Some(raw) = tensor::scalar_f64_from_value_async(value)
+        .await
+        .map_err(|err| interp_error(name, format!("{name}: {err}")))?
+    else {
+        return Err(interp_error(
+            name,
+            format!("{name}: pp field {field} must be scalar"),
+        ));
+    };
+    if !raw.is_finite() || raw < 1.0 || (raw.round() - raw).abs() > 1e-9 {
+        return Err(interp_error(
+            name,
+            format!("{name}: pp field {field} must be a positive integer"),
+        ));
+    }
+    Ok(raw.round())
+}
+
+pub fn evaluate_pp(
+    pp: &PiecewisePolynomial,
+    query: &QueryPoints,
+    extrap: &Extrapolation,
+    name: &'static str,
+) -> BuiltinResult<Value> {
+    let mut out = vec![0.0; query.values.len() * pp.dim];
+    for d in 0..pp.dim {
+        for (q_index, &xq) in query.values.iter().enumerate() {
+            out[q_index + d * query.values.len()] = eval_pp_scalar(pp, d, xq, extrap);
+        }
+    }
+    tensor_from_pp_output(out, query, pp.dim, name)
+}
+
+pub fn tensor_from_query_output(
+    data: Vec<f64>,
+    query: &QueryPoints,
+    series: &NumericSeries,
+    name: &'static str,
+) -> BuiltinResult<Value> {
+    let shape = output_shape(&query.shape, series.series, &series.trailing_shape);
+    value_from_data(data, shape, name)
+}
+
+fn tensor_from_pp_output(
+    data: Vec<f64>,
+    query: &QueryPoints,
+    dim: usize,
+    name: &'static str,
+) -> BuiltinResult<Value> {
+    let shape = if dim == 1 {
+        query.shape.clone()
+    } else {
+        let mut shape = vec![dim];
+        shape.extend(query.shape.iter().copied());
+        shape
+    };
+    value_from_data(data, shape, name)
+}
+
+fn value_from_data(data: Vec<f64>, shape: Vec<usize>, name: &'static str) -> BuiltinResult<Value> {
+    if data.len() == 1 {
+        return Ok(Value::Num(data[0]));
+    }
+    let tensor =
+        Tensor::new(data, shape).map_err(|err| interp_error(name, format!("{name}: {err}")))?;
+    Ok(Value::Tensor(tensor))
+}
+
+fn output_shape(query_shape: &[usize], series: usize, trailing_shape: &[usize]) -> Vec<usize> {
+    if series == 1 {
+        return query_shape.to_vec();
+    }
+    let mut shape = query_shape.to_vec();
+    if trailing_shape.is_empty() {
+        shape.push(series);
+    } else {
+        shape.extend(trailing_shape.iter().copied());
+    }
+    shape
+}
+
+fn canonical_shape(shape: &[usize], len: usize) -> Vec<usize> {
+    tensor::default_shape_for(shape, len)
+}
+
+fn first_non_singleton_len(tensor: &Tensor) -> Option<usize> {
+    canonical_shape(&tensor.shape, tensor.data.len())
+        .into_iter()
+        .find(|&dim| dim > 1)
+}
+
+fn is_vector_shape(shape: &[usize]) -> bool {
+    match shape {
+        [] => true,
+        [_] => true,
+        [rows, cols] => *rows == 1 || *cols == 1,
+        dims => dims.iter().filter(|&&dim| dim > 1).count() <= 1,
+    }
+}
+
+fn eval_linear(x: &[f64], y: &[f64], xq: f64, extrap: &Extrapolation) -> f64 {
+    if !xq.is_finite() {
+        return f64::NAN;
+    }
+    let Some(piece) = interval_index(x, xq, matches!(extrap, Extrapolation::Extrapolate)) else {
+        return out_of_range_value(extrap);
+    };
+    let h = x[piece + 1] - x[piece];
+    let t = (xq - x[piece]) / h;
+    y[piece] + t * (y[piece + 1] - y[piece])
+}
+
+fn eval_nearest(x: &[f64], y: &[f64], xq: f64, extrap: &Extrapolation) -> f64 {
+    if !xq.is_finite() {
+        return f64::NAN;
+    }
+    if xq < x[0] {
+        return match extrap {
+            Extrapolation::Extrapolate => y[0],
+            _ => out_of_range_value(extrap),
+        };
+    }
+    if xq > x[x.len() - 1] {
+        return match extrap {
+            Extrapolation::Extrapolate => y[y.len() - 1],
+            _ => out_of_range_value(extrap),
+        };
+    }
+    match x.binary_search_by(|probe| probe.partial_cmp(&xq).unwrap()) {
+        Ok(index) => y[index],
+        Err(index) => {
+            let left = index.saturating_sub(1);
+            let right = index.min(x.len() - 1);
+            if (xq - x[left]).abs() <= (x[right] - xq).abs() {
+                y[left]
+            } else {
+                y[right]
+            }
+        }
+    }
+}
+
+fn eval_pp_scalar(pp: &PiecewisePolynomial, series: usize, xq: f64, extrap: &Extrapolation) -> f64 {
+    if !xq.is_finite() {
+        return f64::NAN;
+    }
+    let Some(piece) = interval_index(&pp.breaks, xq, matches!(extrap, Extrapolation::Extrapolate))
+    else {
+        return out_of_range_value(extrap);
+    };
+    let t = xq - pp.breaks[piece];
+    let rows = pp.pieces * pp.dim;
+    let row = series * pp.pieces + piece;
+    let mut acc = 0.0;
+    for col in 0..pp.order {
+        acc = acc * t + pp.coefs[row + col * rows];
+    }
+    acc
+}
+
+fn interval_index(x: &[f64], xq: f64, allow_extrapolation: bool) -> Option<usize> {
+    if xq < x[0] {
+        return allow_extrapolation.then_some(0);
+    }
+    let last = x.len() - 1;
+    if xq > x[last] {
+        return allow_extrapolation.then_some(last - 1);
+    }
+    if xq == x[last] {
+        return Some(last - 1);
+    }
+    match x.binary_search_by(|probe| probe.partial_cmp(&xq).unwrap()) {
+        Ok(index) => Some(index.min(last - 1)),
+        Err(index) if index > 0 && index < x.len() => Some(index - 1),
+        _ => None,
+    }
+}
+
+fn out_of_range_value(extrap: &Extrapolation) -> f64 {
+    match extrap {
+        Extrapolation::Nan => f64::NAN,
+        Extrapolation::Extrapolate => f64::NAN,
+        Extrapolation::Value(value) => *value,
+    }
+}
+
+fn spline_coefs_for_series(x: &[f64], y: &[f64]) -> BuiltinResult<Vec<[f64; 4]>> {
+    let n = x.len();
+    if n == 2 {
+        let h = x[1] - x[0];
+        return Ok(vec![[0.0, 0.0, (y[1] - y[0]) / h, y[0]]]);
+    }
+    if n == 3 {
+        return Ok(quadratic_as_piecewise_cubic(x, y));
+    }
+
+    let h: Vec<f64> = x.windows(2).map(|pair| pair[1] - pair[0]).collect();
+    let mut a = vec![vec![0.0; n]; n];
+    let mut rhs = vec![0.0; n];
+
+    a[0][0] = -h[1];
+    a[0][1] = h[0] + h[1];
+    a[0][2] = -h[0];
+    for i in 1..(n - 1) {
+        a[i][i - 1] = h[i - 1];
+        a[i][i] = 2.0 * (h[i - 1] + h[i]);
+        a[i][i + 1] = h[i];
+        rhs[i] = 6.0 * ((y[i + 1] - y[i]) / h[i] - (y[i] - y[i - 1]) / h[i - 1]);
+    }
+    a[n - 1][n - 3] = -h[n - 2];
+    a[n - 1][n - 2] = h[n - 3] + h[n - 2];
+    a[n - 1][n - 1] = -h[n - 3];
+
+    let second = solve_dense(a, rhs)?;
+    Ok(second_derivatives_to_coefs(x, y, &second))
+}
+
+fn quadratic_as_piecewise_cubic(x: &[f64], y: &[f64]) -> Vec<[f64; 4]> {
+    let x0 = x[0];
+    let x1 = x[1];
+    let x2 = x[2];
+    let y0 = y[0];
+    let y1 = y[1];
+    let y2 = y[2];
+    let c2 =
+        y0 / ((x0 - x1) * (x0 - x2)) + y1 / ((x1 - x0) * (x1 - x2)) + y2 / ((x2 - x0) * (x2 - x1));
+    let c1 = -y0 * (x1 + x2) / ((x0 - x1) * (x0 - x2))
+        - y1 * (x0 + x2) / ((x1 - x0) * (x1 - x2))
+        - y2 * (x0 + x1) / ((x2 - x0) * (x2 - x1));
+    let c0 = y0 * x1 * x2 / ((x0 - x1) * (x0 - x2))
+        + y1 * x0 * x2 / ((x1 - x0) * (x1 - x2))
+        + y2 * x0 * x1 / ((x2 - x0) * (x2 - x1));
+    (0..2)
+        .map(|i| {
+            let xi = x[i];
+            let a = c2 * xi * xi + c1 * xi + c0;
+            let b = 2.0 * c2 * xi + c1;
+            [0.0, c2, b, a]
+        })
+        .collect()
+}
+
+fn second_derivatives_to_coefs(x: &[f64], y: &[f64], second: &[f64]) -> Vec<[f64; 4]> {
+    let mut coefs = Vec::with_capacity(x.len() - 1);
+    for i in 0..(x.len() - 1) {
+        let h = x[i + 1] - x[i];
+        let a = y[i];
+        let b = (y[i + 1] - y[i]) / h - h * (2.0 * second[i] + second[i + 1]) / 6.0;
+        let c = second[i] / 2.0;
+        let d = (second[i + 1] - second[i]) / (6.0 * h);
+        coefs.push([d, c, b, a]);
+    }
+    coefs
+}
+
+fn pchip_coefs_for_series(x: &[f64], y: &[f64]) -> Vec<[f64; 4]> {
+    let n = x.len();
+    let h: Vec<f64> = x.windows(2).map(|pair| pair[1] - pair[0]).collect();
+    let delta: Vec<f64> = y
+        .windows(2)
+        .zip(h.iter())
+        .map(|(pair, &width)| (pair[1] - pair[0]) / width)
+        .collect();
+
+    let mut slopes = vec![0.0; n];
+    if n == 2 {
+        slopes[0] = delta[0];
+        slopes[1] = delta[0];
+    } else {
+        slopes[0] = endpoint_slope(h[0], h[1], delta[0], delta[1]);
+        slopes[n - 1] = endpoint_slope(h[n - 2], h[n - 3], delta[n - 2], delta[n - 3]);
+        for i in 1..(n - 1) {
+            if delta[i - 1] == 0.0 || delta[i] == 0.0 || delta[i - 1].signum() != delta[i].signum()
+            {
+                slopes[i] = 0.0;
+            } else {
+                let w1 = 2.0 * h[i] + h[i - 1];
+                let w2 = h[i] + 2.0 * h[i - 1];
+                slopes[i] = (w1 + w2) / (w1 / delta[i - 1] + w2 / delta[i]);
+            }
+        }
+    }
+
+    let mut coefs = Vec::with_capacity(n - 1);
+    for i in 0..(n - 1) {
+        let c0 = y[i];
+        let c1 = slopes[i];
+        let c2 = (3.0 * delta[i] - 2.0 * slopes[i] - slopes[i + 1]) / h[i];
+        let c3 = (slopes[i] + slopes[i + 1] - 2.0 * delta[i]) / (h[i] * h[i]);
+        coefs.push([c3, c2, c1, c0]);
+    }
+    coefs
+}
+
+fn endpoint_slope(h0: f64, h1: f64, del0: f64, del1: f64) -> f64 {
+    let mut slope = ((2.0 * h0 + h1) * del0 - h0 * del1) / (h0 + h1);
+    if slope.signum() != del0.signum() {
+        slope = 0.0;
+    } else if del0.signum() != del1.signum() && slope.abs() > (3.0 * del0).abs() {
+        slope = 3.0 * del0;
+    }
+    slope
+}
+
+fn solve_dense(mut a: Vec<Vec<f64>>, mut rhs: Vec<f64>) -> BuiltinResult<Vec<f64>> {
+    let n = rhs.len();
+    for col in 0..n {
+        let mut pivot = col;
+        let mut pivot_abs = a[col][col].abs();
+        for row in (col + 1)..n {
+            let candidate = a[row][col].abs();
+            if candidate > pivot_abs {
+                pivot = row;
+                pivot_abs = candidate;
+            }
+        }
+        if pivot_abs <= 1.0e-14 {
+            return Err(interp_error(
+                "spline",
+                "spline: singular interpolation system",
+            ));
+        }
+        if pivot != col {
+            a.swap(pivot, col);
+            rhs.swap(pivot, col);
+        }
+        for row in (col + 1)..n {
+            let factor = a[row][col] / a[col][col];
+            a[row][col] = 0.0;
+            for k in (col + 1)..n {
+                a[row][k] -= factor * a[col][k];
+            }
+            rhs[row] -= factor * rhs[col];
+        }
+    }
+
+    let mut solution = vec![0.0; n];
+    for row in (0..n).rev() {
+        let mut acc = rhs[row];
+        for col in (row + 1)..n {
+            acc -= a[row][col] * solution[col];
+        }
+        solution[row] = acc / a[row][row];
+    }
+    Ok(solution)
+}
+
+fn validate_finite_coefs(coefs: &[f64], name: &'static str) -> BuiltinResult<()> {
+    if coefs.iter().any(|value| !value.is_finite()) {
+        return Err(interp_error(
+            name,
+            format!("{name}: interpolation coefficients must be finite"),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scalar_series(y: &[f64]) -> NumericSeries {
+        NumericSeries {
+            x: (1..=y.len()).map(|v| v as f64).collect(),
+            y: y.to_vec(),
+            series: 1,
+            trailing_shape: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn pchip_preserves_monotone_samples() {
+        let series = scalar_series(&[0.0, 1.0, 1.5, 1.75]);
+        let pp = build_pchip_pp(&series, "pchip").expect("pchip");
+        let query = QueryPoints {
+            values: vec![1.25, 1.5, 2.5, 3.5],
+            shape: vec![1, 4],
+        };
+        let value = evaluate_pp(&pp, &query, &Extrapolation::Extrapolate, "pchip").expect("ppval");
+        let Value::Tensor(tensor) = value else {
+            panic!("expected tensor");
+        };
+        assert!(tensor.data.windows(2).all(|pair| pair[1] >= pair[0]));
+    }
+
+    #[test]
+    fn spline_matches_quadratic_for_three_points() {
+        let series = scalar_series(&[1.0, 4.0, 9.0]);
+        let pp = build_spline_pp(&series, "spline").expect("spline");
+        let query = QueryPoints {
+            values: vec![1.5, 2.5],
+            shape: vec![1, 2],
+        };
+        let value = evaluate_pp(&pp, &query, &Extrapolation::Extrapolate, "spline").expect("ppval");
+        let Value::Tensor(tensor) = value else {
+            panic!("expected tensor");
+        };
+        assert!((tensor.data[0] - 2.25).abs() < 1e-10);
+        assert!((tensor.data[1] - 6.25).abs() < 1e-10);
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/interpolation/pp.rs
+++ b/crates/runmat-runtime/src/builtins/math/interpolation/pp.rs
@@ -420,8 +420,8 @@ fn tensor_from_pp_output(
     let shape = if dim == 1 {
         query.shape.clone()
     } else {
-        let mut shape = vec![dim];
-        shape.extend(query.shape.iter().copied());
+        let mut shape = query.shape.clone();
+        shape.push(dim);
         shape
     };
     value_from_data(data, shape, name)
@@ -767,5 +767,30 @@ mod tests {
         };
         assert!((tensor.data[0] - 2.25).abs() < 1e-10);
         assert!((tensor.data[1] - 6.25).abs() < 1e-10);
+    }
+
+    #[test]
+    fn ppval_multiseries_appends_series_dimension() {
+        let series = NumericSeries {
+            x: vec![1.0, 2.0, 3.0],
+            y: vec![1.0, 4.0, 9.0, 100.0, 400.0, 900.0],
+            series: 2,
+            trailing_shape: vec![2],
+        };
+        let pp = build_spline_pp(&series, "spline").expect("spline");
+        let query = QueryPoints {
+            values: vec![1.5, 2.5],
+            shape: vec![1, 2],
+        };
+        let value = evaluate_pp(&pp, &query, &Extrapolation::Extrapolate, "spline").expect("ppval");
+        let Value::Tensor(tensor) = value else {
+            panic!("expected tensor");
+        };
+        assert_eq!(tensor.shape, vec![1, 2, 2]);
+        assert_eq!(tensor.data.len(), 4);
+        assert!((tensor.data[0] - 2.25).abs() < 1e-10);
+        assert!((tensor.data[1] - 6.25).abs() < 1e-10);
+        assert!((tensor.data[2] - 225.0).abs() < 1e-10);
+        assert!((tensor.data[3] - 625.0).abs() < 1e-10);
     }
 }

--- a/crates/runmat-runtime/src/builtins/math/interpolation/ppval.rs
+++ b/crates/runmat-runtime/src/builtins/math/interpolation/ppval.rs
@@ -1,0 +1,97 @@
+//! Evaluate piecewise-polynomial structs produced by `spline` and `pchip`.
+
+use runmat_builtins::{ResolveContext, Type, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ScalarType, ShapeRequirements,
+};
+
+use super::pp::{evaluate_pp, pp_from_value, query_points, Extrapolation};
+
+const NAME: &str = "ppval";
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::math::interpolation::ppval")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: NAME,
+    op_kind: GpuOpKind::Custom("piecewise-polynomial-eval"),
+    supported_precisions: &[ScalarType::F32, ScalarType::F64],
+    broadcast: BroadcastSemantics::Matlab,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::UniformBuffer,
+    residency: ResidencyPolicy::GatherImmediately,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes:
+        "Initial implementation evaluates pp structs on the CPU after gathering GPU query points.",
+};
+
+#[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::math::interpolation::ppval")]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: NAME,
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::UniformBuffer,
+    elementwise: None,
+    reduction: None,
+    emits_nan: true,
+    notes: "ppval is currently a runtime sink.",
+};
+
+fn ppval_type(args: &[Type], _ctx: &ResolveContext) -> Type {
+    match args.get(1) {
+        Some(Type::Num | Type::Int | Type::Bool) => Type::Num,
+        Some(Type::Tensor { shape }) | Some(Type::Logical { shape }) => Type::Tensor {
+            shape: shape.clone(),
+        },
+        _ => Type::tensor(),
+    }
+}
+
+#[runtime_builtin(
+    name = "ppval",
+    category = "math/interpolation",
+    summary = "Evaluate a piecewise-polynomial structure at query points.",
+    keywords = "ppval,piecewise polynomial,spline,pchip",
+    accel = "sink",
+    sink = true,
+    type_resolver(ppval_type),
+    builtin_path = "crate::builtins::math::interpolation::ppval"
+)]
+async fn ppval_builtin(pp: Value, xq: Value) -> crate::BuiltinResult<Value> {
+    let parsed = pp_from_value(pp, NAME).await?;
+    let query = query_points(xq, NAME).await?;
+    evaluate_pp(&parsed, &query, &Extrapolation::Extrapolate, NAME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtins::math::interpolation::pp::{build_spline_pp, pp_to_value, NumericSeries};
+    use futures::executor::block_on;
+    use runmat_builtins::Tensor;
+
+    #[test]
+    fn ppval_evaluates_spline_struct() {
+        let series = NumericSeries {
+            x: vec![1.0, 2.0, 3.0],
+            y: vec![1.0, 4.0, 9.0],
+            series: 1,
+            trailing_shape: Vec::new(),
+        };
+        let pp = pp_to_value(
+            build_spline_pp(&series, "spline").expect("spline"),
+            "spline",
+        )
+        .expect("pp");
+        let query = Value::Tensor(Tensor::new(vec![1.5, 2.5], vec![1, 2]).expect("tensor"));
+        let value = block_on(ppval_builtin(pp, query)).expect("ppval");
+        let Value::Tensor(tensor) = value else {
+            panic!("expected tensor");
+        };
+        assert!((tensor.data[0] - 2.25).abs() < 1e-10);
+        assert!((tensor.data[1] - 6.25).abs() < 1e-10);
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/interpolation/spline.rs
+++ b/crates/runmat-runtime/src/builtins/math/interpolation/spline.rs
@@ -1,0 +1,122 @@
+//! MATLAB-compatible `spline` builtin backed by piecewise-polynomial structs.
+
+use runmat_builtins::{ResolveContext, Type, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ScalarType, ShapeRequirements,
+};
+
+use super::pp::{
+    build_spline_pp, evaluate_pp, interp_error, pp_to_value, query_points, series_from_values,
+    Extrapolation,
+};
+
+const NAME: &str = "spline";
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::math::interpolation::spline")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: NAME,
+    op_kind: GpuOpKind::Custom("cubic-spline"),
+    supported_precisions: &[ScalarType::F32, ScalarType::F64],
+    broadcast: BroadcastSemantics::Matlab,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::GatherImmediately,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "Spline coefficient construction and evaluation currently run on the CPU reference path after gathering GPU inputs.",
+};
+
+#[runmat_macros::register_fusion_spec(
+    builtin_path = "crate::builtins::math::interpolation::spline"
+)]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: NAME,
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: false,
+    notes: "Spline builds a piecewise-polynomial representation and is not fused.",
+};
+
+fn spline_type(args: &[Type], _ctx: &ResolveContext) -> Type {
+    match args.len() {
+        0 | 1 => Type::Unknown,
+        2 => Type::Struct { known_fields: None },
+        _ => match args.get(2) {
+            Some(Type::Num | Type::Int | Type::Bool) => Type::Num,
+            Some(Type::Tensor { shape }) | Some(Type::Logical { shape }) => Type::Tensor {
+                shape: shape.clone(),
+            },
+            _ => Type::tensor(),
+        },
+    }
+}
+
+#[runtime_builtin(
+    name = "spline",
+    category = "math/interpolation",
+    summary = "Cubic spline interpolation and piecewise-polynomial construction.",
+    keywords = "spline,cubic interpolation,pp,ppval",
+    accel = "sink",
+    sink = true,
+    type_resolver(spline_type),
+    builtin_path = "crate::builtins::math::interpolation::spline"
+)]
+async fn spline_builtin(x: Value, y: Value, rest: Vec<Value>) -> crate::BuiltinResult<Value> {
+    let series = series_from_values(x, y, NAME).await?;
+    let pp = build_spline_pp(&series, NAME)?;
+    match rest.len() {
+        0 => pp_to_value(pp, NAME),
+        1 => {
+            let query = query_points(rest.into_iter().next().expect("query"), NAME).await?;
+            evaluate_pp(&pp, &query, &Extrapolation::Extrapolate, NAME)
+        }
+        _ => Err(interp_error(NAME, "spline: too many input arguments")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::{StructValue, Tensor};
+
+    fn row(values: &[f64]) -> Value {
+        Value::Tensor(Tensor::new(values.to_vec(), vec![1, values.len()]).expect("tensor"))
+    }
+
+    #[test]
+    fn spline_two_arg_returns_pp_struct() {
+        let value = block_on(spline_builtin(
+            row(&[1.0, 2.0, 3.0]),
+            row(&[1.0, 4.0, 9.0]),
+            vec![],
+        ))
+        .expect("spline");
+        let Value::Struct(StructValue { fields }) = value else {
+            panic!("expected struct");
+        };
+        assert!(fields.contains_key("breaks"));
+        assert!(fields.contains_key("coefs"));
+    }
+
+    #[test]
+    fn spline_three_arg_evaluates() {
+        let value = block_on(spline_builtin(
+            row(&[1.0, 2.0, 3.0]),
+            row(&[1.0, 4.0, 9.0]),
+            vec![Value::Num(1.5)],
+        ))
+        .expect("spline");
+        let Value::Num(result) = value else {
+            panic!("expected scalar");
+        };
+        assert!((result - 2.25).abs() < 1e-10);
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/mod.rs
+++ b/crates/runmat-runtime/src/builtins/math/mod.rs
@@ -1,5 +1,6 @@
 pub mod elementwise;
 pub mod fft;
+pub mod interpolation;
 pub mod linalg;
 pub mod poly;
 pub mod reduction;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds substantial new numerical logic (spline/PCHIP coefficient construction and multi-shape evaluation) where edge cases and MATLAB-compatibility correctness are the main risk; changes are isolated to new interpolation builtins and metadata.
> 
> **Overview**
> Adds a new `math/interpolation` builtin module implementing MATLAB-compatible `interp1`, `interp2`, `spline`, `pchip`, and `ppval`, including argument parsing, extrapolation/method options, and shape handling for scalar vs tensor queries.
> 
> Introduces shared piecewise-polynomial helpers in `pp.rs` (pp struct construction/parsing, spline/PCHIP coefficient generation, linear/nearest and pp evaluation), registers GPU/fusion specs (currently CPU-gather “sink” behavior), and adds corresponding builtin metadata JSON plus unit tests for key behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 818b673a12dd4bd4bce6921663b07032ca114320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->