### PR TITLE
removed extraneous return for Windows clippy

### DIFF
--- a/crates/runmat-runtime/src/builtins/image/imread.rs
+++ b/crates/runmat-runtime/src/builtins/image/imread.rs
@@ -210,7 +210,7 @@ fn file_url_to_path(url: &Url) -> BuiltinResult<PathBuf> {
             } else {
                 decoded.as_str()
             };
-        return Ok(PathBuf::from(path));
+        Ok(PathBuf::from(path))
     }
 
     #[cfg(not(windows))]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, behavior-preserving change that only removes an extraneous `return` in the Windows-only branch of `file_url_to_path` to satisfy clippy.
> 
> **Overview**
> Cleans up `file_url_to_path` in `imread` by removing a redundant `return` in the Windows-specific code path, returning `Ok(PathBuf::from(path))` as the block’s final expression (clippy/style-only, no intended behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d96de6466e6a989aea30b2a580b8a49055b409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->