### PR TITLE
Add clearvars builtin support

### DIFF
--- a/crates/runmat-core/tests/command_controls.rs
+++ b/crates/runmat-core/tests/command_controls.rs
@@ -178,6 +178,56 @@ fn clearvars_except_keeps_named_bindings() {
 }
 
 #[test]
+fn clearvars_selected_names_with_except_preserves_exclusions() {
+    let mut engine = gc_test_context(RunMatSession::new).unwrap();
+
+    block_on(engine.execute("a = 1; b = 2; c = 3; untouched = 4;")).unwrap();
+
+    let result = block_on(engine.execute("clearvars a b c -except b;")).unwrap();
+    assert!(result.error.is_none());
+    assert!(result.workspace.full);
+
+    let names: Vec<&str> = result
+        .workspace
+        .values
+        .iter()
+        .map(|entry| entry.name.as_str())
+        .collect();
+    assert!(!names.contains(&"a"), "a should have been cleared");
+    assert!(names.contains(&"b"), "b should have been preserved");
+    assert!(!names.contains(&"c"), "c should have been cleared");
+    assert!(
+        names.contains(&"untouched"),
+        "variables outside the selected clear set should remain"
+    );
+}
+
+#[test]
+fn clearvars_function_call_selected_names_with_except_preserves_exclusions() {
+    let mut engine = gc_test_context(RunMatSession::new).unwrap();
+
+    block_on(engine.execute("a = 1; b = 2; c = 3; untouched = 4;")).unwrap();
+
+    let result = block_on(engine.execute("clearvars('a', 'b', 'c', '-except', 'b');")).unwrap();
+    assert!(result.error.is_none());
+    assert!(result.workspace.full);
+
+    let names: Vec<&str> = result
+        .workspace
+        .values
+        .iter()
+        .map(|entry| entry.name.as_str())
+        .collect();
+    assert!(!names.contains(&"a"), "a should have been cleared");
+    assert!(names.contains(&"b"), "b should have been preserved");
+    assert!(!names.contains(&"c"), "c should have been cleared");
+    assert!(
+        names.contains(&"untouched"),
+        "variables outside the selected clear set should remain"
+    );
+}
+
+#[test]
 fn clearvars_repro_with_clc_and_close_all_executes() {
     let mut engine = gc_test_context(RunMatSession::new).unwrap();
 

--- a/crates/runmat-core/tests/command_controls.rs
+++ b/crates/runmat-core/tests/command_controls.rs
@@ -114,6 +114,85 @@ fn clear_followed_by_assignments_shows_vars_in_workspace() {
 }
 
 #[test]
+fn clearvars_command_clears_workspace_state() {
+    let mut engine = gc_test_context(RunMatSession::new).unwrap();
+
+    block_on(engine.execute("x = 1; y = 2;")).unwrap();
+
+    let result = block_on(engine.execute("clearvars;")).unwrap();
+    assert!(result.error.is_none());
+    assert!(result.workspace.full);
+    assert!(result.workspace.values.is_empty());
+
+    let err = block_on(engine.execute("x")).unwrap_err();
+    assert!(err.to_string().contains("Undefined variable: x"));
+}
+
+#[test]
+fn clearvars_named_variable_removes_only_that_binding() {
+    let mut engine = gc_test_context(RunMatSession::new).unwrap();
+
+    block_on(engine.execute("x = 1; y = 2;")).unwrap();
+
+    let result = block_on(engine.execute("clearvars x;")).unwrap();
+    assert!(result.error.is_none());
+    assert!(result.workspace.full);
+    assert_eq!(result.workspace.values.len(), 1);
+    assert_eq!(result.workspace.values[0].name, "y");
+
+    let err = block_on(engine.execute("x")).unwrap_err();
+    assert!(err.to_string().contains("Undefined variable: x"));
+}
+
+#[test]
+fn clearvars_multiple_named_variables_accepts_multiple_inputs() {
+    let mut engine = gc_test_context(RunMatSession::new).unwrap();
+
+    block_on(engine.execute("a = 1; b = 2; c = 3;")).unwrap();
+
+    let result = block_on(engine.execute("clearvars a b;")).unwrap();
+    assert!(result.error.is_none());
+    assert!(result.workspace.full);
+    assert_eq!(result.workspace.values.len(), 1);
+    assert_eq!(result.workspace.values[0].name, "c");
+}
+
+#[test]
+fn clearvars_except_keeps_named_bindings() {
+    let mut engine = gc_test_context(RunMatSession::new).unwrap();
+
+    block_on(engine.execute("drop1 = 1; keep = 2; drop2 = 3;")).unwrap();
+
+    let result = block_on(engine.execute("clearvars -except keep;")).unwrap();
+    assert!(result.error.is_none());
+    assert!(result.workspace.full);
+    assert_eq!(result.workspace.values.len(), 1);
+    assert_eq!(result.workspace.values[0].name, "keep");
+
+    let value = block_on(engine.execute("keep")).unwrap();
+    assert!(value.error.is_none());
+    assert_eq!(
+        value.value.as_ref().map(|v| v.to_string()),
+        Some("2".to_string())
+    );
+}
+
+#[test]
+fn clearvars_repro_with_clc_and_close_all_executes() {
+    let mut engine = gc_test_context(RunMatSession::new).unwrap();
+
+    let result = block_on(engine.execute("clearvars; clc; close all\nx = 5;\ndisp(x);")).unwrap();
+    assert!(result.error.is_none());
+    assert!(
+        result
+            .streams
+            .iter()
+            .any(|entry| entry.stream == ExecutionStreamKind::ClearScreen),
+        "expected clc to emit a clear-screen control event"
+    );
+}
+
+#[test]
 fn clc_emits_clear_screen_control_stream() {
     let mut engine = gc_test_context(RunMatSession::new).unwrap();
 

--- a/crates/runmat-core/tests/command_controls.rs
+++ b/crates/runmat-core/tests/command_controls.rs
@@ -228,6 +228,24 @@ fn clearvars_function_call_selected_names_with_except_preserves_exclusions() {
 }
 
 #[test]
+fn clearvars_named_variable_is_undefined_later_in_same_execution() {
+    let mut engine = gc_test_context(RunMatSession::new).unwrap();
+
+    let result = block_on(engine.execute("x = 7; clearvars x; disp(x);")).unwrap();
+    let err = result.error.expect("expected cleared x to be undefined");
+    assert!(err.to_string().contains("Undefined variable: x"));
+}
+
+#[test]
+fn clear_named_variable_is_undefined_later_in_same_execution() {
+    let mut engine = gc_test_context(RunMatSession::new).unwrap();
+
+    let result = block_on(engine.execute("x = 7; clear x; disp(x);")).unwrap();
+    let err = result.error.expect("expected cleared x to be undefined");
+    assert!(err.to_string().contains("Undefined variable: x"));
+}
+
+#[test]
 fn clearvars_repro_with_clc_and_close_all_executes() {
     let mut engine = gc_test_context(RunMatSession::new).unwrap();
 

--- a/crates/runmat-parser/src/parser/command.rs
+++ b/crates/runmat-parser/src/parser/command.rs
@@ -98,6 +98,10 @@ const COMMAND_VERBS: &[CommandVerb] = &[
         arg_kind: CommandArgKind::StringifyWords,
     },
     CommandVerb {
+        name: "clearvars",
+        arg_kind: CommandArgKind::StringifyWords,
+    },
+    CommandVerb {
         name: "format",
         arg_kind: CommandArgKind::Keyword {
             allowed: &[
@@ -117,7 +121,7 @@ impl Parser {
             ));
         }
         let name_token = self.next().unwrap();
-        let mut args = self.parse_command_args();
+        let mut args = self.parse_command_args(&name_token.lexeme);
         if let Some(command) = self.lookup_command(&name_token.lexeme) {
             self.normalize_command_args(command, &mut args[..])?;
         }
@@ -154,7 +158,9 @@ impl Parser {
         let mut saw_arg = false;
         self.skip_command_continuations(&mut i);
 
-        if !matches!(
+        if self.try_skip_dash_option(verb, &mut i) {
+            saw_arg = true;
+        } else if !matches!(
             self.peek_token_at(i),
             Some(Token::Ident | Token::Integer | Token::Float | Token::Str | Token::End)
         ) {
@@ -170,6 +176,9 @@ impl Parser {
                 Some(Token::Ident | Token::Integer | Token::Float | Token::Str | Token::End) => {
                     saw_arg = true;
                     i += 1;
+                }
+                Some(Token::Minus) if self.try_skip_dash_option(verb, &mut i) => {
+                    saw_arg = true;
                 }
                 Some(Token::Ellipsis) => self.skip_command_continuations(&mut i),
                 _ => break,
@@ -191,7 +200,7 @@ impl Parser {
         }
     }
 
-    fn parse_command_args(&mut self) -> Vec<Expr> {
+    fn parse_command_args(&mut self, verb: &str) -> Vec<Expr> {
         let mut args = Vec::new();
         loop {
             if matches!(self.peek_token(), Some(Token::Newline)) {
@@ -225,11 +234,21 @@ impl Parser {
                     let span = self.span_from(token.position, token.end);
                     args.push(Expr::String(token.lexeme, span));
                 }
+                Some(Token::Minus)
+                    if self.can_parse_dash_option_arg(verb)
+                        && matches!(self.peek_token_at(1), Some(Token::Ident)) =>
+                {
+                    let minus = self.next().unwrap();
+                    let Some(option) = self.next() else {
+                        break;
+                    };
+                    let span = self.span_from(minus.position, option.end);
+                    args.push(Expr::Ident(format!("-{}", option.lexeme), span));
+                }
                 Some(Token::Slash)
                 | Some(Token::Star)
                 | Some(Token::Backslash)
                 | Some(Token::Plus)
-                | Some(Token::Minus)
                 | Some(Token::LParen)
                 | Some(Token::Dot)
                 | Some(Token::LBracket)
@@ -239,6 +258,23 @@ impl Parser {
             }
         }
         args
+    }
+
+    fn try_skip_dash_option(&self, verb: &str, offset: &mut usize) -> bool {
+        if !self.can_parse_dash_option_arg(verb) {
+            return false;
+        }
+        if !matches!(self.peek_token_at(*offset), Some(Token::Minus))
+            || !matches!(self.peek_token_at(*offset + 1), Some(Token::Ident))
+        {
+            return false;
+        }
+        *offset += 2;
+        true
+    }
+
+    fn can_parse_dash_option_arg(&self, verb: &str) -> bool {
+        verb.eq_ignore_ascii_case("clearvars")
     }
 
     fn skip_command_continuations(&self, offset: &mut usize) {

--- a/crates/runmat-parser/tests/command_syntax.rs
+++ b/crates/runmat-parser/tests/command_syntax.rs
@@ -153,6 +153,40 @@ fn clear_all_stringifies_bare_word_arg() {
 }
 
 #[test]
+fn clearvars_stringifies_bare_word_args() {
+    let program =
+        parse_with_options("clearvars x y", ParserOptions::new(CompatMode::Matlab)).unwrap();
+    match &program.body[0] {
+        Stmt::ExprStmt(Expr::FuncCall(name, args, _), false, _) => {
+            assert_eq!(name, "clearvars");
+            assert_eq!(args.len(), 2);
+            assert!(matches!(args[0], Expr::String(ref s, _) if s == "\"x\""));
+            assert!(matches!(args[1], Expr::String(ref s, _) if s == "\"y\""));
+        }
+        _ => panic!("expected clearvars x y to become clearvars(\"x\", \"y\")"),
+    }
+}
+
+#[test]
+fn clearvars_except_stringifies_dash_option_and_names() {
+    let program = parse_with_options(
+        "clearvars -except x y",
+        ParserOptions::new(CompatMode::Matlab),
+    )
+    .unwrap();
+    match &program.body[0] {
+        Stmt::ExprStmt(Expr::FuncCall(name, args, _), false, _) => {
+            assert_eq!(name, "clearvars");
+            assert_eq!(args.len(), 3);
+            assert!(matches!(args[0], Expr::String(ref s, _) if s == "\"-except\""));
+            assert!(matches!(args[1], Expr::String(ref s, _) if s == "\"x\""));
+            assert!(matches!(args[2], Expr::String(ref s, _) if s == "\"y\""));
+        }
+        _ => panic!("expected clearvars -except x y to become a clearvars call"),
+    }
+}
+
+#[test]
 fn invalid_keyword_rejected() {
     let err = parse_with_options("grid maybe", ParserOptions::new(CompatMode::Matlab));
     assert!(err.is_err());

--- a/crates/runmat-runtime/src/builtins/builtins-json/clearvars.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/clearvars.json
@@ -30,12 +30,13 @@
     "unit": null,
     "integration": "command_controls::clearvars_command_clears_workspace_state"
   },
-  "description": "`clearvars` removes variables from the active RunMat workspace. RunMat supports MATLAB-style command forms such as `clearvars x y` and exclusion forms such as `clearvars -except keep`, updating the session snapshot so hosts can drop cleared bindings.",
+  "description": "`clearvars` removes variables from the active RunMat workspace. RunMat supports MATLAB-style command forms such as `clearvars x y`, whole-workspace exclusion forms such as `clearvars -except keep`, and selected-variable exclusion forms such as `clearvars a b -except b`, updating the session snapshot so hosts can drop cleared bindings.",
   "behaviors": [
     "`clearvars` with no inputs clears all workspace variables created in the current session.",
     "`clearvars x` removes the variable `x` while leaving other workspace bindings intact.",
     "Multiple names can be supplied as separate inputs or command-form tokens, for example `clearvars x y z`.",
     "`clearvars -except x y` removes all active workspace variables except `x` and `y`.",
+    "`clearvars a b c -except b` removes only selected variables `a` and `c`, preserves selected exclusion `b`, and leaves variables outside the selected clear set untouched.",
     "Function-call forms accept variable names as string scalars, row character vectors, or string arrays.",
     "Clearing a name that does not exist is a no-op.",
     "`clearvars` is a sink builtin and does not produce a meaningful output value."
@@ -55,6 +56,11 @@
       "description": "Keep selected variables while clearing the rest",
       "input": "raw = 1;\nanswer = 42;\ntmp = 3;\nclearvars -except answer",
       "output": "% answer remains defined; raw and tmp are removed"
+    },
+    {
+      "description": "Clear selected variables while preserving exclusions",
+      "input": "a = 1;\nb = 2;\nc = 3;\nuntouched = 4;\nclearvars a b c -except b",
+      "output": "% a and c are removed; b and untouched remain defined"
     }
   ],
   "faqs": [

--- a/crates/runmat-runtime/src/builtins/builtins-json/clearvars.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/clearvars.json
@@ -1,0 +1,103 @@
+{
+  "title": "clearvars",
+  "category": "introspection",
+  "keywords": [
+    "clearvars",
+    "clear variables",
+    "workspace",
+    "variables",
+    "-except"
+  ],
+  "summary": "Clear variables from the active workspace, with optional exclusions.",
+  "references": [
+    "https://www.mathworks.com/help/matlab/ref/clearvars.html"
+  ],
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [],
+    "broadcasting": "none",
+    "notes": "Runs on the host CPU because it mutates the session workspace rather than array contents."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 16,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": null,
+    "integration": "command_controls::clearvars_command_clears_workspace_state"
+  },
+  "description": "`clearvars` removes variables from the active RunMat workspace. RunMat supports MATLAB-style command forms such as `clearvars x y` and exclusion forms such as `clearvars -except keep`, updating the session snapshot so hosts can drop cleared bindings.",
+  "behaviors": [
+    "`clearvars` with no inputs clears all workspace variables created in the current session.",
+    "`clearvars x` removes the variable `x` while leaving other workspace bindings intact.",
+    "Multiple names can be supplied as separate inputs or command-form tokens, for example `clearvars x y z`.",
+    "`clearvars -except x y` removes all active workspace variables except `x` and `y`.",
+    "Function-call forms accept variable names as string scalars, row character vectors, or string arrays.",
+    "Clearing a name that does not exist is a no-op.",
+    "`clearvars` is a sink builtin and does not produce a meaningful output value."
+  ],
+  "examples": [
+    {
+      "description": "Clear the entire interactive workspace",
+      "input": "x = 1;\ny = magic(3);\nclearvars",
+      "output": "% x and y are removed from the workspace"
+    },
+    {
+      "description": "Clear selected variables",
+      "input": "a = 1;\nb = 2;\nc = 3;\nclearvars a b",
+      "output": "% a and b are removed; c remains defined"
+    },
+    {
+      "description": "Keep selected variables while clearing the rest",
+      "input": "raw = 1;\nanswer = 42;\ntmp = 3;\nclearvars -except answer",
+      "output": "% answer remains defined; raw and tmp are removed"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How is `clearvars` different from `clear`?",
+      "answer": "`clearvars` focuses on workspace variables and supports the `-except` option for preserving named bindings while clearing the rest."
+    },
+    {
+      "question": "Can I clear only one variable?",
+      "answer": "Yes. Use `clearvars x` or `clearvars(\"x\")` to remove one variable, and pass multiple names to clear more than one binding in a single call."
+    },
+    {
+      "question": "Does `clearvars -except x` clear figures or the console?",
+      "answer": "No. It only mutates workspace variables. Use `close all` for figures and `clc` for the visible console."
+    },
+    {
+      "question": "Does GPU residency matter?",
+      "answer": "No. `clearvars` operates on session bookkeeping, not on array kernels or provider-managed computations."
+    }
+  ],
+  "links": [
+    {
+      "label": "clear",
+      "url": "./clear"
+    },
+    {
+      "label": "who",
+      "url": "./who"
+    },
+    {
+      "label": "whos",
+      "url": "./whos"
+    },
+    {
+      "label": "clc",
+      "url": "./clc"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/introspection/clearvars.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/introspection/clearvars.rs"
+  },
+  "gpu_behavior": [
+    "`clearvars` performs host-side workspace mutation only. It does not launch GPU kernels, does not participate in fusion, and does not depend on acceleration providers."
+  ]
+}

--- a/crates/runmat-runtime/src/builtins/introspection/clearvars.rs
+++ b/crates/runmat-runtime/src/builtins/introspection/clearvars.rs
@@ -1,0 +1,117 @@
+//! MATLAB-compatible `clearvars` builtin for workspace variables.
+
+use std::collections::HashSet;
+
+use runmat_builtins::{Tensor, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::{build_runtime_error, workspace, BuiltinResult};
+
+#[runtime_builtin(
+    name = "clearvars",
+    category = "introspection",
+    summary = "Clear variables from the active workspace, with optional exclusions.",
+    keywords = "clearvars,workspace,variables,except",
+    sink = true,
+    suppress_auto_output = true,
+    builtin_path = "crate::builtins::introspection::clearvars"
+)]
+async fn clearvars_builtin(args: Vec<Value>) -> BuiltinResult<Value> {
+    if args.is_empty() {
+        workspace::clear().map_err(clearvars_error)?;
+        return Ok(empty_return_value());
+    }
+
+    let mut words = Vec::new();
+    for arg in &args {
+        collect_clearvars_words(arg, &mut words)?;
+    }
+
+    let mut except = false;
+    let mut names = Vec::new();
+    for (index, word) in words.iter().enumerate() {
+        let name = word.trim();
+        if name.is_empty() {
+            continue;
+        }
+        if name.eq_ignore_ascii_case("-except") {
+            if index != 0 {
+                return Err(clearvars_error(
+                    "clearvars: -except must appear before variable names",
+                ));
+            }
+            except = true;
+            continue;
+        }
+        if name.starts_with('-') {
+            return Err(clearvars_error(format!(
+                "clearvars: unsupported option '{name}'"
+            )));
+        }
+        names.push(name.to_string());
+    }
+
+    if except {
+        if names.is_empty() {
+            return Err(clearvars_error(
+                "clearvars: -except requires at least one variable name",
+            ));
+        }
+        clear_except(&names)?;
+    } else {
+        for name in names {
+            workspace::remove(&name).map_err(clearvars_error)?;
+        }
+    }
+
+    Ok(empty_return_value())
+}
+
+fn clear_except(names: &[String]) -> BuiltinResult<()> {
+    let keep: HashSet<&str> = names.iter().map(String::as_str).collect();
+    let snapshot = workspace::snapshot()
+        .ok_or_else(|| clearvars_error("clearvars: workspace state unavailable"))?;
+    for (name, _) in snapshot {
+        if !keep.contains(name.as_str()) {
+            workspace::remove(&name).map_err(clearvars_error)?;
+        }
+    }
+    Ok(())
+}
+
+fn clearvars_error(message: impl Into<String>) -> crate::RuntimeError {
+    build_runtime_error(message)
+        .with_builtin("clearvars")
+        .build()
+}
+
+fn collect_clearvars_words(arg: &Value, out: &mut Vec<String>) -> BuiltinResult<()> {
+    match arg {
+        Value::String(text) => {
+            out.push(text.trim().to_string());
+            Ok(())
+        }
+        Value::CharArray(chars) => {
+            if chars.rows > 1 {
+                return Err(clearvars_error(
+                    "clearvars: character array inputs must be a row vector or scalar text value",
+                ));
+            }
+            out.push(chars.data.iter().collect::<String>().trim().to_string());
+            Ok(())
+        }
+        Value::StringArray(array) => {
+            for text in &array.data {
+                out.push(text.trim().to_string());
+            }
+            Ok(())
+        }
+        _ => Err(clearvars_error(
+            "clearvars: expected variable names as character vectors or string scalars",
+        )),
+    }
+}
+
+fn empty_return_value() -> Value {
+    Value::Tensor(Tensor::zeros(vec![0, 0]))
+}

--- a/crates/runmat-runtime/src/builtins/introspection/clearvars.rs
+++ b/crates/runmat-runtime/src/builtins/introspection/clearvars.rs
@@ -27,20 +27,19 @@ async fn clearvars_builtin(args: Vec<Value>) -> BuiltinResult<Value> {
         collect_clearvars_words(arg, &mut words)?;
     }
 
-    let mut except = false;
-    let mut names = Vec::new();
-    for (index, word) in words.iter().enumerate() {
+    let mut targets = Vec::new();
+    let mut exclusions = Vec::new();
+    let mut saw_except = false;
+    for word in words.iter() {
         let name = word.trim();
         if name.is_empty() {
             continue;
         }
         if name.eq_ignore_ascii_case("-except") {
-            if index != 0 {
-                return Err(clearvars_error(
-                    "clearvars: -except must appear before variable names",
-                ));
+            if saw_except {
+                return Err(clearvars_error("clearvars: duplicate -except option"));
             }
-            except = true;
+            saw_except = true;
             continue;
         }
         if name.starts_with('-') {
@@ -48,18 +47,22 @@ async fn clearvars_builtin(args: Vec<Value>) -> BuiltinResult<Value> {
                 "clearvars: unsupported option '{name}'"
             )));
         }
-        names.push(name.to_string());
+        if saw_except {
+            exclusions.push(name.to_string());
+        } else {
+            targets.push(name.to_string());
+        }
     }
 
-    if except {
-        if names.is_empty() {
+    if saw_except {
+        if exclusions.is_empty() {
             return Err(clearvars_error(
                 "clearvars: -except requires at least one variable name",
             ));
         }
-        clear_except(&names)?;
+        clear_except(&targets, &exclusions)?;
     } else {
-        for name in names {
+        for name in targets {
             workspace::remove(&name).map_err(clearvars_error)?;
         }
     }
@@ -67,13 +70,21 @@ async fn clearvars_builtin(args: Vec<Value>) -> BuiltinResult<Value> {
     Ok(empty_return_value())
 }
 
-fn clear_except(names: &[String]) -> BuiltinResult<()> {
-    let keep: HashSet<&str> = names.iter().map(String::as_str).collect();
-    let snapshot = workspace::snapshot()
-        .ok_or_else(|| clearvars_error("clearvars: workspace state unavailable"))?;
-    for (name, _) in snapshot {
-        if !keep.contains(name.as_str()) {
-            workspace::remove(&name).map_err(clearvars_error)?;
+fn clear_except(targets: &[String], exclusions: &[String]) -> BuiltinResult<()> {
+    let keep: HashSet<&str> = exclusions.iter().map(String::as_str).collect();
+    if targets.is_empty() {
+        let snapshot = workspace::snapshot()
+            .ok_or_else(|| clearvars_error("clearvars: workspace state unavailable"))?;
+        for (name, _) in snapshot {
+            if !keep.contains(name.as_str()) {
+                workspace::remove(&name).map_err(clearvars_error)?;
+            }
+        }
+    } else {
+        for name in targets {
+            if !keep.contains(name.as_str()) {
+                workspace::remove(name).map_err(clearvars_error)?;
+            }
         }
     }
     Ok(())

--- a/crates/runmat-runtime/src/builtins/introspection/mod.rs
+++ b/crates/runmat-runtime/src/builtins/introspection/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod class;
 pub mod clear;
+pub mod clearvars;
 pub(crate) mod isa;
 pub(crate) mod ischar;
 pub(crate) mod isstring;

--- a/crates/runmat-vm/src/interpreter/dispatch/mod.rs
+++ b/crates/runmat-vm/src/interpreter/dispatch/mod.rs
@@ -250,7 +250,7 @@ pub async fn dispatch_instruction(
         Instr::LoadVar(index) => {
             if call_counts.is_empty() {
                 if let Some(name) = var_names.get(index) {
-                    if matches!(workspace_slot_assigned(*index), Some(false)) {
+                    if !matches!(workspace_slot_assigned(*index), Some(true)) {
                         return Err(crate::interpreter::errors::mex(
                             "UndefinedVariable",
                             &format!("Undefined variable: {name}"),

--- a/crates/runmat-vm/src/interpreter/dispatch/mod.rs
+++ b/crates/runmat-vm/src/interpreter/dispatch/mod.rs
@@ -9,7 +9,9 @@ mod stack;
 
 use crate::bytecode::Instr;
 use crate::interpreter::debug;
-use crate::runtime::workspace::{refresh_workspace_state, workspace_slot_assigned};
+use crate::runtime::workspace::{
+    refresh_workspace_state, workspace_slot_assigned, workspace_state_available,
+};
 use runmat_builtins::Value;
 use runmat_runtime::dispatcher::gather_if_needed_async;
 use runmat_runtime::RuntimeError;
@@ -250,7 +252,9 @@ pub async fn dispatch_instruction(
         Instr::LoadVar(index) => {
             if call_counts.is_empty() {
                 if let Some(name) = var_names.get(index) {
-                    if !matches!(workspace_slot_assigned(*index), Some(true)) {
+                    if workspace_state_available()
+                        && !matches!(workspace_slot_assigned(*index), Some(true))
+                    {
                         return Err(crate::interpreter::errors::mex(
                             "UndefinedVariable",
                             &format!("Undefined variable: {name}"),

--- a/crates/runmat-vm/src/interpreter/dispatch/mod.rs
+++ b/crates/runmat-vm/src/interpreter/dispatch/mod.rs
@@ -9,7 +9,7 @@ mod stack;
 
 use crate::bytecode::Instr;
 use crate::interpreter::debug;
-use crate::runtime::workspace::refresh_workspace_state;
+use crate::runtime::workspace::{refresh_workspace_state, workspace_slot_assigned};
 use runmat_builtins::Value;
 use runmat_runtime::dispatcher::gather_if_needed_async;
 use runmat_runtime::RuntimeError;
@@ -248,6 +248,26 @@ pub async fn dispatch_instruction(
             )))
         }
         Instr::LoadVar(index) => {
+            if call_counts.is_empty() {
+                if let Some(name) = var_names.get(index) {
+                    if matches!(workspace_slot_assigned(*index), Some(false)) {
+                        return Err(crate::interpreter::errors::mex(
+                            "UndefinedVariable",
+                            &format!("Undefined variable: {name}"),
+                        ));
+                    }
+                }
+            }
+            if *index >= vars.len() {
+                let name = var_names
+                    .get(index)
+                    .cloned()
+                    .unwrap_or_else(|| format!("#{index}"));
+                return Err(crate::interpreter::errors::mex(
+                    "UndefinedVariable",
+                    &format!("Undefined variable: {name}"),
+                ));
+            }
             let value = vars[*index].clone();
             debug::trace_load_var(*pc, *index, &value);
             load_var(stack, vars, *index);

--- a/crates/runmat-vm/src/runtime/workspace.rs
+++ b/crates/runmat-vm/src/runtime/workspace.rs
@@ -124,6 +124,10 @@ pub fn workspace_slot_assigned(index: usize) -> Option<bool> {
     })
 }
 
+pub fn workspace_state_available() -> bool {
+    WORKSPACE_STATE.with(|state| state.borrow().is_some())
+}
+
 pub fn workspace_assign(name: &str, value: Value) -> Result<(), String> {
     let vars_ptr = WORKSPACE_VARS.with(|slot| *slot.borrow());
     let Some(vars_ptr) = vars_ptr else {

--- a/crates/runmat-vm/src/runtime/workspace.rs
+++ b/crates/runmat-vm/src/runtime/workspace.rs
@@ -115,6 +115,15 @@ pub fn workspace_lookup(name: &str) -> Option<Value> {
     })
 }
 
+pub fn workspace_slot_assigned(index: usize) -> Option<bool> {
+    WORKSPACE_STATE.with(|state| {
+        let state_ref = state.borrow();
+        let ws = state_ref.as_ref()?;
+        let name = ws.idx_to_name.get(&index)?;
+        Some(ws.assigned.contains(name))
+    })
+}
+
 pub fn workspace_assign(name: &str, value: Value) -> Result<(), String> {
     let vars_ptr = WORKSPACE_VARS.with(|slot| *slot.borrow());
     let Some(vars_ptr) = vars_ptr else {

--- a/crates/runmat-vm/tests/basics.rs
+++ b/crates/runmat-vm/tests/basics.rs
@@ -4,10 +4,11 @@ mod test_helpers;
 use runmat_accelerate::ShapeInfo;
 use runmat_builtins::Value;
 use runmat_parser::parse;
-use runmat_vm::{compile, Instr};
+use runmat_vm::{compile, Bytecode, Instr};
 use std::collections::HashMap;
 use std::convert::TryInto;
 use test_helpers::execute;
+use test_helpers::interpret;
 use test_helpers::lower;
 
 #[test]
@@ -40,6 +41,19 @@ fn call_builtin_multi_output_advances_pc_for_zero_outputs() {
     let vars = execute(&hir).expect("execute disp script");
     let x: f64 = (&vars[0]).try_into().expect("convert x to f64");
     assert_eq!(x, 42.0);
+}
+
+#[test]
+fn direct_interpret_loads_named_slot_without_workspace_state() {
+    let mut bytecode = Bytecode::with_instructions(
+        vec![Instr::LoadConst(7.0), Instr::StoreVar(0), Instr::LoadVar(0)],
+        1,
+    );
+    bytecode.var_names.insert(0, "x".to_string());
+
+    let vars = interpret(&bytecode).expect("direct VM interpret should load x");
+    let x: f64 = (&vars[0]).try_into().unwrap();
+    assert_eq!(x, 7.0);
 }
 
 #[test]

--- a/website/content/builtins-search-index.json
+++ b/website/content/builtins-search-index.json
@@ -440,6 +440,18 @@
     ]
   },
   {
+    "title": "clearvars",
+    "slug": "clearvars",
+    "summary": "Clear variables from the active workspace, with optional exclusions.",
+    "keywords": [
+      "clearvars",
+      "clear variables",
+      "workspace",
+      "variables",
+      "-except"
+    ]
+  },
+  {
     "title": "close",
     "slug": "close",
     "summary": "Close TCP clients or servers that were created by tcpclient, tcpserver, or accept.",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new workspace-mutating builtin and extends command parsing plus VM variable-load error handling; changes to `Instr::LoadVar` undefined-variable checks could affect runtime behavior in edge cases.
> 
> **Overview**
> Adds MATLAB-compatible `clearvars` support, including command-form invocation, function-call forms, and the `-except` option to preserve specified bindings while clearing others.
> 
> Updates the command-syntax parser to treat dash-options (currently only for `clearvars`) as stringified arguments (e.g. `-except`), and extends tests to cover `clearvars` behavior and mixed command sequences.
> 
> Tightens VM `LoadVar` handling to error immediately for workspace slots that are known-but-unassigned after workspace mutations, introducing new workspace-state helpers and a regression test for direct bytecode interpretation without workspace state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d829a0f8144010bc61f21fe09fdf11584b3f63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->