### PR TITLE
Add initial imshow implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5829,6 +5829,7 @@ dependencies = [
  "getrandom 0.2.16",
  "glam",
  "glob",
+ "image",
  "inventory",
  "js-sys",
  "lapack",

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ team management.<br/><br/>
 - **Plotting**
 
   - Interactive 2D and 3D plots with GPU-accelerated rendering
-  - 30+ plot types: line, scatter, bar, surface, mesh, histogram, stem, errorbar, area, contour, pie, plot3, imagesc, and log-scale variants
+  - 30+ plot types: line, scatter, bar, surface, mesh, histogram, stem, errorbar, area, contour, pie, plot3, imagesc, imshow, and log-scale variants
   - Graphics handles, subplot state, annotation builtins (`title`, `sgtitle`, `xlabel`, `legend`), and 3D camera controls
 
   Open-source plotting engine demo (works in CLI and in the browser sandbox):

--- a/bindings/ts/bun.lock
+++ b/bindings/ts/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "runmat",
-      "dependencies": {
-        "runmat": "link:runmat",
-      },
       "devDependencies": {
         "@types/node": "^22.10.1",
         "fake-indexeddb": "^6.0.1",
@@ -214,8 +211,6 @@
     "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": "dist/esm/bin.mjs" }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
     "rollup": ["rollup@4.53.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.53.3", "@rollup/rollup-android-arm64": "4.53.3", "@rollup/rollup-darwin-arm64": "4.53.3", "@rollup/rollup-darwin-x64": "4.53.3", "@rollup/rollup-freebsd-arm64": "4.53.3", "@rollup/rollup-freebsd-x64": "4.53.3", "@rollup/rollup-linux-arm-gnueabihf": "4.53.3", "@rollup/rollup-linux-arm-musleabihf": "4.53.3", "@rollup/rollup-linux-arm64-gnu": "4.53.3", "@rollup/rollup-linux-arm64-musl": "4.53.3", "@rollup/rollup-linux-loong64-gnu": "4.53.3", "@rollup/rollup-linux-ppc64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-musl": "4.53.3", "@rollup/rollup-linux-s390x-gnu": "4.53.3", "@rollup/rollup-linux-x64-gnu": "4.53.3", "@rollup/rollup-linux-x64-musl": "4.53.3", "@rollup/rollup-openharmony-arm64": "4.53.3", "@rollup/rollup-win32-arm64-msvc": "4.53.3", "@rollup/rollup-win32-ia32-msvc": "4.53.3", "@rollup/rollup-win32-x64-gnu": "4.53.3", "@rollup/rollup-win32-x64-msvc": "4.53.3", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA=="],
-
-    "runmat": ["runmat@link:runmat", {}],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 

--- a/bindings/ts/src/fs/default.ts
+++ b/bindings/ts/src/fs/default.ts
@@ -2,11 +2,26 @@ import type { RunMatFilesystemProvider } from "./provider-types.js";
 import { createInMemoryFsProvider } from "./memory.js";
 import { createIndexedDbFsProvider } from "./indexeddb.js";
 
+const DEFAULT_PROVIDER_SYMBOL = Symbol.for("runmat.fs.defaultProvider");
+
 /**
  * Picks the best filesystem backend available in the current runtime.
  * Preference order: IndexedDB (browser) → in-memory fallback.
  */
 export async function createDefaultFsProvider(): Promise<RunMatFilesystemProvider> {
+  const globalState = globalThis as typeof globalThis & {
+    [DEFAULT_PROVIDER_SYMBOL]?: Promise<RunMatFilesystemProvider>;
+  };
+  if (!globalState[DEFAULT_PROVIDER_SYMBOL]) {
+    globalState[DEFAULT_PROVIDER_SYMBOL] = createDefaultFsProviderUncached().catch((error) => {
+      delete globalState[DEFAULT_PROVIDER_SYMBOL];
+      throw error;
+    });
+  }
+  return globalState[DEFAULT_PROVIDER_SYMBOL];
+}
+
+async function createDefaultFsProviderUncached(): Promise<RunMatFilesystemProvider> {
   if (supportsIndexedDb()) {
     try {
       return await createIndexedDbFsProvider();

--- a/bindings/ts/src/fs/indexeddb.ts
+++ b/bindings/ts/src/fs/indexeddb.ts
@@ -16,6 +16,29 @@ export interface IndexedDbFsHandle {
 
 const DEFAULT_DB_NAME = "runmat-fs";
 const DEFAULT_STORE_NAME = "entries";
+const SHARED_BACKINGS_SYMBOL = Symbol.for("runmat.fs.indexedDbBackings");
+
+interface SharedIndexedDbBacking {
+  db: IDBDatabase;
+  storeName: string;
+  volume: MemoryVolume;
+  flushDebounceMs: number;
+  refCount: number;
+  pendingFlush: Promise<void> | null;
+  flushTimer: ReturnType<typeof setTimeout> | null;
+  closed: boolean;
+  dirty: boolean;
+}
+
+function sharedBackings(): Map<string, Promise<SharedIndexedDbBacking>> {
+  const globalState = globalThis as typeof globalThis & {
+    [SHARED_BACKINGS_SYMBOL]?: Map<string, Promise<SharedIndexedDbBacking>>;
+  };
+  if (!globalState[SHARED_BACKINGS_SYMBOL]) {
+    globalState[SHARED_BACKINGS_SYMBOL] = new Map();
+  }
+  return globalState[SHARED_BACKINGS_SYMBOL];
+}
 
 export async function createIndexedDbFsHandle(
   options: IndexedDbProviderOptions = {}
@@ -24,11 +47,19 @@ export async function createIndexedDbFsHandle(
   const dbName = options.dbName ?? DEFAULT_DB_NAME;
   const storeName = options.storeName ?? DEFAULT_STORE_NAME;
   const version = options.version ?? 1;
-  const db = await openDatabase(idb, dbName, storeName, version);
-  const snapshot = await readAllEntries(db, storeName);
-  const volume = new MemoryVolume({ now: options.now });
-  volume.load(snapshot);
-  return new IndexedDbHandle(db, storeName, volume, options.flushDebounceMs ?? 25);
+  const key = sharedBackingKey(dbName, storeName, version);
+  const backings = sharedBackings();
+  let backingPromise = backings.get(key);
+  if (!backingPromise) {
+    backingPromise = createSharedBacking(idb, dbName, storeName, version, options).catch((error) => {
+      backings.delete(key);
+      throw error;
+    });
+    backings.set(key, backingPromise);
+  }
+  const backing = await backingPromise;
+  backing.refCount += 1;
+  return new IndexedDbHandle(key, backing);
 }
 
 export async function createIndexedDbFsProvider(
@@ -40,31 +71,26 @@ export async function createIndexedDbFsProvider(
 
 class IndexedDbHandle implements IndexedDbFsHandle {
   public readonly provider: RunMatFilesystemProvider;
-  private pendingFlush: Promise<void> | null = null;
-  private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private closed = false;
-  private dirty = false;
 
   constructor(
-    private readonly db: IDBDatabase,
-    private readonly storeName: string,
-    private readonly volume: MemoryVolume,
-    private readonly flushDebounceMs: number
+    private readonly key: string,
+    private readonly backing: SharedIndexedDbBacking
   ) {
-    this.provider = volume.createProvider(() => this.onMutate());
+    this.provider = backing.volume.createProvider(() => this.onMutate());
   }
 
   async flush(): Promise<void> {
-    if (this.closed) {
+    if (this.backing.closed) {
       return;
     }
-    if (this.flushTimer) {
-      clearTimeout(this.flushTimer);
-      this.flushTimer = null;
+    if (this.backing.flushTimer) {
+      clearTimeout(this.backing.flushTimer);
+      this.backing.flushTimer = null;
     }
     this.queueFlush();
-    if (this.pendingFlush) {
-      await this.pendingFlush;
+    if (this.backing.pendingFlush) {
+      await this.backing.pendingFlush;
     }
   }
 
@@ -72,58 +98,95 @@ class IndexedDbHandle implements IndexedDbFsHandle {
     if (this.closed) {
       return;
     }
-    if (this.flushTimer) {
-      clearTimeout(this.flushTimer);
-      this.flushTimer = null;
-    }
     this.closed = true;
-    this.db.close();
+    if (this.backing.closed) {
+      return;
+    }
+    this.backing.refCount = Math.max(0, this.backing.refCount - 1);
+    if (this.backing.refCount > 0) {
+      return;
+    }
+    if (this.backing.flushTimer) {
+      clearTimeout(this.backing.flushTimer);
+      this.backing.flushTimer = null;
+    }
+    this.backing.closed = true;
+    this.backing.db.close();
+    sharedBackings().delete(this.key);
   }
 
   private scheduleFlush(): void {
-    if (this.closed) {
+    if (this.backing.closed) {
       return;
     }
-    if (this.flushDebounceMs === 0) {
+    if (this.backing.flushDebounceMs === 0) {
       this.queueFlush();
       return;
     }
-    if (this.flushTimer) {
-      clearTimeout(this.flushTimer);
+    if (this.backing.flushTimer) {
+      clearTimeout(this.backing.flushTimer);
     }
-    this.flushTimer = setTimeout(() => {
-      this.flushTimer = null;
+    this.backing.flushTimer = setTimeout(() => {
+      this.backing.flushTimer = null;
       this.queueFlush();
-    }, this.flushDebounceMs);
+    }, this.backing.flushDebounceMs);
   }
 
   private queueFlush(): void {
-    if (this.closed || this.pendingFlush) {
+    if (this.backing.closed || this.backing.pendingFlush) {
       return;
     }
-    this.pendingFlush = this.persistAll().finally(() => {
-      this.pendingFlush = null;
-      if (this.dirty) {
+    this.backing.pendingFlush = this.persistAll().finally(() => {
+      this.backing.pendingFlush = null;
+      if (this.backing.dirty) {
         this.queueFlush();
       }
     });
   }
 
   private onMutate(): void {
-    this.dirty = true;
+    this.backing.dirty = true;
     this.scheduleFlush();
   }
 
   private async persistAll(): Promise<void> {
-    while (!this.closed) {
-      this.dirty = false;
-      const snapshot = this.volume.serialize();
-      await writeAllEntries(this.db, this.storeName, snapshot);
-      if (!this.dirty) {
+    while (!this.backing.closed) {
+      this.backing.dirty = false;
+      const snapshot = this.backing.volume.serialize();
+      await writeAllEntries(this.backing.db, this.backing.storeName, snapshot);
+      if (!this.backing.dirty) {
         break;
       }
     }
   }
+}
+
+async function createSharedBacking(
+  idb: IDBFactory,
+  dbName: string,
+  storeName: string,
+  version: number,
+  options: IndexedDbProviderOptions
+): Promise<SharedIndexedDbBacking> {
+  const db = await openDatabase(idb, dbName, storeName, version);
+  const snapshot = await readAllEntries(db, storeName);
+  const volume = new MemoryVolume({ now: options.now });
+  volume.load(snapshot);
+  return {
+    db,
+    storeName,
+    volume,
+    flushDebounceMs: options.flushDebounceMs ?? 25,
+    refCount: 0,
+    pendingFlush: null,
+    flushTimer: null,
+    closed: false,
+    dirty: false
+  };
+}
+
+function sharedBackingKey(dbName: string, storeName: string, version: number): string {
+  return `${dbName}\0${storeName}\0${version}`;
 }
 
 function getIndexedDb(): IDBFactory {

--- a/bindings/ts/src/fs/indexeddb.ts
+++ b/bindings/ts/src/fs/indexeddb.ts
@@ -23,11 +23,17 @@ interface SharedIndexedDbBacking {
   storeName: string;
   volume: MemoryVolume;
   flushDebounceMs: number;
+  options: SharedIndexedDbBackingOptions;
   refCount: number;
   pendingFlush: Promise<void> | null;
   flushTimer: ReturnType<typeof setTimeout> | null;
   closed: boolean;
   dirty: boolean;
+}
+
+interface SharedIndexedDbBackingOptions {
+  flushDebounceMs: number;
+  now: (() => number) | null;
 }
 
 function sharedBackings(): Map<string, Promise<SharedIndexedDbBacking>> {
@@ -48,16 +54,18 @@ export async function createIndexedDbFsHandle(
   const storeName = options.storeName ?? DEFAULT_STORE_NAME;
   const version = options.version ?? 1;
   const key = sharedBackingKey(dbName, storeName, version);
+  const backingOptions = normalizeSharedBackingOptions(options);
   const backings = sharedBackings();
   let backingPromise = backings.get(key);
   if (!backingPromise) {
-    backingPromise = createSharedBacking(idb, dbName, storeName, version, options).catch((error) => {
+    backingPromise = createSharedBacking(idb, dbName, storeName, version, backingOptions).catch((error) => {
       backings.delete(key);
       throw error;
     });
     backings.set(key, backingPromise);
   }
   const backing = await backingPromise;
+  assertSharedBackingOptions(key, backing.options, backingOptions);
   backing.refCount += 1;
   return new IndexedDbHandle(key, backing);
 }
@@ -166,23 +174,53 @@ async function createSharedBacking(
   dbName: string,
   storeName: string,
   version: number,
-  options: IndexedDbProviderOptions
+  options: SharedIndexedDbBackingOptions
 ): Promise<SharedIndexedDbBacking> {
   const db = await openDatabase(idb, dbName, storeName, version);
   const snapshot = await readAllEntries(db, storeName);
-  const volume = new MemoryVolume({ now: options.now });
+  const volume = new MemoryVolume({ now: options.now ?? undefined });
   volume.load(snapshot);
   return {
     db,
     storeName,
     volume,
-    flushDebounceMs: options.flushDebounceMs ?? 25,
+    flushDebounceMs: options.flushDebounceMs,
+    options,
     refCount: 0,
     pendingFlush: null,
     flushTimer: null,
     closed: false,
     dirty: false
   };
+}
+
+function normalizeSharedBackingOptions(options: IndexedDbProviderOptions): SharedIndexedDbBackingOptions {
+  return {
+    flushDebounceMs: options.flushDebounceMs ?? 25,
+    now: options.now ?? null
+  };
+}
+
+function assertSharedBackingOptions(
+  key: string,
+  active: SharedIndexedDbBackingOptions,
+  requested: SharedIndexedDbBackingOptions
+): void {
+  const mismatches: string[] = [];
+  if (active.flushDebounceMs !== requested.flushDebounceMs) {
+    mismatches.push("flushDebounceMs");
+  }
+  if (active.now !== requested.now) {
+    mismatches.push("now");
+  }
+  if (mismatches.length === 0) {
+    return;
+  }
+  throw new Error(
+    `IndexedDB filesystem backing '${key}' is already open with different ${mismatches.join(
+      " and "
+    )}; close existing handles before opening it with different persistence options`
+  );
 }
 
 function sharedBackingKey(dbName: string, storeName: string, version: number): string {

--- a/bindings/ts/src/fs/providers.spec.ts
+++ b/bindings/ts/src/fs/providers.spec.ts
@@ -69,9 +69,45 @@ describe("indexeddb filesystem provider", () => {
 
     await deleteDatabase(dbName);
   });
+
+  it("shares a live volume across same-page handles", async () => {
+    const dbName = `runmat-test-live-${Date.now()}`;
+    const handle1 = await createIndexedDbFsHandle({ dbName, flushDebounceMs: 0 });
+    const handle2 = await createIndexedDbFsHandle({ dbName, flushDebounceMs: 0 });
+
+    try {
+      handle2.provider.writeFile("/test.jpg", new Uint8Array([1, 2, 3]));
+      expect(handle1.provider.readFile("/test.jpg")).toEqual(new Uint8Array([1, 2, 3]));
+
+      handle1.close();
+      handle2.provider.writeFile("/after-close.txt", encoder.encode("still-live"));
+      await handle2.flush();
+      handle2.close();
+
+      const handle3 = await createIndexedDbFsHandle({ dbName, flushDebounceMs: 0 });
+      try {
+        expect(toText(handle3.provider.readFile("/after-close.txt"))).toBe("still-live");
+      } finally {
+        handle3.close();
+      }
+    } finally {
+      handle1.close();
+      handle2.close();
+      await deleteDatabase(dbName);
+    }
+  });
 });
 
 describe("default filesystem provider", () => {
+  it("shares one live provider across default calls", async () => {
+    const provider1 = await createDefaultFsProvider();
+    const provider2 = await createDefaultFsProvider();
+
+    expect(provider2).toBe(provider1);
+    provider1.writeFile("/default-shared.txt", encoder.encode("shared"));
+    expect(toText(provider2.readFile("/default-shared.txt"))).toBe("shared");
+  });
+
   it("uses persistent storage when IndexedDB is available", async () => {
     const provider1 = await createDefaultFsProvider();
     provider1.createDirAll?.("/auto");

--- a/bindings/ts/src/fs/providers.spec.ts
+++ b/bindings/ts/src/fs/providers.spec.ts
@@ -96,6 +96,24 @@ describe("indexeddb filesystem provider", () => {
       await deleteDatabase(dbName);
     }
   });
+
+  it("rejects incompatible shared backing options for the same database", async () => {
+    const dbName = `runmat-test-options-${Date.now()}`;
+    const now = () => 1;
+    const handle = await createIndexedDbFsHandle({ dbName, flushDebounceMs: 5_000, now });
+
+    try {
+      await expect(createIndexedDbFsHandle({ dbName, flushDebounceMs: 0, now })).rejects.toThrow(
+        /flushDebounceMs/
+      );
+      await expect(
+        createIndexedDbFsHandle({ dbName, flushDebounceMs: 5_000, now: () => 2 })
+      ).rejects.toThrow(/now/);
+    } finally {
+      handle.close();
+      await deleteDatabase(dbName);
+    }
+  });
 });
 
 describe("default filesystem provider", () => {

--- a/crates/runmat-runtime/Cargo.toml
+++ b/crates/runmat-runtime/Cargo.toml
@@ -48,6 +48,7 @@ glob = "0.3"
 url = "2.5"
 base64 = "0.22"
 sha2 = "0.10"
+image = { version = "0.24", default-features = false, features = ["png", "jpeg", "gif", "bmp", "tiff"] }
 
 # Platform-specific BLAS/LAPACK implementations
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/runmat-runtime/src/builtins/builtins-json/imshow.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/imshow.json
@@ -13,12 +13,9 @@
   "gpu_support": {
     "elementwise": false,
     "reduction": false,
-    "precisions": [
-      "single",
-      "double"
-    ],
+    "precisions": [],
     "broadcasting": "none",
-    "notes": "`imshow` is a plotting sink. Grayscale gpuArray inputs can use the existing image/surface rendering path; filename decoding and truecolor normalization run on the host."
+    "notes": "`imshow` is a plotting sink and does not advertise precision-specialized GPU kernels. Grayscale gpuArray inputs may use the image/surface rendering path; filename decoding and truecolor normalization run on the host."
   },
   "fusion": {
     "elementwise": false,

--- a/crates/runmat-runtime/src/builtins/builtins-json/imshow.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/imshow.json
@@ -1,0 +1,97 @@
+{
+  "title": "imshow",
+  "category": "plotting",
+  "keywords": [
+    "imshow",
+    "image display",
+    "grayscale image",
+    "binary image",
+    "rgb image",
+    "matlab imshow"
+  ],
+  "summary": "Display grayscale, binary, truecolor, or file-backed images.",
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [
+      "single",
+      "double"
+    ],
+    "broadcasting": "none",
+    "notes": "`imshow` is a plotting sink. Grayscale gpuArray inputs can use the existing image/surface rendering path; filename decoding and truecolor normalization run on the host."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 2,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::plotting::imshow::tests"
+  },
+  "description": "`imshow` displays image data using MATLAB-familiar defaults. Numeric and logical 2-D arrays render as grayscale images, MxNx3 and MxNx4 arrays render as truecolor images, and filename inputs are decoded through RunMat's filesystem layer before display.",
+  "behaviors": [
+    "`imshow(I)` displays 2-D numeric data with grayscale limits `[0, 1]`, matching MATLAB double-image defaults.",
+    "`imshow(BW)` displays logical image data as black and white using `[0, 1]` limits.",
+    "`imshow(RGB)` displays MxNx3 truecolor data directly.",
+    "`imshow(RGBA)` displays MxNx4 truecolor data with alpha.",
+    "`imshow(I, [low high])` displays grayscale image data using an explicit display range.",
+    "`imshow(I, [])` auto-scales grayscale image data from finite minimum to finite maximum.",
+    "`imshow(filename)` reads and decodes an image file, then displays it as truecolor data."
+  ],
+  "examples": [
+    {
+      "description": "Display a simple grayscale image",
+      "input": "row = 100;\ncol = 100;\nrsm = ones(row, col);\nimshow(rsm);"
+    },
+    {
+      "description": "Auto-scale a matrix for display",
+      "input": "A = peaks(128);\nimshow(A, []);"
+    },
+    {
+      "description": "Display truecolor RGB data",
+      "input": "R = ones(64, 64);\nG = zeros(64, 64);\nB = zeros(64, 64);\nRGB = cat(3, R, G, B);\nimshow(RGB);"
+    },
+    {
+      "description": "Display an image file",
+      "input": "imshow(\"photo.png\");"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What display range does imshow use for doubles?",
+      "answer": "`imshow(I)` uses `[0, 1]` for floating-point grayscale data. Use `imshow(I, [])` when you want RunMat to scale the visible range from the data minimum to maximum."
+    },
+    {
+      "question": "Does imshow support uint8 and uint16 image defaults?",
+      "answer": "File-backed images decode with byte pixel semantics. User-created integer image arrays currently depend on RunMat's broader numeric-class metadata model, so exact MATLAB class-dependent defaults for dense uint8/uint16 tensors are tracked separately."
+    },
+    {
+      "question": "How is imshow different from imagesc?",
+      "answer": "`imshow` is for image display and uses grayscale or truecolor image defaults. `imagesc` is for scaled matrix visualization and maps data through the active colormap."
+    }
+  ],
+  "links": [
+    {
+      "label": "image",
+      "url": "./image"
+    },
+    {
+      "label": "imagesc",
+      "url": "./imagesc"
+    },
+    {
+      "label": "colormap",
+      "url": "./colormap"
+    },
+    {
+      "label": "axis",
+      "url": "./axis"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/plotting/ops/imshow.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/plotting/ops/imshow.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/plotting/mod.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/mod.rs
@@ -64,6 +64,8 @@ pub(crate) mod hold;
 pub(crate) mod image;
 #[path = "ops/imagesc.rs"]
 pub(crate) mod imagesc;
+#[path = "ops/imshow.rs"]
+pub(crate) mod imshow;
 #[path = "ops/isgraphics.rs"]
 pub(crate) mod isgraphics;
 #[path = "ops/ishandle.rs"]

--- a/crates/runmat-runtime/src/builtins/plotting/ops/imshow.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/imshow.rs
@@ -1,0 +1,732 @@
+use std::cell::RefCell;
+use std::io::Cursor;
+#[cfg(target_arch = "wasm32")]
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use runmat_builtins::{CharArray, NumericDType, StringArray, Tensor, Value};
+use runmat_macros::runtime_builtin;
+use runmat_plot::plots::{ColorMap, ShadingMode, SurfacePlot};
+
+use super::common::SurfaceDataInput;
+use super::state::{render_active_plot, PlotRenderOptions};
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ShapeRequirements,
+};
+use crate::builtins::common::tensor;
+use crate::builtins::plotting::type_resolvers::handle_scalar_type;
+
+const BUILTIN_NAME: &str = "imshow";
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::plotting::imshow")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: "imshow",
+    op_kind: GpuOpKind::PlotRender,
+    supported_precisions: &[],
+    broadcast: BroadcastSemantics::None,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::InheritInputs,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "imshow is a plotting sink; grayscale GPU inputs may remain on device when a shared WGPU context is installed.",
+};
+
+#[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::plotting::imshow")]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: "imshow",
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: false,
+    notes: "imshow terminates fusion graphs and performs rendering.",
+};
+
+#[runtime_builtin(
+    name = "imshow",
+    category = "plotting",
+    summary = "Display grayscale, binary, truecolor, or file-backed images.",
+    keywords = "imshow,plotting,image,grayscale,rgb,binary",
+    sink = true,
+    suppress_auto_output = true,
+    type_resolver(handle_scalar_type),
+    builtin_path = "crate::builtins::plotting::imshow"
+)]
+pub async fn imshow_builtin(args: Vec<Value>) -> crate::BuiltinResult<f64> {
+    let (image_value, range) = parse_args(args).await?;
+
+    if let Some(path) = string_like_path(&image_value)? {
+        if range != DisplayRange::Default {
+            return Err(imshow_error(
+                "imshow: display ranges are only supported for numeric image data",
+            ));
+        }
+        let tensor = tensor_from_image_file(&path).await?;
+        return render_truecolor_tensor(tensor).await;
+    }
+
+    let image_value = normalize_image_value(image_value)?;
+    if is_truecolor_value(&image_value) {
+        if range != DisplayRange::Default {
+            return Err(imshow_error(
+                "imshow: display ranges are only supported for grayscale image data",
+            ));
+        }
+        let tensor = tensor_from_value(image_value).await?;
+        return render_truecolor_tensor(tensor).await;
+    }
+
+    render_grayscale_value(image_value, range).await
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum DisplayRange {
+    Default,
+    Auto,
+    Limits(f64, f64),
+}
+
+async fn parse_args(args: Vec<Value>) -> crate::BuiltinResult<(Value, DisplayRange)> {
+    match args.len() {
+        0 => Err(imshow_error("imshow: expected image data or filename")),
+        1 => Ok((
+            args.into_iter().next().expect("one arg"),
+            DisplayRange::Default,
+        )),
+        2 => {
+            let mut it = args.into_iter();
+            let image_value = it.next().expect("image arg");
+            let range_value = it.next().expect("range arg");
+            Ok((image_value, parse_display_range(range_value).await?))
+        }
+        _ => Err(imshow_error("imshow: too many input arguments")),
+    }
+}
+
+async fn parse_display_range(value: Value) -> crate::BuiltinResult<DisplayRange> {
+    let host = crate::gather_if_needed_async(&value)
+        .await
+        .map_err(|flow| {
+            crate::builtins::common::map_control_flow_with_builtin(flow, BUILTIN_NAME)
+        })?;
+    match host {
+        Value::Tensor(tensor) if tensor.data.is_empty() => Ok(DisplayRange::Auto),
+        Value::Tensor(tensor) if tensor.data.len() == 2 => {
+            let lo = tensor.data[0];
+            let hi = tensor.data[1];
+            validate_display_limits(lo, hi)
+        }
+        _ => Err(imshow_error(
+            "imshow: display range must be [] or a two-element numeric vector",
+        )),
+    }
+}
+
+fn validate_display_limits(lo: f64, hi: f64) -> crate::BuiltinResult<DisplayRange> {
+    if !lo.is_finite() || !hi.is_finite() || lo >= hi {
+        return Err(imshow_error(
+            "imshow: display range must contain finite increasing limits",
+        ));
+    }
+    Ok(DisplayRange::Limits(lo, hi))
+}
+
+fn normalize_image_value(value: Value) -> crate::BuiltinResult<Value> {
+    match value {
+        Value::LogicalArray(array) => tensor::logical_to_tensor(&array)
+            .map(Value::Tensor)
+            .map_err(|err| imshow_error(format!("imshow: {err}"))),
+        Value::Bool(flag) => Tensor::new(vec![if flag { 1.0 } else { 0.0 }], vec![1, 1])
+            .map(Value::Tensor)
+            .map_err(|err| imshow_error(format!("imshow: {err}"))),
+        Value::Num(value) => Tensor::new(vec![value], vec![1, 1])
+            .map(Value::Tensor)
+            .map_err(|err| imshow_error(format!("imshow: {err}"))),
+        Value::Int(value) => Tensor::new(vec![value.to_f64()], vec![1, 1])
+            .map(Value::Tensor)
+            .map_err(|err| imshow_error(format!("imshow: {err}"))),
+        other => Ok(other),
+    }
+}
+
+fn is_truecolor_value(value: &Value) -> bool {
+    match value {
+        Value::Tensor(tensor) => tensor
+            .shape
+            .get(2)
+            .copied()
+            .is_some_and(|c| c == 3 || c == 4),
+        Value::GpuTensor(handle) => handle
+            .shape
+            .get(2)
+            .copied()
+            .is_some_and(|c| c == 3 || c == 4),
+        _ => false,
+    }
+}
+
+async fn tensor_from_value(value: Value) -> crate::BuiltinResult<Tensor> {
+    match value {
+        Value::GpuTensor(handle) => {
+            super::common::gather_tensor_from_gpu_async(handle, BUILTIN_NAME).await
+        }
+        other => Tensor::try_from(&other).map_err(|err| imshow_error(format!("imshow: {err}"))),
+    }
+}
+
+async fn render_grayscale_value(value: Value, range: DisplayRange) -> crate::BuiltinResult<f64> {
+    let c_input = SurfaceDataInput::from_value(value, BUILTIN_NAME)?;
+    let (rows, cols) = c_input.grid_shape(BUILTIN_NAME)?;
+    let x_axis = default_axis_vec(cols);
+    let y_axis = default_image_y_axis(rows);
+    let color_limits = display_range_for_input(&c_input, range).await?;
+    let mut surface = build_grayscale_image_surface(c_input, x_axis, y_axis, color_limits).await?;
+
+    surface = surface
+        .with_flatten_z(true)
+        .with_image_mode(true)
+        .with_colormap(ColorMap::Gray)
+        .with_shading(ShadingMode::None)
+        .with_color_limits(Some(color_limits));
+    render_surface(surface, Some(color_limits)).await
+}
+
+async fn render_truecolor_tensor(tensor: Tensor) -> crate::BuiltinResult<f64> {
+    let (rows, cols) = truecolor_shape(&tensor)?;
+    let x_host = default_axis_vec(cols);
+    let y_host = default_image_y_axis(rows);
+    let surface = build_truecolor_image_surface(tensor, x_host, y_host)?
+        .with_flatten_z(true)
+        .with_image_mode(true)
+        .with_shading(ShadingMode::None);
+    render_surface(surface, None).await
+}
+
+async fn render_surface(
+    mut surface: SurfacePlot,
+    color_limits: Option<(f64, f64)>,
+) -> crate::BuiltinResult<f64> {
+    surface = surface.with_flatten_z(true).with_image_mode(true);
+    let mut surface = Some(surface);
+    let plot_index_out = Rc::new(RefCell::new(None));
+    let plot_index_slot = Rc::clone(&plot_index_out);
+    let figure_handle = crate::builtins::plotting::current_figure_handle();
+    let opts = PlotRenderOptions {
+        title: "Image",
+        x_label: "X",
+        y_label: "Y",
+        axis_equal: true,
+        ..Default::default()
+    };
+    let render_result = render_active_plot(BUILTIN_NAME, opts, move |figure, axes| {
+        if let Some(limits) = color_limits {
+            figure.set_axes_color_limits(axes, Some(limits));
+        }
+        let plot_index = figure
+            .add_surface_plot_on_axes(surface.take().expect("imshow plot consumed once"), axes);
+        *plot_index_slot.borrow_mut() = Some((axes, plot_index));
+        Ok(())
+    });
+    let Some((axes, plot_index)) = *plot_index_out.borrow() else {
+        return render_result.map(|_| f64::NAN);
+    };
+    let handle =
+        crate::builtins::plotting::state::register_image_handle(figure_handle, axes, plot_index);
+    if let Err(err) = render_result {
+        let lower = err.to_string().to_lowercase();
+        if lower.contains("plotting is unavailable") || lower.contains("non-main thread") {
+            return Ok(handle);
+        }
+        return Err(err);
+    }
+    Ok(handle)
+}
+
+async fn display_range_for_input(
+    input: &SurfaceDataInput,
+    range: DisplayRange,
+) -> crate::BuiltinResult<(f64, f64)> {
+    match range {
+        DisplayRange::Default => Ok((0.0, 1.0)),
+        DisplayRange::Limits(lo, hi) => Ok((lo, hi)),
+        DisplayRange::Auto => {
+            let (lo, hi) = match input {
+                SurfaceDataInput::Host(tensor) => finite_tensor_bounds(tensor),
+                SurfaceDataInput::Gpu(handle) => {
+                    let (lo, hi) =
+                        super::gpu_helpers::axis_bounds_async(handle, BUILTIN_NAME).await?;
+                    (lo as f64, hi as f64)
+                }
+            };
+            Ok(expand_degenerate_limits(lo, hi))
+        }
+    }
+}
+
+fn finite_tensor_bounds(tensor: &Tensor) -> (f64, f64) {
+    let mut lo = f64::INFINITY;
+    let mut hi = f64::NEG_INFINITY;
+    for &value in &tensor.data {
+        if value.is_finite() {
+            lo = lo.min(value);
+            hi = hi.max(value);
+        }
+    }
+    if lo.is_finite() && hi.is_finite() {
+        (lo, hi)
+    } else {
+        (0.0, 1.0)
+    }
+}
+
+fn expand_degenerate_limits(lo: f64, hi: f64) -> (f64, f64) {
+    if lo < hi {
+        return (lo, hi);
+    }
+    if lo > 0.0 {
+        (0.0, lo)
+    } else if lo < 0.0 {
+        (lo, 0.0)
+    } else {
+        (0.0, 1.0)
+    }
+}
+
+fn default_axis_vec(len: usize) -> Vec<f64> {
+    (1..=len).map(|idx| idx as f64).collect()
+}
+
+fn default_image_y_axis(rows: usize) -> Vec<f64> {
+    (1..=rows).rev().map(|idx| idx as f64).collect()
+}
+
+fn truecolor_shape(tensor: &Tensor) -> crate::BuiltinResult<(usize, usize)> {
+    let rows = tensor.shape.first().copied().unwrap_or(tensor.rows);
+    let cols = tensor.shape.get(1).copied().unwrap_or(tensor.cols);
+    let channels = tensor.shape.get(2).copied().unwrap_or(1);
+    if rows == 0 || cols == 0 || (channels != 3 && channels != 4) {
+        return Err(imshow_error(
+            "imshow: truecolor image data must be MxNx3 or MxNx4",
+        ));
+    }
+    let expected_len = rows * cols * channels;
+    if tensor.data.len() != expected_len {
+        return Err(imshow_error("imshow: truecolor image data length mismatch"));
+    }
+    Ok((rows, cols))
+}
+
+fn build_truecolor_image_surface(
+    tensor: Tensor,
+    x_axis: Vec<f64>,
+    y_axis: Vec<f64>,
+) -> crate::BuiltinResult<SurfacePlot> {
+    let image_rows = tensor.shape.first().copied().unwrap_or(tensor.rows);
+    let image_cols = tensor.shape.get(1).copied().unwrap_or(tensor.cols);
+    if x_axis.len() != image_cols || y_axis.len() != image_rows {
+        return Err(imshow_error(
+            "imshow: truecolor image axes must match image columns and rows",
+        ));
+    }
+    let channels = tensor.shape.get(2).copied().unwrap_or(3);
+    let mut grid = vec![vec![glam::Vec4::ZERO; image_rows]; image_cols];
+    for row in 0..image_rows {
+        for col in 0..image_cols {
+            let base = row + image_rows * col;
+            let r = tensor.data[base] as f32;
+            let g = tensor.data[base + image_rows * image_cols] as f32;
+            let b = tensor.data[base + 2 * image_rows * image_cols] as f32;
+            let a = if channels == 4 {
+                tensor.data[base + 3 * image_rows * image_cols] as f32
+            } else {
+                1.0
+            };
+            grid[col][row] = glam::Vec4::new(r, g, b, a);
+        }
+    }
+    let z = vec![vec![0.0; image_rows]; image_cols];
+    Ok(SurfacePlot::new(x_axis, y_axis, z)
+        .map_err(|err| imshow_error(format!("imshow: {err}")))?
+        .with_flatten_z(true)
+        .with_image_mode(true)
+        .with_color_grid(grid)
+        .with_shading(ShadingMode::None))
+}
+
+async fn build_grayscale_image_surface(
+    input: SurfaceDataInput,
+    x_axis: Vec<f64>,
+    y_axis: Vec<f64>,
+    color_limits: (f64, f64),
+) -> crate::BuiltinResult<SurfacePlot> {
+    let tensor = match input {
+        SurfaceDataInput::Host(tensor) => tensor,
+        SurfaceDataInput::Gpu(handle) => {
+            super::common::gather_tensor_from_gpu_async(handle, BUILTIN_NAME).await?
+        }
+    };
+    let grid = tensor_to_image_grid(tensor, x_axis.len(), y_axis.len())?;
+    Ok(SurfacePlot::new(x_axis, y_axis, grid)
+        .map_err(|err| imshow_error(format!("imshow: {err}")))?
+        .with_flatten_z(true)
+        .with_image_mode(true)
+        .with_colormap(ColorMap::Gray)
+        .with_shading(ShadingMode::None)
+        .with_color_limits(Some(color_limits)))
+}
+
+fn tensor_to_image_grid(
+    tensor: Tensor,
+    cols: usize,
+    rows: usize,
+) -> crate::BuiltinResult<Vec<Vec<f64>>> {
+    if tensor.data.len() != rows * cols {
+        return Err(imshow_error(format!(
+            "imshow: image data must contain exactly {} values ({}x{})",
+            rows * cols,
+            rows,
+            cols
+        )));
+    }
+    let mut grid = vec![vec![0.0; rows]; cols];
+    for row in 0..rows {
+        for (col, col_vec) in grid.iter_mut().enumerate().take(cols) {
+            col_vec[row] = tensor.data[row + rows * col];
+        }
+    }
+    Ok(grid)
+}
+
+async fn tensor_from_image_file(path: &str) -> crate::BuiltinResult<Tensor> {
+    let bytes = read_image_file_bytes(path).await?;
+    let reader = image::io::Reader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .map_err(|err| {
+            imshow_error(format!(
+                "imshow: unable to identify image file '{path}' ({err})"
+            ))
+        })?;
+    let image = reader.decode().map_err(|err| {
+        imshow_error(format!(
+            "imshow: unable to decode image file '{path}' ({err})"
+        ))
+    })?;
+    let rgba = image.to_rgba8();
+    let (width, height) = rgba.dimensions();
+    let rows = height as usize;
+    let cols = width as usize;
+    let channels = 4;
+    let plane = rows * cols;
+    let mut data = vec![0.0; plane * channels];
+    for row in 0..rows {
+        for col in 0..cols {
+            let pixel = rgba.get_pixel(col as u32, row as u32).0;
+            let base = row + rows * col;
+            data[base] = f64::from(pixel[0]) / 255.0;
+            data[base + plane] = f64::from(pixel[1]) / 255.0;
+            data[base + 2 * plane] = f64::from(pixel[2]) / 255.0;
+            data[base + 3 * plane] = f64::from(pixel[3]) / 255.0;
+        }
+    }
+    Tensor::new_with_dtype(data, vec![rows, cols, channels], NumericDType::F64)
+        .map_err(|err| imshow_error(format!("imshow: {err}")))
+}
+
+async fn read_image_file_bytes(path: &str) -> crate::BuiltinResult<Vec<u8>> {
+    match runmat_filesystem::read_async(path).await {
+        Ok(bytes) => Ok(bytes),
+        Err(fs_err) => {
+            #[cfg(target_arch = "wasm32")]
+            {
+                match read_unique_virtual_file_by_name(path).await {
+                    Ok(Some(bytes)) => return Ok(bytes),
+                    Ok(None) => {}
+                    Err(search_err) => {
+                        return Err(imshow_error(format!(
+                            "imshow: unable to read image file '{path}' ({fs_err}; virtual filesystem search failed: {search_err})"
+                        )));
+                    }
+                }
+                Err(imshow_error(format!(
+                    "imshow: unable to read image file '{path}' ({fs_err}; no unique uploaded file named '{path}' was found in the virtual filesystem)"
+                )))
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                Err(imshow_error(format!(
+                    "imshow: unable to read image file '{path}' ({fs_err})"
+                )))
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn read_unique_virtual_file_by_name(path: &str) -> Result<Option<Vec<u8>>, String> {
+    if !is_simple_relative_filename(path) {
+        return Ok(None);
+    }
+    let matches = find_virtual_files_named(path).await?;
+    match matches.as_slice() {
+        [] => Ok(None),
+        [found] => runmat_filesystem::read_async(found)
+            .await
+            .map(Some)
+            .map_err(|err| format!("matched '{}', but read failed: {err}", found.display())),
+        _ => Err(format!(
+            "filename is ambiguous; matches: {}",
+            matches
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn find_virtual_files_named(file_name: &str) -> Result<Vec<PathBuf>, String> {
+    const MAX_VISITED_DIRS: usize = 4096;
+
+    let mut matches = Vec::new();
+    let mut stack = vec![PathBuf::from("/")];
+    let mut visited = 0usize;
+    while let Some(dir) = stack.pop() {
+        visited += 1;
+        if visited > MAX_VISITED_DIRS {
+            return Err("virtual filesystem search exceeded directory limit".to_string());
+        }
+        let entries = match runmat_filesystem::read_dir_async(&dir).await {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for entry in entries {
+            let name = entry.file_name().to_string_lossy();
+            if entry.is_dir() {
+                stack.push(entry.path().to_path_buf());
+            } else if name == file_name {
+                matches.push(entry.path().to_path_buf());
+            }
+        }
+    }
+    Ok(matches)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn is_simple_relative_filename(path: &str) -> bool {
+    let path = Path::new(path);
+    !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, std::path::Component::Normal(_)))
+        && path.components().count() == 1
+}
+
+fn string_like_path(value: &Value) -> crate::BuiltinResult<Option<String>> {
+    match value {
+        Value::String(s) => Ok(Some(s.clone())),
+        Value::StringArray(array) => scalar_string_array(array).map(Some),
+        Value::CharArray(chars) => scalar_char_array(chars).map(Some),
+        _ => Ok(None),
+    }
+}
+
+fn scalar_string_array(array: &StringArray) -> crate::BuiltinResult<String> {
+    if array.data.len() == 1 {
+        Ok(array.data[0].clone())
+    } else {
+        Err(imshow_error("imshow: filename must be a string scalar"))
+    }
+}
+
+fn scalar_char_array(chars: &CharArray) -> crate::BuiltinResult<String> {
+    if chars.rows == 1 {
+        Ok(chars.data.iter().collect())
+    } else {
+        Err(imshow_error(
+            "imshow: filename must be a character row vector",
+        ))
+    }
+}
+
+fn imshow_error(message: impl Into<String>) -> crate::RuntimeError {
+    crate::builtins::plotting::plotting_error(BUILTIN_NAME, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtins::common::test_support;
+    use crate::builtins::plotting::get::get_builtin;
+    use crate::builtins::plotting::tests::{ensure_plot_test_env, lock_plot_registry};
+    use crate::builtins::plotting::{
+        clear_figure, clone_figure, current_figure_handle, reset_hold_state_for_run,
+    };
+    use runmat_builtins::LogicalArray;
+    use runmat_plot::plots::PlotElement;
+
+    fn matrix(data: Vec<f64>, rows: usize, cols: usize) -> Tensor {
+        Tensor {
+            data,
+            shape: vec![rows, cols],
+            rows,
+            cols,
+            dtype: NumericDType::F64,
+        }
+    }
+
+    fn reset() -> crate::builtins::plotting::state::PlotTestLockGuard {
+        let guard = lock_plot_registry();
+        ensure_plot_test_env();
+        reset_hold_state_for_run();
+        let _ = clear_figure(None);
+        guard
+    }
+
+    #[test]
+    fn imshow_repro_displays_ones_as_grayscale_image() {
+        let _guard = reset();
+        let handle = futures::executor::block_on(imshow_builtin(vec![Value::Tensor(matrix(
+            vec![1.0; 100 * 100],
+            100,
+            100,
+        ))]))
+        .unwrap();
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let PlotElement::Surface(surface) = fig.plots().next().unwrap() else {
+            panic!("expected surface");
+        };
+        assert!(surface.flatten_z);
+        assert!(surface.image_mode);
+        assert_eq!(surface.colormap, ColorMap::Gray);
+        assert_eq!(surface.color_limits, Some((0.0, 1.0)));
+        assert_eq!(
+            get_builtin(vec![Value::Num(handle), Value::String("Type".into())]).unwrap(),
+            Value::String("image".into())
+        );
+    }
+
+    #[test]
+    fn imshow_is_registered_with_dispatcher() {
+        let _guard = reset();
+        let result = futures::executor::block_on(crate::call_builtin_async(
+            BUILTIN_NAME,
+            &[Value::Tensor(matrix(vec![1.0; 4], 2, 2))],
+        ))
+        .expect("imshow should be registered");
+        assert!(matches!(result, Value::Num(handle) if handle.is_finite()));
+    }
+
+    #[test]
+    fn imshow_accepts_explicit_display_range() {
+        let _guard = reset();
+        let range = Tensor::new(vec![10.0, 20.0], vec![1, 2]).unwrap();
+        futures::executor::block_on(imshow_builtin(vec![
+            Value::Tensor(matrix(vec![10.0, 15.0, 20.0, 12.0], 2, 2)),
+            Value::Tensor(range),
+        ]))
+        .unwrap();
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let PlotElement::Surface(surface) = fig.plots().next().unwrap() else {
+            panic!("expected surface");
+        };
+        assert_eq!(surface.color_limits, Some((10.0, 20.0)));
+    }
+
+    #[test]
+    fn imshow_empty_display_range_auto_scales() {
+        let _guard = reset();
+        let empty = Tensor::new(Vec::new(), vec![0, 0]).unwrap();
+        futures::executor::block_on(imshow_builtin(vec![
+            Value::Tensor(matrix(vec![10.0, 15.0, 20.0, 12.0], 2, 2)),
+            Value::Tensor(empty),
+        ]))
+        .unwrap();
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let PlotElement::Surface(surface) = fig.plots().next().unwrap() else {
+            panic!("expected surface");
+        };
+        assert_eq!(surface.color_limits, Some((10.0, 20.0)));
+    }
+
+    #[test]
+    fn imshow_logical_image_uses_binary_limits() {
+        let _guard = reset();
+        let logical = LogicalArray::new(vec![1, 0, 0, 1], vec![2, 2]).unwrap();
+        futures::executor::block_on(imshow_builtin(vec![Value::LogicalArray(logical)])).unwrap();
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let PlotElement::Surface(surface) = fig.plots().next().unwrap() else {
+            panic!("expected surface");
+        };
+        assert_eq!(surface.color_limits, Some((0.0, 1.0)));
+        assert_eq!(surface.colormap, ColorMap::Gray);
+    }
+
+    #[test]
+    fn imshow_truecolor_builds_color_grid() {
+        let _guard = reset();
+        let tensor = Tensor {
+            data: vec![1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0],
+            shape: vec![2, 2, 3],
+            rows: 2,
+            cols: 2,
+            dtype: NumericDType::F64,
+        };
+        futures::executor::block_on(imshow_builtin(vec![Value::Tensor(tensor)])).unwrap();
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let PlotElement::Surface(surface) = fig.plots().next().unwrap() else {
+            panic!("expected surface");
+        };
+        assert!(surface.image_mode);
+        let grid = surface.color_grid.as_ref().expect("color grid");
+        assert_eq!(surface.x_data.len(), 2);
+        assert_eq!(surface.y_data.len(), 2);
+        assert_eq!(surface.y_data, vec![2.0, 1.0]);
+        assert_eq!(grid.len(), 2);
+        assert_eq!(grid[0].len(), 2);
+        assert_eq!(surface.color_limits, None);
+    }
+
+    #[test]
+    fn imshow_decodes_filename_input_without_rotating() {
+        let _guard = reset();
+        let mut path = std::env::temp_dir();
+        path.push(format!("runmat_imshow_{}.png", std::process::id()));
+        let mut image = image::RgbaImage::new(3, 2);
+        image.put_pixel(0, 0, image::Rgba([255, 0, 0, 255]));
+        image.put_pixel(1, 0, image::Rgba([0, 255, 0, 255]));
+        image.put_pixel(2, 0, image::Rgba([0, 0, 255, 255]));
+        image.put_pixel(0, 1, image::Rgba([0, 255, 255, 255]));
+        image.put_pixel(1, 1, image::Rgba([255, 0, 255, 255]));
+        image.put_pixel(2, 1, image::Rgba([255, 255, 0, 255]));
+        image.save(&path).expect("save png");
+
+        futures::executor::block_on(imshow_builtin(vec![Value::String(
+            path.to_string_lossy().to_string(),
+        )]))
+        .unwrap();
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let PlotElement::Surface(surface) = fig.plots().next().unwrap() else {
+            panic!("expected surface");
+        };
+        assert_eq!(surface.x_data.len(), 3);
+        assert_eq!(surface.y_data.len(), 2);
+        assert_eq!(surface.x_data, vec![1.0, 2.0, 3.0]);
+        assert_eq!(surface.y_data, vec![2.0, 1.0]);
+        let grid = surface.color_grid.as_ref().expect("color grid");
+        assert_eq!(grid.len(), 3);
+        assert_eq!(grid[0].len(), 2);
+        assert_eq!(grid[0][0], glam::Vec4::new(1.0, 0.0, 0.0, 1.0));
+        assert_eq!(grid[1][0], glam::Vec4::new(0.0, 1.0, 0.0, 1.0));
+        assert_eq!(grid[2][0], glam::Vec4::new(0.0, 0.0, 1.0, 1.0));
+        assert_eq!(grid[0][1], glam::Vec4::new(0.0, 1.0, 1.0, 1.0));
+        assert_eq!(grid[1][1], glam::Vec4::new(1.0, 0.0, 1.0, 1.0));
+        assert_eq!(grid[2][1], glam::Vec4::new(1.0, 1.0, 0.0, 1.0));
+
+        let _ = test_support::fs::remove_file(&path);
+    }
+}

--- a/crates/runmat-runtime/src/builtins/plotting/ops/imshow.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/imshow.rs
@@ -207,10 +207,9 @@ async fn render_truecolor_tensor(tensor: Tensor) -> crate::BuiltinResult<f64> {
 }
 
 async fn render_surface(
-    mut surface: SurfacePlot,
+    surface: SurfacePlot,
     color_limits: Option<(f64, f64)>,
 ) -> crate::BuiltinResult<f64> {
-    surface = surface.with_flatten_z(true).with_image_mode(true);
     let mut surface = Some(surface);
     let plot_index_out = Rc::new(RefCell::new(None));
     let plot_index_slot = Rc::clone(&plot_index_out);

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -32,7 +32,7 @@ Browse the complete list: [Built-in Function Reference](/docs/matlab-function-re
 
 RunMat includes 40+ plotting builtins with GPU-first rendering, interactive 3D camera, theming, and scene persistence.
 
-**2D chart types:** `plot`, `scatter`, `bar`, `histogram`, `hist`, `area`, `stairs`, `stem`, `errorbar`, `pie`, `contour`, `contourf`, `image`, `imagesc`, `quiver`
+**2D chart types:** `plot`, `scatter`, `bar`, `histogram`, `hist`, `area`, `stairs`, `stem`, `errorbar`, `pie`, `contour`, `contourf`, `image`, `imagesc`, `imshow`, `quiver`
 
 **3D chart types:** `plot3`, `surf`, `surfc`, `mesh`, `meshc`, `scatter3`
 
@@ -56,7 +56,7 @@ RunMat focuses on core MATLAB — the language, operators, data types, and gener
 | Simulink | ❌ | RunMat is script-based only; no block-diagram modeling |
 | Signal Processing | ❌ | Not implemented |
 | Control System | ❌ | Not implemented |
-| Image Processing | ❌ | Basic array ops and `image`/`imagesc` work on image data |
+| Image Processing | ❌ | Basic array ops and `image`/`imagesc`/`imshow` work on image data |
 | Statistics & Machine Learning | ❌ | Core stats functions (`mean`, `std`, `var`, `median`, `sort`, `hist`, etc.) are available as builtins |
 | Optimization | ❌ | Not implemented |
 | Symbolic Math | ❌ | Not implemented |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new plotting builtin that decodes and renders image files (new `image` dependency) and changes browser filesystem initialization to use shared, global singletons, which could affect persistence/cleanup semantics across callers.
> 
> **Overview**
> Adds a new MATLAB-compatible plotting builtin `imshow` with unit tests and reference metadata. It supports grayscale and truecolor array inputs plus filename inputs that are decoded via the new Rust `image` dependency and rendered through the existing surface-plot/image-handle path.
> 
> Updates the TypeScript filesystem layer to **share providers/backings within a page**: `createDefaultFsProvider()` now returns a cached singleton, and the IndexedDB provider now reuses a shared live `MemoryVolume`/DB connection with ref-counted cleanup and option compatibility checks (with new tests). Documentation is updated to list `imshow`, and lockfiles are adjusted accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77010a715417d1298d6be6185f5b38a0936f99cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->