### PR TITLE
Add heatmap plot support

### DIFF
--- a/crates/runmat-plot/src/core/plot_renderer.rs
+++ b/crates/runmat-plot/src/core/plot_renderer.rs
@@ -2790,6 +2790,18 @@ impl PlotRenderer {
             .and_then(|f| f.categorical_axis_labels_for_axes(axes_index))
     }
 
+    pub fn overlay_x_tick_labels_for_axes(&self, axes_index: usize) -> Option<Vec<String>> {
+        self.last_figure
+            .as_ref()
+            .and_then(|f| f.x_axis_tick_labels_for_axes(axes_index))
+    }
+
+    pub fn overlay_y_tick_labels_for_axes(&self, axes_index: usize) -> Option<Vec<String>> {
+        self.last_figure
+            .as_ref()
+            .and_then(|f| f.y_axis_tick_labels_for_axes(axes_index))
+    }
+
     pub fn overlay_histogram_edges_for_axes(&self, axes_index: usize) -> Option<(bool, Vec<f64>)> {
         self.last_figure
             .as_ref()

--- a/crates/runmat-plot/src/event.rs
+++ b/crates/runmat-plot/src/event.rs
@@ -553,6 +553,10 @@ pub struct SerializedAxesMetadata {
     pub y_label: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub z_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub x_tick_labels: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub y_tick_labels: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub x_limits: Option<[f64; 2]>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -603,6 +607,8 @@ impl From<AxesMetadata> for SerializedAxesMetadata {
             x_label: value.x_label,
             y_label: value.y_label,
             z_label: value.z_label,
+            x_tick_labels: value.x_tick_labels,
+            y_tick_labels: value.y_tick_labels,
             x_limits: value.x_limits.map(|(a, b)| [a, b]),
             y_limits: value.y_limits.map(|(a, b)| [a, b]),
             z_limits: value.z_limits.map(|(a, b)| [a, b]),
@@ -638,6 +644,8 @@ impl From<SerializedAxesMetadata> for AxesMetadata {
             x_label: value.x_label,
             y_label: value.y_label,
             z_label: value.z_label,
+            x_tick_labels: value.x_tick_labels,
+            y_tick_labels: value.y_tick_labels,
             x_limits: value.x_limits.map(|[a, b]| (a, b)),
             y_limits: value.y_limits.map(|[a, b]| (a, b)),
             z_limits: value.z_limits.map(|[a, b]| (a, b)),

--- a/crates/runmat-plot/src/gui/plot_overlay.rs
+++ b/crates/runmat-plot/src/gui/plot_overlay.rs
@@ -1580,6 +1580,76 @@ impl PlotOverlay {
                     &edges,
                 );
             }
+            if let Some(labels) = axes_index.and_then(|idx| {
+                plot_renderer
+                    .overlay_x_tick_labels_for_axes(idx)
+                    .filter(|labels| !labels.is_empty())
+            }) {
+                cat_x = true;
+                let stride = Self::label_stride(&labels, plot_rect.width(), tick_font.size);
+                for (label_idx, label) in labels.iter().enumerate() {
+                    if label_idx != 0 && label_idx != labels.len() - 1 && label_idx % stride != 0 {
+                        continue;
+                    }
+                    let x_val = (label_idx + 1) as f64;
+                    if x_val < x_min || x_val > x_max {
+                        continue;
+                    }
+                    let x_screen =
+                        plot_rect.min.x + ((x_val - x_min) / x_range) as f32 * plot_rect.width();
+                    let x_screen = Self::snap_coord(x_screen, ppp);
+                    ui.painter().line_segment(
+                        [
+                            Pos2::new(x_screen, border_bottom),
+                            Pos2::new(x_screen, border_bottom + tick_length),
+                        ],
+                        Stroke::new(1.0, axis_color),
+                    );
+                    let text = truncate_label(label, 14);
+                    ui.painter().text(
+                        Pos2::new(x_screen, border_bottom + label_offset),
+                        Align2::CENTER_CENTER,
+                        text,
+                        tick_font.clone(),
+                        label_color,
+                    );
+                }
+            }
+            if let Some(labels) = axes_index.and_then(|idx| {
+                plot_renderer
+                    .overlay_y_tick_labels_for_axes(idx)
+                    .filter(|labels| !labels.is_empty())
+            }) {
+                cat_y = true;
+                let stride = Self::label_stride(&labels, plot_rect.height(), tick_font.size);
+                for (label_idx, label) in labels.iter().enumerate() {
+                    if label_idx != 0 && label_idx != labels.len() - 1 && label_idx % stride != 0 {
+                        continue;
+                    }
+                    let y_val = (label_idx + 1) as f64;
+                    if y_val < y_min || y_val > y_max {
+                        continue;
+                    }
+                    let y_screen =
+                        plot_rect.max.y - ((y_val - y_min) / y_range) as f32 * plot_rect.height();
+                    let y_screen = Self::snap_coord(y_screen, ppp);
+                    ui.painter().line_segment(
+                        [
+                            Pos2::new(border_left - tick_length, y_screen),
+                            Pos2::new(border_left, y_screen),
+                        ],
+                        Stroke::new(1.0, axis_color),
+                    );
+                    let text = truncate_label(label, 14);
+                    ui.painter().text(
+                        Pos2::new(border_left - label_offset, y_screen),
+                        Align2::CENTER_CENTER,
+                        text,
+                        tick_font.clone(),
+                        label_color,
+                    );
+                }
+            }
             if let Some((is_x, labels)) = axes_index
                 .and_then(|idx| plot_renderer.overlay_categorical_labels_for_axes(idx))
                 .or_else(|| {
@@ -1588,12 +1658,10 @@ impl PlotOverlay {
                         .map(|(is_x, labels)| (is_x, labels.clone()))
                 })
             {
-                if is_x {
+                if (is_x && cat_x) || (!is_x && cat_y) {
+                    // Explicit axes tick labels take precedence over inferred bar labels.
+                } else if is_x {
                     cat_x = true;
-                } else {
-                    cat_y = true;
-                }
-                if is_x {
                     let stride = Self::label_stride(&labels, plot_rect.width(), tick_font.size);
                     // Draw X categorical labels at integer positions (1..n)
                     for (label_idx, label) in labels.iter().enumerate() {
@@ -1629,6 +1697,7 @@ impl PlotOverlay {
                         );
                     }
                 } else {
+                    cat_y = true;
                     let stride = Self::label_stride(&labels, plot_rect.height(), tick_font.size);
                     // Draw Y categorical labels at integer positions (1..n)
                     for (label_idx, label) in labels.iter().enumerate() {

--- a/crates/runmat-plot/src/plots/figure.rs
+++ b/crates/runmat-plot/src/plots/figure.rs
@@ -125,6 +125,8 @@ pub struct AxesMetadata {
     pub x_label: Option<String>,
     pub y_label: Option<String>,
     pub z_label: Option<String>,
+    pub x_tick_labels: Option<Vec<String>>,
+    pub y_tick_labels: Option<Vec<String>>,
     pub x_limits: Option<(f64, f64)>,
     pub y_limits: Option<(f64, f64)>,
     pub z_limits: Option<(f64, f64)>,
@@ -497,6 +499,20 @@ impl Figure {
         }
         if axes_index == self.active_axes_index {
             self.sync_legacy_fields_from_active_axes();
+        }
+        self.dirty = true;
+    }
+
+    pub fn set_axes_tick_labels(
+        &mut self,
+        axes_index: usize,
+        x_labels: Option<Vec<String>>,
+        y_labels: Option<Vec<String>>,
+    ) {
+        self.ensure_axes_metadata_capacity(axes_index + 1);
+        if let Some(meta) = self.axes_metadata.get_mut(axes_index) {
+            meta.x_tick_labels = x_labels;
+            meta.y_tick_labels = y_labels;
         }
         self.dirty = true;
     }
@@ -1338,6 +1354,18 @@ impl Figure {
             }
         }
         None
+    }
+
+    pub fn x_axis_tick_labels_for_axes(&self, axes_index: usize) -> Option<Vec<String>> {
+        self.axes_metadata
+            .get(axes_index)
+            .and_then(|meta| meta.x_tick_labels.clone())
+    }
+
+    pub fn y_axis_tick_labels_for_axes(&self, axes_index: usize) -> Option<Vec<String>> {
+        self.axes_metadata
+            .get(axes_index)
+            .and_then(|meta| meta.y_tick_labels.clone())
     }
 
     pub fn histogram_axis_edges_for_axes(&self, axes_index: usize) -> Option<(bool, Vec<f64>)> {

--- a/crates/runmat-runtime/src/builtins/builtins-json/heatmap.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/heatmap.json
@@ -1,0 +1,77 @@
+{
+  "title": "heatmap",
+  "category": "plotting",
+  "keywords": [
+    "heatmap",
+    "HeatmapChart",
+    "matrix visualization",
+    "colormap",
+    "plotting"
+  ],
+  "summary": "Create heatmap charts from matrix data with optional row and column labels.",
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [
+      "single",
+      "double"
+    ],
+    "broadcasting": "none",
+    "notes": "`heatmap` is a plotting sink. Inputs are gathered to build labeled chart state, then rendered through the scaled-image surface path."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 3,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::plotting::heatmap::tests"
+  },
+  "description": "`heatmap` creates a heatmap-style chart from numeric matrix data. RunMat supports `heatmap(CData)` and `heatmap(XValues, YValues, CData)`, returns a heatmap graphics handle, and supports common chart properties such as `Title`, `XLabel`, `YLabel`, `ColorbarVisible`, and `Colormap` through `get`, `set`, and dot-property assignment.",
+  "behaviors": [
+    "`heatmap(CData)` displays matrix values using default row and column labels.",
+    "`heatmap(XValues, YValues, CData)` uses text, string-array, cell-array, or numeric labels for the displayed columns and rows.",
+    "The returned heatmap handle participates in RunMat's plotting property system.",
+    "Color rendering uses the shared scaled-image and colormap path."
+  ],
+  "examples": [
+    {
+      "description": "Create a labeled heatmap chart",
+      "input": "cdata = [45 60 32; 43 54 76; 32 94 68; 23 95 58];\nxvalues = {'Small','Medium','Large'};\nyvalues = {'Green','Red','Blue','Gray'};\nh = heatmap(xvalues,yvalues,cdata);\nh.Title = 'T-Shirt Orders';\nh.XLabel = 'Sizes';\nh.YLabel = 'Colors';"
+    },
+    {
+      "description": "Create a heatmap from matrix data",
+      "input": "A = magic(5);\nh = heatmap(A);\nh.Colormap = 'hot';\nh.ColorbarVisible = true;"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Does heatmap support table inputs?",
+      "answer": "Not yet. RunMat currently supports matrix CData inputs with optional row and column labels. Table-based MATLAB signatures will be added once table values are represented in the runtime."
+    }
+  ],
+  "links": [
+    {
+      "label": "imagesc",
+      "url": "./imagesc"
+    },
+    {
+      "label": "colormap",
+      "url": "./colormap"
+    },
+    {
+      "label": "colorbar",
+      "url": "./colorbar"
+    },
+    {
+      "label": "Styling plots and axes",
+      "url": "/docs/plotting/styling-plots-and-axes"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/plotting/ops/heatmap.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/plotting/ops/heatmap.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/plotting/core/properties.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/core/properties.rs
@@ -2578,18 +2578,12 @@ fn apply_heatmap_property(
                     format!("{builtin}: XDisplayLabels length must match heatmap columns"),
                 ));
             }
-            super::state::set_tick_labels_for_axes(
-                heatmap_handle.figure,
-                heatmap_handle.axes_index,
-                Some(labels.clone()),
-                Some(heatmap_handle.y_labels.clone()),
-            )
-            .map_err(|err| map_figure_error(builtin, err))?;
-            super::state::update_heatmap_handle(
+            super::state::set_heatmap_display_labels(
                 heatmap_handle.figure,
                 heatmap_handle.axes_index,
                 heatmap_handle.plot_index,
-                |state| state.x_labels = labels,
+                Some(labels),
+                None,
             )
             .map_err(|err| map_figure_error(builtin, err))
         }
@@ -2601,18 +2595,12 @@ fn apply_heatmap_property(
                     format!("{builtin}: YDisplayLabels length must match heatmap rows"),
                 ));
             }
-            super::state::set_tick_labels_for_axes(
-                heatmap_handle.figure,
-                heatmap_handle.axes_index,
-                Some(heatmap_handle.x_labels.clone()),
-                Some(labels.clone()),
-            )
-            .map_err(|err| map_figure_error(builtin, err))?;
-            super::state::update_heatmap_handle(
+            super::state::set_heatmap_display_labels(
                 heatmap_handle.figure,
                 heatmap_handle.axes_index,
                 heatmap_handle.plot_index,
-                |state| state.y_labels = labels,
+                None,
+                Some(labels),
             )
             .map_err(|err| map_figure_error(builtin, err))
         }

--- a/crates/runmat-runtime/src/builtins/plotting/core/properties.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/core/properties.rs
@@ -178,6 +178,67 @@ pub fn parse_text_style_pairs(builtin: &'static str, args: &[Value]) -> BuiltinR
     Ok(style)
 }
 
+pub fn validate_heatmap_property_pairs(
+    args: &[Value],
+    x_label_len: usize,
+    y_label_len: usize,
+    builtin: &'static str,
+) -> BuiltinResult<()> {
+    if args.is_empty() {
+        return Ok(());
+    }
+    if !args.len().is_multiple_of(2) {
+        return Err(plotting_error(
+            builtin,
+            format!("{builtin}: property/value arguments must come in pairs"),
+        ));
+    }
+    for pair in args.chunks_exact(2) {
+        let key = property_name(&pair[0], builtin)?;
+        match key.as_str() {
+            "title" => validate_axes_text_alias(PlotObjectKind::Title, &pair[1], builtin)?,
+            "xlabel" => validate_axes_text_alias(PlotObjectKind::XLabel, &pair[1], builtin)?,
+            "ylabel" => validate_axes_text_alias(PlotObjectKind::YLabel, &pair[1], builtin)?,
+            "colorbar" | "colorbarvisible" => {
+                value_as_bool(&pair[1]).ok_or_else(|| {
+                    plotting_error(builtin, format!("{builtin}: Colorbar must be logical"))
+                })?;
+            }
+            "colormap" => {
+                let name = value_as_string(&pair[1]).ok_or_else(|| {
+                    plotting_error(builtin, format!("{builtin}: Colormap must be a string"))
+                })?;
+                parse_colormap_name(&name, builtin)?;
+            }
+            "xdisplaylabels" => {
+                let labels = string_labels_from_value(&pair[1], builtin)?;
+                if labels.len() != x_label_len {
+                    return Err(plotting_error(
+                        builtin,
+                        format!("{builtin}: XDisplayLabels length must match heatmap columns"),
+                    ));
+                }
+            }
+            "ydisplaylabels" => {
+                let labels = string_labels_from_value(&pair[1], builtin)?;
+                if labels.len() != y_label_len {
+                    return Err(plotting_error(
+                        builtin,
+                        format!("{builtin}: YDisplayLabels length must match heatmap rows"),
+                    ));
+                }
+            }
+            other => {
+                return Err(plotting_error(
+                    builtin,
+                    format!("{builtin}: unsupported heatmap property `{other}`"),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 pub fn split_legend_style_pairs<'a>(
     builtin: &'static str,
     args: &'a [Value],
@@ -2986,6 +3047,31 @@ fn apply_axes_text_alias(
     };
     set_text_properties_for_axes(handle, axes_index, kind, text, Some(style))
         .map_err(|err| map_figure_error(builtin, err))?;
+    Ok(())
+}
+
+fn validate_axes_text_alias(
+    kind: PlotObjectKind,
+    value: &Value,
+    builtin: &'static str,
+) -> BuiltinResult<()> {
+    if value_as_string(value).is_some() {
+        return Ok(());
+    }
+
+    let scalar = handle_scalar(value, builtin)?;
+    let (src_handle, src_axes, src_kind) =
+        decode_plot_object_handle(scalar).map_err(|err| map_figure_error(builtin, err))?;
+    if src_kind != kind {
+        return Err(plotting_error(
+            builtin,
+            format!(
+                "{builtin}: expected a matching text handle for `{}`",
+                key_name(kind)
+            ),
+        ));
+    }
+    axes_metadata_snapshot(src_handle, src_axes).map_err(|err| map_figure_error(builtin, err))?;
     Ok(())
 }
 

--- a/crates/runmat-runtime/src/builtins/plotting/core/properties.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/core/properties.rs
@@ -211,7 +211,7 @@ pub fn validate_heatmap_property_pairs(
                 parse_colormap_name(&name, builtin)?;
             }
             "xdisplaylabels" => {
-                let labels = string_labels_from_value(&pair[1], builtin)?;
+                let labels = label_strings_from_value(&pair[1], builtin, "labels")?;
                 if labels.len() != x_label_len {
                     return Err(plotting_error(
                         builtin,
@@ -220,7 +220,7 @@ pub fn validate_heatmap_property_pairs(
                 }
             }
             "ydisplaylabels" => {
-                let labels = string_labels_from_value(&pair[1], builtin)?;
+                let labels = label_strings_from_value(&pair[1], builtin, "labels")?;
                 if labels.len() != y_label_len {
                     return Err(plotting_error(
                         builtin,
@@ -2571,7 +2571,7 @@ fn apply_heatmap_property(
             builtin,
         ),
         "xdisplaylabels" => {
-            let labels = string_labels_from_value(value, builtin)?;
+            let labels = label_strings_from_value(value, builtin, "labels")?;
             if labels.len() != heatmap_handle.x_labels.len() {
                 return Err(plotting_error(
                     builtin,
@@ -2588,7 +2588,7 @@ fn apply_heatmap_property(
             .map_err(|err| map_figure_error(builtin, err))
         }
         "ydisplaylabels" => {
-            let labels = string_labels_from_value(value, builtin)?;
+            let labels = label_strings_from_value(value, builtin, "labels")?;
             if labels.len() != heatmap_handle.y_labels.len() {
                 return Err(plotting_error(
                     builtin,
@@ -3207,7 +3207,11 @@ fn string_array_from_vec(data: Vec<String>) -> BuiltinResult<Value> {
     Ok(Value::StringArray(array))
 }
 
-fn string_labels_from_value(value: &Value, builtin: &'static str) -> BuiltinResult<Vec<String>> {
+pub(crate) fn label_strings_from_value(
+    value: &Value,
+    builtin: &'static str,
+    label_context: &str,
+) -> BuiltinResult<Vec<String>> {
     match value {
         Value::StringArray(array) => Ok(array.data.clone()),
         Value::Cell(cell) => cell
@@ -3217,7 +3221,7 @@ fn string_labels_from_value(value: &Value, builtin: &'static str) -> BuiltinResu
                 value_as_text_string(item).ok_or_else(|| {
                     plotting_error(
                         builtin,
-                        format!("{builtin}: labels must contain text values"),
+                        format!("{builtin}: {label_context} must contain text values"),
                     )
                 })
             })
@@ -3225,9 +3229,11 @@ fn string_labels_from_value(value: &Value, builtin: &'static str) -> BuiltinResu
         Value::CharArray(chars) if chars.rows == 1 => Ok(vec![chars.data.iter().collect()]),
         Value::String(text) => Ok(vec![text.clone()]),
         Value::Tensor(tensor) => Ok(tensor.data.iter().map(|v| v.to_string()).collect()),
+        Value::Int(i) => Ok(vec![i.to_i64().to_string()]),
+        Value::Num(v) => Ok(vec![v.to_string()]),
         other => Err(plotting_error(
             builtin,
-            format!("{builtin}: unsupported label value {other:?}"),
+            format!("{builtin}: unsupported {label_context} value {other:?}"),
         )),
     }
 }

--- a/crates/runmat-runtime/src/builtins/plotting/core/properties.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/core/properties.rs
@@ -2578,6 +2578,13 @@ fn apply_heatmap_property(
                     format!("{builtin}: XDisplayLabels length must match heatmap columns"),
                 ));
             }
+            super::state::set_tick_labels_for_axes(
+                heatmap_handle.figure,
+                heatmap_handle.axes_index,
+                Some(labels.clone()),
+                Some(heatmap_handle.y_labels.clone()),
+            )
+            .map_err(|err| map_figure_error(builtin, err))?;
             super::state::update_heatmap_handle(
                 heatmap_handle.figure,
                 heatmap_handle.axes_index,
@@ -2594,6 +2601,13 @@ fn apply_heatmap_property(
                     format!("{builtin}: YDisplayLabels length must match heatmap rows"),
                 ));
             }
+            super::state::set_tick_labels_for_axes(
+                heatmap_handle.figure,
+                heatmap_handle.axes_index,
+                Some(heatmap_handle.x_labels.clone()),
+                Some(labels.clone()),
+            )
+            .map_err(|err| map_figure_error(builtin, err))?;
             super::state::update_heatmap_handle(
                 heatmap_handle.figure,
                 heatmap_handle.axes_index,

--- a/crates/runmat-runtime/src/builtins/plotting/core/properties.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/core/properties.rs
@@ -696,7 +696,11 @@ fn canonical_property_name(name: &str) -> &str {
         "grid" => "grid",
         "axisequal" => "axisequal",
         "colorbar" => "colorbar",
+        "colorbarvisible" => "colorbarvisible",
         "colormap" => "colormap",
+        "xdisplaylabels" => "xdisplaylabels",
+        "ydisplaylabels" => "ydisplaylabels",
+        "colordata" | "cdata" => "colordata",
         "xlim" => "xlim",
         "ylim" => "ylim",
         "zlim" => "zlim",
@@ -1111,6 +1115,9 @@ fn get_plot_child_property(
         super::state::PlotChildHandleState::Image(image) => {
             get_image_property(image, property, builtin)
         }
+        super::state::PlotChildHandleState::Heatmap(heatmap) => {
+            get_heatmap_property(heatmap, property, builtin)
+        }
         super::state::PlotChildHandleState::Area(area) => {
             get_area_property(area, property, builtin)
         }
@@ -1169,6 +1176,9 @@ fn apply_plot_child_property(
         }
         super::state::PlotChildHandleState::Image(image) => {
             apply_image_property(image, key, value, builtin)
+        }
+        super::state::PlotChildHandleState::Heatmap(heatmap) => {
+            apply_heatmap_property(heatmap, key, value, builtin)
         }
         super::state::PlotChildHandleState::Area(area) => {
             apply_area_property(area, key, value, builtin)
@@ -2079,6 +2089,98 @@ fn get_image_property(
     }
 }
 
+fn get_heatmap_property(
+    heatmap_handle: &super::state::HeatmapHandleState,
+    property: Option<&str>,
+    builtin: &'static str,
+) -> BuiltinResult<Value> {
+    let figure = super::state::clone_figure(heatmap_handle.figure)
+        .ok_or_else(|| plotting_error(builtin, format!("{builtin}: invalid heatmap figure")))?;
+    let plot = figure
+        .plots()
+        .nth(heatmap_handle.plot_index)
+        .ok_or_else(|| plotting_error(builtin, format!("{builtin}: invalid heatmap handle")))?;
+    let runmat_plot::plots::figure::PlotElement::Surface(surface) = plot else {
+        return Err(plotting_error(
+            builtin,
+            format!("{builtin}: invalid heatmap handle"),
+        ));
+    };
+    if !surface.image_mode {
+        return Err(plotting_error(
+            builtin,
+            format!("{builtin}: handle does not reference a heatmap plot"),
+        ));
+    }
+    let meta = figure
+        .axes_metadata(heatmap_handle.axes_index)
+        .ok_or_else(|| plotting_error(builtin, format!("{builtin}: invalid heatmap axes")))?;
+    match property.map(canonical_property_name) {
+        None => {
+            let mut st = StructValue::new();
+            st.insert("Type", Value::String("heatmap".into()));
+            st.insert(
+                "Parent",
+                Value::Num(super::state::encode_axes_handle(
+                    heatmap_handle.figure,
+                    heatmap_handle.axes_index,
+                )),
+            );
+            st.insert("Children", handles_value(Vec::new()));
+            st.insert(
+                "Title",
+                Value::String(meta.title.clone().unwrap_or_default()),
+            );
+            st.insert(
+                "XLabel",
+                Value::String(meta.x_label.clone().unwrap_or_default()),
+            );
+            st.insert(
+                "YLabel",
+                Value::String(meta.y_label.clone().unwrap_or_default()),
+            );
+            st.insert(
+                "XDisplayLabels",
+                string_array_from_vec(heatmap_handle.x_labels.clone())?,
+            );
+            st.insert(
+                "YDisplayLabels",
+                string_array_from_vec(heatmap_handle.y_labels.clone())?,
+            );
+            st.insert(
+                "ColorData",
+                Value::Tensor(heatmap_handle.color_data.clone()),
+            );
+            st.insert("ColorbarVisible", Value::Bool(meta.colorbar_enabled));
+            st.insert(
+                "Colormap",
+                Value::String(format!("{:?}", meta.colormap).to_ascii_lowercase()),
+            );
+            Ok(Value::Struct(st))
+        }
+        Some("type") => Ok(Value::String("heatmap".into())),
+        Some("parent") => Ok(Value::Num(super::state::encode_axes_handle(
+            heatmap_handle.figure,
+            heatmap_handle.axes_index,
+        ))),
+        Some("children") => Ok(handles_value(Vec::new())),
+        Some("title") => Ok(Value::String(meta.title.clone().unwrap_or_default())),
+        Some("xlabel") => Ok(Value::String(meta.x_label.clone().unwrap_or_default())),
+        Some("ylabel") => Ok(Value::String(meta.y_label.clone().unwrap_or_default())),
+        Some("xdisplaylabels") => string_array_from_vec(heatmap_handle.x_labels.clone()),
+        Some("ydisplaylabels") => string_array_from_vec(heatmap_handle.y_labels.clone()),
+        Some("colordata") => Ok(Value::Tensor(heatmap_handle.color_data.clone())),
+        Some("colorbarvisible") | Some("colorbar") => Ok(Value::Bool(meta.colorbar_enabled)),
+        Some("colormap") => Ok(Value::String(
+            format!("{:?}", meta.colormap).to_ascii_lowercase(),
+        )),
+        Some(other) => Err(plotting_error(
+            builtin,
+            format!("{builtin}: unsupported heatmap property `{other}`"),
+        )),
+    }
+}
+
 fn get_area_property(
     area_handle: &super::state::AreaHandleState,
     property: Option<&str>,
@@ -2363,6 +2465,87 @@ fn apply_image_property(
     })
     .map_err(|err| map_figure_error(builtin, err))?;
     Ok(())
+}
+
+fn apply_heatmap_property(
+    heatmap_handle: &super::state::HeatmapHandleState,
+    key: &str,
+    value: &Value,
+    builtin: &'static str,
+) -> BuiltinResult<()> {
+    match key {
+        "title" => apply_axes_property(
+            heatmap_handle.figure,
+            heatmap_handle.axes_index,
+            "title",
+            value,
+            builtin,
+        ),
+        "xlabel" => apply_axes_property(
+            heatmap_handle.figure,
+            heatmap_handle.axes_index,
+            "xlabel",
+            value,
+            builtin,
+        ),
+        "ylabel" => apply_axes_property(
+            heatmap_handle.figure,
+            heatmap_handle.axes_index,
+            "ylabel",
+            value,
+            builtin,
+        ),
+        "colorbar" | "colorbarvisible" => apply_axes_property(
+            heatmap_handle.figure,
+            heatmap_handle.axes_index,
+            "colorbar",
+            value,
+            builtin,
+        ),
+        "colormap" => apply_axes_property(
+            heatmap_handle.figure,
+            heatmap_handle.axes_index,
+            "colormap",
+            value,
+            builtin,
+        ),
+        "xdisplaylabels" => {
+            let labels = string_labels_from_value(value, builtin)?;
+            if labels.len() != heatmap_handle.x_labels.len() {
+                return Err(plotting_error(
+                    builtin,
+                    format!("{builtin}: XDisplayLabels length must match heatmap columns"),
+                ));
+            }
+            super::state::update_heatmap_handle(
+                heatmap_handle.figure,
+                heatmap_handle.axes_index,
+                heatmap_handle.plot_index,
+                |state| state.x_labels = labels,
+            )
+            .map_err(|err| map_figure_error(builtin, err))
+        }
+        "ydisplaylabels" => {
+            let labels = string_labels_from_value(value, builtin)?;
+            if labels.len() != heatmap_handle.y_labels.len() {
+                return Err(plotting_error(
+                    builtin,
+                    format!("{builtin}: YDisplayLabels length must match heatmap rows"),
+                ));
+            }
+            super::state::update_heatmap_handle(
+                heatmap_handle.figure,
+                heatmap_handle.axes_index,
+                heatmap_handle.plot_index,
+                |state| state.y_labels = labels,
+            )
+            .map_err(|err| map_figure_error(builtin, err))
+        }
+        other => Err(plotting_error(
+            builtin,
+            format!("{builtin}: unsupported heatmap property `{other}`"),
+        )),
+    }
 }
 
 fn apply_area_property(
@@ -2927,6 +3110,38 @@ fn tensor_from_vec(data: Vec<f64>) -> Value {
         data,
         dtype: runmat_builtins::NumericDType::F64,
     })
+}
+
+fn string_array_from_vec(data: Vec<String>) -> BuiltinResult<Value> {
+    let cols = data.len();
+    let array = StringArray::new(data, vec![1, cols])
+        .map_err(|e| plotting_error("get", format!("get: {e}")))?;
+    Ok(Value::StringArray(array))
+}
+
+fn string_labels_from_value(value: &Value, builtin: &'static str) -> BuiltinResult<Vec<String>> {
+    match value {
+        Value::StringArray(array) => Ok(array.data.clone()),
+        Value::Cell(cell) => cell
+            .data
+            .iter()
+            .map(|item| {
+                value_as_text_string(item).ok_or_else(|| {
+                    plotting_error(
+                        builtin,
+                        format!("{builtin}: labels must contain text values"),
+                    )
+                })
+            })
+            .collect(),
+        Value::CharArray(chars) if chars.rows == 1 => Ok(vec![chars.data.iter().collect()]),
+        Value::String(text) => Ok(vec![text.clone()]),
+        Value::Tensor(tensor) => Ok(tensor.data.iter().map(|v| v.to_string()).collect()),
+        other => Err(plotting_error(
+            builtin,
+            format!("{builtin}: unsupported label value {other:?}"),
+        )),
+    }
 }
 
 fn tensor_from_matrix(data: Vec<Vec<f64>>) -> Value {

--- a/crates/runmat-runtime/src/builtins/plotting/core/state.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/core/state.rs
@@ -896,21 +896,6 @@ pub fn set_colorbar_enabled_for_axes(
     Ok(())
 }
 
-pub fn set_tick_labels_for_axes(
-    handle: FigureHandle,
-    axes_index: usize,
-    x_labels: Option<Vec<String>>,
-    y_labels: Option<Vec<String>>,
-) -> Result<(), FigureError> {
-    let ((), figure_clone) = with_axes_target_mut(handle, axes_index, |state| {
-        state
-            .figure
-            .set_axes_tick_labels(axes_index, x_labels, y_labels);
-    })?;
-    notify_with_figure(handle, &figure_clone, FigureEventKind::Updated);
-    Ok(())
-}
-
 pub fn set_legend_for_axes(
     handle: FigureHandle,
     axes_index: usize,
@@ -1359,28 +1344,59 @@ pub fn plot_child_handle_snapshot(handle: f64) -> Result<PlotChildHandleState, F
         .ok_or(FigureError::InvalidPlotObjectHandle)
 }
 
-pub fn update_heatmap_handle(
+pub fn set_heatmap_display_labels(
     figure: FigureHandle,
     axes_index: usize,
     plot_index: usize,
-    updater: impl FnOnce(&mut HeatmapHandleState),
+    x_labels: Option<Vec<String>>,
+    y_labels: Option<Vec<String>>,
 ) -> Result<(), FigureError> {
-    let mut reg = registry();
-    let state = reg.plot_children.values_mut().find(|state| match state {
-        PlotChildHandleState::Heatmap(heatmap) => {
-            heatmap.figure == figure
-                && heatmap.axes_index == axes_index
-                && heatmap.plot_index == plot_index
+    let figure_clone = {
+        let mut reg = registry();
+        let (current_x_labels, current_y_labels) = {
+            let state = reg.plot_children.values_mut().find(|state| match state {
+                PlotChildHandleState::Heatmap(heatmap) => {
+                    heatmap.figure == figure
+                        && heatmap.axes_index == axes_index
+                        && heatmap.plot_index == plot_index
+                }
+                _ => false,
+            });
+            let PlotChildHandleState::Heatmap(heatmap) =
+                state.ok_or(FigureError::InvalidPlotObjectHandle)?
+            else {
+                return Err(FigureError::InvalidPlotObjectHandle);
+            };
+            if let Some(labels) = x_labels {
+                heatmap.x_labels = labels;
+            }
+            if let Some(labels) = y_labels {
+                heatmap.y_labels = labels;
+            }
+            (heatmap.x_labels.clone(), heatmap.y_labels.clone())
+        };
+
+        let state = get_state_mut(&mut reg, figure);
+        let total_axes = state.figure.axes_rows.max(1) * state.figure.axes_cols.max(1);
+        if axes_index >= total_axes {
+            return Err(FigureError::InvalidSubplotIndex {
+                rows: state.figure.axes_rows.max(1),
+                cols: state.figure.axes_cols.max(1),
+                index: axes_index,
+            });
         }
-        _ => false,
-    });
-    match state.ok_or(FigureError::InvalidPlotObjectHandle)? {
-        PlotChildHandleState::Heatmap(heatmap) => {
-            updater(heatmap);
-            Ok(())
-        }
-        _ => Err(FigureError::InvalidPlotObjectHandle),
-    }
+        state.active_axes = axes_index;
+        state.figure.set_active_axes_index(axes_index);
+        state.figure.set_axes_tick_labels(
+            axes_index,
+            Some(current_x_labels),
+            Some(current_y_labels),
+        );
+        state.revision = state.revision.wrapping_add(1);
+        state.figure.clone()
+    };
+    notify_with_figure(figure, &figure_clone, FigureEventKind::Updated);
+    Ok(())
 }
 
 pub fn update_histogram_handle_for_plot(

--- a/crates/runmat-runtime/src/builtins/plotting/core/state.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/core/state.rs
@@ -1,4 +1,5 @@
 use once_cell::sync::OnceCell;
+use runmat_builtins::Tensor;
 use runmat_plot::plots::{
     surface::ColorMap, surface::ShadingMode, Figure, LegendStyle, LineStyle, PlotElement, TextStyle,
 };
@@ -235,6 +236,16 @@ pub struct ImageHandleState {
 }
 
 #[derive(Clone, Debug)]
+pub struct HeatmapHandleState {
+    pub figure: FigureHandle,
+    pub axes_index: usize,
+    pub plot_index: usize,
+    pub x_labels: Vec<String>,
+    pub y_labels: Vec<String>,
+    pub color_data: Tensor,
+}
+
+#[derive(Clone, Debug)]
 pub struct AreaHandleState {
     pub figure: FigureHandle,
     pub axes_index: usize,
@@ -259,6 +270,7 @@ pub enum PlotChildHandleState {
     Stairs(SimplePlotHandleState),
     Quiver(QuiverHandleState),
     Image(ImageHandleState),
+    Heatmap(HeatmapHandleState),
     Area(AreaHandleState),
     Surface(SimplePlotHandleState),
     Line3(SimplePlotHandleState),
@@ -1219,6 +1231,31 @@ pub fn register_image_handle(figure: FigureHandle, axes_index: usize, plot_index
     })
 }
 
+pub fn register_heatmap_handle(
+    figure: FigureHandle,
+    axes_index: usize,
+    plot_index: usize,
+    x_labels: Vec<String>,
+    y_labels: Vec<String>,
+    color_data: Tensor,
+) -> f64 {
+    let mut reg = registry();
+    let id = reg.next_plot_child_handle;
+    reg.next_plot_child_handle += 1;
+    reg.plot_children.insert(
+        id,
+        PlotChildHandleState::Heatmap(HeatmapHandleState {
+            figure,
+            axes_index,
+            plot_index,
+            x_labels,
+            y_labels,
+            color_data,
+        }),
+    );
+    id as f64
+}
+
 pub fn register_area_handle(figure: FigureHandle, axes_index: usize, plot_index: usize) -> f64 {
     register_simple_plot_handle(figure, axes_index, plot_index, |state| {
         PlotChildHandleState::Area(AreaHandleState {
@@ -1305,6 +1342,30 @@ pub fn plot_child_handle_snapshot(handle: f64) -> Result<PlotChildHandleState, F
         .get(&(handle.round() as u64))
         .cloned()
         .ok_or(FigureError::InvalidPlotObjectHandle)
+}
+
+pub fn update_heatmap_handle(
+    figure: FigureHandle,
+    axes_index: usize,
+    plot_index: usize,
+    updater: impl FnOnce(&mut HeatmapHandleState),
+) -> Result<(), FigureError> {
+    let mut reg = registry();
+    let state = reg.plot_children.values_mut().find(|state| match state {
+        PlotChildHandleState::Heatmap(heatmap) => {
+            heatmap.figure == figure
+                && heatmap.axes_index == axes_index
+                && heatmap.plot_index == plot_index
+        }
+        _ => false,
+    });
+    match state.ok_or(FigureError::InvalidPlotObjectHandle)? {
+        PlotChildHandleState::Heatmap(heatmap) => {
+            updater(heatmap);
+            Ok(())
+        }
+        _ => Err(FigureError::InvalidPlotObjectHandle),
+    }
 }
 
 pub fn update_histogram_handle_for_plot(
@@ -1485,6 +1546,7 @@ fn purge_plot_children_for_figure(reg: &mut PlotRegistry, handle: FigureHandle) 
         PlotChildHandleState::ErrorBar(err) => err.figure != handle,
         PlotChildHandleState::Quiver(quiver) => quiver.figure != handle,
         PlotChildHandleState::Image(image) => image.figure != handle,
+        PlotChildHandleState::Heatmap(heatmap) => heatmap.figure != handle,
         PlotChildHandleState::Area(area) => area.figure != handle,
         PlotChildHandleState::Text(text) => text.figure != handle,
     });
@@ -1518,6 +1580,9 @@ fn purge_plot_children_for_axes(reg: &mut PlotRegistry, handle: FigureHandle, ax
         }
         PlotChildHandleState::Image(image) => {
             !(image.figure == handle && image.axes_index == axes_index)
+        }
+        PlotChildHandleState::Heatmap(heatmap) => {
+            !(heatmap.figure == handle && heatmap.axes_index == axes_index)
         }
         PlotChildHandleState::Area(area) => {
             !(area.figure == handle && area.axes_index == axes_index)

--- a/crates/runmat-runtime/src/builtins/plotting/core/state.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/core/state.rs
@@ -896,6 +896,21 @@ pub fn set_colorbar_enabled_for_axes(
     Ok(())
 }
 
+pub fn set_tick_labels_for_axes(
+    handle: FigureHandle,
+    axes_index: usize,
+    x_labels: Option<Vec<String>>,
+    y_labels: Option<Vec<String>>,
+) -> Result<(), FigureError> {
+    let ((), figure_clone) = with_axes_target_mut(handle, axes_index, |state| {
+        state
+            .figure
+            .set_axes_tick_labels(axes_index, x_labels, y_labels);
+    })?;
+    notify_with_figure(handle, &figure_clone, FigureEventKind::Updated);
+    Ok(())
+}
+
 pub fn set_legend_for_axes(
     handle: FigureHandle,
     axes_index: usize,

--- a/crates/runmat-runtime/src/builtins/plotting/mod.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/mod.rs
@@ -54,6 +54,8 @@ pub(crate) mod gca;
 pub(crate) mod gcf;
 #[path = "ops/get.rs"]
 pub(crate) mod get;
+#[path = "ops/heatmap.rs"]
+pub(crate) mod heatmap;
 #[path = "ops/hist.rs"]
 pub mod hist;
 #[path = "ops/histogram.rs"]

--- a/crates/runmat-runtime/src/builtins/plotting/ops/heatmap.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/heatmap.rs
@@ -62,6 +62,13 @@ pub async fn heatmap_builtin(args: Vec<Value>) -> crate::BuiltinResult<f64> {
         rest,
     } = parse_heatmap_args(args).await?;
 
+    crate::builtins::plotting::properties::validate_heatmap_property_pairs(
+        &rest,
+        x_labels.len(),
+        y_labels.len(),
+        BUILTIN_NAME,
+    )?;
+
     let rows = color_data.rows;
     let cols = color_data.cols;
     let render_data = transpose_for_surface(&color_data);
@@ -383,5 +390,42 @@ mod tests {
             panic!("expected string array");
         };
         assert_eq!(labels.data, vec!["Small", "Medium", "Large"]);
+    }
+
+    #[test]
+    fn heatmap_rejects_bad_property_pairs_before_mutating_figure() {
+        let _guard = setup();
+        let before = clone_figure(current_figure_handle())
+            .map(|figure| figure.plots().count())
+            .unwrap_or(0);
+
+        let err = futures::executor::block_on(heatmap_builtin(vec![
+            Value::Cell(
+                CellArray::new(
+                    vec![Value::String("A".into()), Value::String("B".into())],
+                    1,
+                    2,
+                )
+                .unwrap(),
+            ),
+            Value::Cell(
+                CellArray::new(
+                    vec![Value::String("C".into()), Value::String("D".into())],
+                    1,
+                    2,
+                )
+                .unwrap(),
+            ),
+            Value::Tensor(tensor(vec![1.0, 2.0, 3.0, 4.0], 2, 2)),
+            Value::String("NotAHeatmapProperty".into()),
+            Value::Num(1.0),
+        ]))
+        .expect_err("invalid property should fail");
+        assert!(err.to_string().contains("unsupported heatmap property"));
+
+        let after = clone_figure(current_figure_handle())
+            .map(|figure| figure.plots().count())
+            .unwrap_or(0);
+        assert_eq!(after, before);
     }
 }

--- a/crates/runmat-runtime/src/builtins/plotting/ops/heatmap.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/heatmap.rs
@@ -95,6 +95,8 @@ pub async fn heatmap_builtin(args: Vec<Value>) -> crate::BuiltinResult<f64> {
     let mut surface = Some(surface);
     let plot_index_out = Rc::new(RefCell::new(None));
     let plot_index_slot = Rc::clone(&plot_index_out);
+    let render_x_labels = x_labels.clone();
+    let render_y_labels = y_labels.clone();
     let figure_handle = crate::builtins::plotting::current_figure_handle();
     let render_result = render_active_plot(
         BUILTIN_NAME,
@@ -111,6 +113,11 @@ pub async fn heatmap_builtin(args: Vec<Value>) -> crate::BuiltinResult<f64> {
                 axes,
             );
             figure.set_axes_colorbar_enabled(axes, true);
+            figure.set_axes_tick_labels(
+                axes,
+                Some(render_x_labels.clone()),
+                Some(render_y_labels.clone()),
+            );
             *plot_index_slot.borrow_mut() = Some((axes, plot_index));
             Ok(())
         },
@@ -380,6 +387,25 @@ mod tests {
         assert_eq!(
             get_builtin(vec![Value::Num(handle), Value::String("XLabel".into())]).unwrap(),
             Value::String("Sizes".into())
+        );
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let meta = fig.axes_metadata(0).unwrap();
+        assert_eq!(
+            meta.x_tick_labels.as_ref().unwrap(),
+            &vec![
+                "Small".to_string(),
+                "Medium".to_string(),
+                "Large".to_string()
+            ]
+        );
+        assert_eq!(
+            meta.y_tick_labels.as_ref().unwrap(),
+            &vec![
+                "Green".to_string(),
+                "Red".to_string(),
+                "Blue".to_string(),
+                "Gray".to_string()
+            ]
         );
         let labels = get_builtin(vec![
             Value::Num(handle),

--- a/crates/runmat-runtime/src/builtins/plotting/ops/heatmap.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/heatmap.rs
@@ -1,13 +1,12 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use runmat_builtins::{StringArray, Tensor, Value};
+use runmat_builtins::{Tensor, Value};
 use runmat_macros::runtime_builtin;
 use runmat_plot::plots::{ColorMap, ShadingMode};
 
 use super::common::{gather_tensor_from_gpu_async, SurfaceDataInput};
 use super::op_common::surface_inputs::AxisSource;
-use super::op_common::value_as_text_string;
 use super::state::{color_limits_snapshot, render_active_plot, PlotRenderOptions};
 use crate::builtins::common::spec::{
     BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
@@ -218,32 +217,11 @@ fn labels_from_value(
     expected_len: usize,
     axis_name: &str,
 ) -> crate::BuiltinResult<Vec<String>> {
-    let labels = match value {
-        Value::StringArray(StringArray { data, .. }) => data.clone(),
-        Value::Cell(cell) => cell
-            .data
-            .iter()
-            .map(|item| {
-                value_as_text_string(item).ok_or_else(|| {
-                    crate::builtins::plotting::plotting_error(
-                        BUILTIN_NAME,
-                        format!("heatmap: {axis_name} cell values must be text"),
-                    )
-                })
-            })
-            .collect::<crate::BuiltinResult<Vec<_>>>()?,
-        Value::CharArray(chars) if chars.rows == 1 => vec![chars.data.iter().collect()],
-        Value::String(text) => vec![text.clone()],
-        Value::Tensor(tensor) => tensor.data.iter().map(|v| v.to_string()).collect(),
-        Value::Int(i) => vec![i.to_i64().to_string()],
-        Value::Num(v) => vec![v.to_string()],
-        other => {
-            return Err(crate::builtins::plotting::plotting_error(
-                BUILTIN_NAME,
-                format!("heatmap: unsupported {axis_name} value {other:?}"),
-            ))
-        }
-    };
+    let labels = crate::builtins::plotting::properties::label_strings_from_value(
+        value,
+        BUILTIN_NAME,
+        axis_name,
+    )?;
     if labels.len() != expected_len {
         return Err(crate::builtins::plotting::plotting_error(
             BUILTIN_NAME,

--- a/crates/runmat-runtime/src/builtins/plotting/ops/heatmap.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/heatmap.rs
@@ -1,0 +1,387 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use runmat_builtins::{StringArray, Tensor, Value};
+use runmat_macros::runtime_builtin;
+use runmat_plot::plots::{ColorMap, ShadingMode};
+
+use super::common::{gather_tensor_from_gpu_async, SurfaceDataInput};
+use super::op_common::surface_inputs::AxisSource;
+use super::op_common::value_as_text_string;
+use super::state::{color_limits_snapshot, render_active_plot, PlotRenderOptions};
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ShapeRequirements,
+};
+use crate::builtins::plotting::type_resolvers::handle_scalar_type;
+
+const BUILTIN_NAME: &str = "heatmap";
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::plotting::heatmap")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: "heatmap",
+    op_kind: GpuOpKind::PlotRender,
+    supported_precisions: &[],
+    broadcast: BroadcastSemantics::None,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::GatherImmediately,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "heatmap is a plotting sink; inputs are gathered to build labeled HeatmapChart state.",
+};
+
+#[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::plotting::heatmap")]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: "heatmap",
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: false,
+    notes: "heatmap terminates fusion graphs and performs rendering.",
+};
+
+#[runtime_builtin(
+    name = "heatmap",
+    category = "plotting",
+    summary = "Create a MATLAB-compatible heatmap chart.",
+    keywords = "heatmap,plotting,chart,colormap,matrix visualization",
+    sink = true,
+    suppress_auto_output = true,
+    type_resolver(handle_scalar_type),
+    builtin_path = "crate::builtins::plotting::heatmap"
+)]
+pub async fn heatmap_builtin(args: Vec<Value>) -> crate::BuiltinResult<f64> {
+    let ParsedHeatmap {
+        x_labels,
+        y_labels,
+        color_data,
+        rest,
+    } = parse_heatmap_args(args).await?;
+
+    let rows = color_data.rows;
+    let cols = color_data.cols;
+    let render_data = transpose_for_surface(&color_data);
+    let x_axis = AxisSource::Host(default_axis(cols));
+    let y_axis = AxisSource::Host(default_axis(rows));
+    let color_limits = color_limits_snapshot();
+    let mut surface = super::image::build_indexed_image_surface(
+        &SurfaceDataInput::Host(render_data),
+        &x_axis,
+        &y_axis,
+        ColorMap::Parula,
+        color_limits,
+    )
+    .await?;
+    surface = surface
+        .with_flatten_z(true)
+        .with_image_mode(true)
+        .with_colormap(ColorMap::Parula)
+        .with_shading(ShadingMode::None);
+    if color_limits.is_some() {
+        surface = surface.with_color_limits(color_limits);
+    }
+
+    let mut surface = Some(surface);
+    let plot_index_out = Rc::new(RefCell::new(None));
+    let plot_index_slot = Rc::clone(&plot_index_out);
+    let figure_handle = crate::builtins::plotting::current_figure_handle();
+    let render_result = render_active_plot(
+        BUILTIN_NAME,
+        PlotRenderOptions {
+            title: "",
+            x_label: "",
+            y_label: "",
+            axis_equal: true,
+            ..Default::default()
+        },
+        move |figure, axes| {
+            let plot_index = figure.add_surface_plot_on_axes(
+                surface.take().expect("heatmap plot consumed once"),
+                axes,
+            );
+            figure.set_axes_colorbar_enabled(axes, true);
+            *plot_index_slot.borrow_mut() = Some((axes, plot_index));
+            Ok(())
+        },
+    );
+    let Some((axes, plot_index)) = *plot_index_out.borrow() else {
+        return render_result.map(|_| f64::NAN);
+    };
+    let handle = crate::builtins::plotting::state::register_heatmap_handle(
+        figure_handle,
+        axes,
+        plot_index,
+        x_labels,
+        y_labels,
+        color_data,
+    );
+    if !rest.is_empty() {
+        let plot_handle = crate::builtins::plotting::properties::resolve_plot_handle(
+            &Value::Num(handle),
+            BUILTIN_NAME,
+        )?;
+        crate::builtins::plotting::properties::set_properties(plot_handle, &rest, BUILTIN_NAME)?;
+    }
+    if let Err(err) = render_result {
+        let lower = err.to_string().to_lowercase();
+        if lower.contains("plotting is unavailable") || lower.contains("non-main thread") {
+            return Ok(handle);
+        }
+        return Err(err);
+    }
+    Ok(handle)
+}
+
+struct ParsedHeatmap {
+    x_labels: Vec<String>,
+    y_labels: Vec<String>,
+    color_data: Tensor,
+    rest: Vec<Value>,
+}
+
+async fn parse_heatmap_args(args: Vec<Value>) -> crate::BuiltinResult<ParsedHeatmap> {
+    match args.len() {
+        0 => Err(crate::builtins::plotting::plotting_error(
+            BUILTIN_NAME,
+            "heatmap: expected CData or XValues,YValues,CData input",
+        )),
+        1 => {
+            let color_data = cdata_tensor(args.into_iter().next().expect("one arg")).await?;
+            let x_labels = default_labels(color_data.cols);
+            let y_labels = default_labels(color_data.rows);
+            Ok(ParsedHeatmap {
+                x_labels,
+                y_labels,
+                color_data,
+                rest: Vec::new(),
+            })
+        }
+        2 => Err(crate::builtins::plotting::plotting_error(
+            BUILTIN_NAME,
+            "heatmap: expected CData or XValues,YValues,CData input",
+        )),
+        _ => {
+            let mut it = args.into_iter();
+            let x = it.next().expect("x labels");
+            let y = it.next().expect("y labels");
+            let c = it.next().expect("cdata");
+            let rest: Vec<Value> = it.collect();
+            let color_data = cdata_tensor(c).await?;
+            let x_labels = labels_from_value(&x, color_data.cols, "XValues")?;
+            let y_labels = labels_from_value(&y, color_data.rows, "YValues")?;
+            Ok(ParsedHeatmap {
+                x_labels,
+                y_labels,
+                color_data,
+                rest,
+            })
+        }
+    }
+}
+
+async fn cdata_tensor(value: Value) -> crate::BuiltinResult<Tensor> {
+    let tensor = match value {
+        Value::GpuTensor(handle) => gather_tensor_from_gpu_async(handle, BUILTIN_NAME).await?,
+        other => Tensor::try_from(&other).map_err(|e| {
+            crate::builtins::plotting::plotting_error(BUILTIN_NAME, format!("heatmap: {e}"))
+        })?,
+    };
+    if tensor.rows == 0 || tensor.cols == 0 {
+        return Err(crate::builtins::plotting::plotting_error(
+            BUILTIN_NAME,
+            "heatmap: CData must contain at least a 2-D grid",
+        ));
+    }
+    Ok(tensor)
+}
+
+fn labels_from_value(
+    value: &Value,
+    expected_len: usize,
+    axis_name: &str,
+) -> crate::BuiltinResult<Vec<String>> {
+    let labels = match value {
+        Value::StringArray(StringArray { data, .. }) => data.clone(),
+        Value::Cell(cell) => cell
+            .data
+            .iter()
+            .map(|item| {
+                value_as_text_string(item).ok_or_else(|| {
+                    crate::builtins::plotting::plotting_error(
+                        BUILTIN_NAME,
+                        format!("heatmap: {axis_name} cell values must be text"),
+                    )
+                })
+            })
+            .collect::<crate::BuiltinResult<Vec<_>>>()?,
+        Value::CharArray(chars) if chars.rows == 1 => vec![chars.data.iter().collect()],
+        Value::String(text) => vec![text.clone()],
+        Value::Tensor(tensor) => tensor.data.iter().map(|v| v.to_string()).collect(),
+        Value::Int(i) => vec![i.to_i64().to_string()],
+        Value::Num(v) => vec![v.to_string()],
+        other => {
+            return Err(crate::builtins::plotting::plotting_error(
+                BUILTIN_NAME,
+                format!("heatmap: unsupported {axis_name} value {other:?}"),
+            ))
+        }
+    };
+    if labels.len() != expected_len {
+        return Err(crate::builtins::plotting::plotting_error(
+            BUILTIN_NAME,
+            format!("heatmap: {axis_name} must have {expected_len} labels"),
+        ));
+    }
+    Ok(labels)
+}
+
+fn default_labels(len: usize) -> Vec<String> {
+    (1..=len).map(|idx| idx.to_string()).collect()
+}
+
+fn default_axis(len: usize) -> Vec<f64> {
+    (1..=len).map(|idx| idx as f64).collect()
+}
+
+fn transpose_for_surface(tensor: &Tensor) -> Tensor {
+    let mut data = vec![0.0; tensor.data.len()];
+    for row in 0..tensor.rows {
+        for col in 0..tensor.cols {
+            let src = row + tensor.rows * col;
+            let dst = col + tensor.cols * row;
+            data[dst] = tensor.data[src];
+        }
+    }
+    Tensor {
+        data,
+        shape: vec![tensor.cols, tensor.rows],
+        rows: tensor.cols,
+        cols: tensor.rows,
+        dtype: tensor.dtype,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtins::plotting::get::get_builtin;
+    use crate::builtins::plotting::set::set_builtin;
+    use crate::builtins::plotting::tests::{ensure_plot_test_env, lock_plot_registry};
+    use crate::builtins::plotting::{
+        clear_figure, clone_figure, current_figure_handle, reset_hold_state_for_run,
+    };
+    use runmat_builtins::{CellArray, NumericDType, Value};
+    use runmat_plot::plots::PlotElement;
+
+    fn setup() -> crate::builtins::plotting::state::PlotTestLockGuard {
+        let guard = lock_plot_registry();
+        ensure_plot_test_env();
+        reset_hold_state_for_run();
+        let _ = clear_figure(None);
+        guard
+    }
+
+    fn tensor(data: Vec<f64>, rows: usize, cols: usize) -> Tensor {
+        Tensor {
+            data,
+            shape: vec![rows, cols],
+            rows,
+            cols,
+            dtype: NumericDType::F64,
+        }
+    }
+
+    #[test]
+    fn heatmap_cdata_builds_heatmap_handle() {
+        let _guard = setup();
+        let handle = futures::executor::block_on(heatmap_builtin(vec![Value::Tensor(tensor(
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            2,
+            3,
+        ))]))
+        .expect("heatmap should render");
+        assert!(handle.is_finite());
+
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let PlotElement::Surface(surface) = fig.plots().next().unwrap() else {
+            panic!("expected surface");
+        };
+        assert!(surface.flatten_z);
+        assert!(surface.image_mode);
+        assert_eq!(surface.x_data, vec![1.0, 2.0, 3.0]);
+        assert_eq!(surface.y_data, vec![1.0, 2.0]);
+        assert!(fig.axes_metadata(0).unwrap().colorbar_enabled);
+    }
+
+    #[test]
+    fn heatmap_accepts_labels_and_exposes_chart_properties() {
+        let _guard = setup();
+        let x = CellArray::new(
+            vec![
+                Value::String("Small".into()),
+                Value::String("Medium".into()),
+                Value::String("Large".into()),
+            ],
+            1,
+            3,
+        )
+        .unwrap();
+        let y = CellArray::new(
+            vec![
+                Value::String("Green".into()),
+                Value::String("Red".into()),
+                Value::String("Blue".into()),
+                Value::String("Gray".into()),
+            ],
+            1,
+            4,
+        )
+        .unwrap();
+        let cdata = tensor(
+            vec![
+                45.0, 43.0, 32.0, 23.0, 60.0, 54.0, 94.0, 95.0, 32.0, 76.0, 68.0, 58.0,
+            ],
+            4,
+            3,
+        );
+        let handle = futures::executor::block_on(heatmap_builtin(vec![
+            Value::Cell(x),
+            Value::Cell(y),
+            Value::Tensor(cdata),
+        ]))
+        .expect("heatmap should render");
+
+        set_builtin(vec![
+            Value::Num(handle),
+            Value::String("Title".into()),
+            Value::String("T-Shirt Orders".into()),
+            Value::String("XLabel".into()),
+            Value::String("Sizes".into()),
+            Value::String("YLabel".into()),
+            Value::String("Colors".into()),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            get_builtin(vec![Value::Num(handle), Value::String("Title".into())]).unwrap(),
+            Value::String("T-Shirt Orders".into())
+        );
+        assert_eq!(
+            get_builtin(vec![Value::Num(handle), Value::String("XLabel".into())]).unwrap(),
+            Value::String("Sizes".into())
+        );
+        let labels = get_builtin(vec![
+            Value::Num(handle),
+            Value::String("XDisplayLabels".into()),
+        ])
+        .unwrap();
+        let Value::StringArray(labels) = labels else {
+            panic!("expected string array");
+        };
+        assert_eq!(labels.data, vec!["Small", "Medium", "Large"]);
+    }
+}

--- a/crates/runmat-runtime/src/builtins/plotting/ops/heatmap.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/heatmap.rs
@@ -416,6 +416,53 @@ mod tests {
             panic!("expected string array");
         };
         assert_eq!(labels.data, vec!["Small", "Medium", "Large"]);
+
+        set_builtin(vec![
+            Value::Num(handle),
+            Value::String("XDisplayLabels".into()),
+            Value::Cell(
+                CellArray::new(
+                    vec![
+                        Value::String("S".into()),
+                        Value::String("M".into()),
+                        Value::String("L".into()),
+                    ],
+                    1,
+                    3,
+                )
+                .unwrap(),
+            ),
+            Value::String("YDisplayLabels".into()),
+            Value::Cell(
+                CellArray::new(
+                    vec![
+                        Value::String("G".into()),
+                        Value::String("R".into()),
+                        Value::String("B".into()),
+                        Value::String("Y".into()),
+                    ],
+                    1,
+                    4,
+                )
+                .unwrap(),
+            ),
+        ])
+        .unwrap();
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let meta = fig.axes_metadata(0).unwrap();
+        assert_eq!(
+            meta.x_tick_labels.as_ref().unwrap(),
+            &vec!["S".to_string(), "M".to_string(), "L".to_string()]
+        );
+        assert_eq!(
+            meta.y_tick_labels.as_ref().unwrap(),
+            &vec![
+                "G".to_string(),
+                "R".to_string(),
+                "B".to_string(),
+                "Y".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/crates/runmat-vm/src/object/resolve.rs
+++ b/crates/runmat-vm/src/object/resolve.rs
@@ -364,6 +364,7 @@ fn is_invalid_graphics_handle_error(err: &RuntimeError) -> bool {
     text.contains("unsupported or invalid plotting handle")
         || text.contains("invalid plotting handle")
         || text.contains("invalid figure handle")
+        || text.contains("invalid axes handle")
 }
 
 fn is_possible_graphics_handle_value(value: &Value) -> bool {

--- a/crates/runmat-vm/src/object/resolve.rs
+++ b/crates/runmat-vm/src/object/resolve.rs
@@ -76,7 +76,7 @@ pub async fn load_member(
         }
         Value::ClassRef(cls) => load_static_member(&cls, &field),
         base @ (Value::Num(_) | Value::Int(_)) => {
-            if !is_encoded_graphics_handle_value(&base) {
+            if !is_possible_graphics_handle_value(&base) {
                 return Err(mex("LoadMember", "LoadMember on non-object"));
             }
             load_graphics_member(base, &field).await.map_err(|err| {
@@ -270,7 +270,7 @@ where
             Ok(Value::Struct(st))
         }
         base @ (Value::Num(_) | Value::Int(_)) => {
-            if !is_encoded_graphics_handle_value(&base) {
+            if !is_possible_graphics_handle_value(&base) {
                 return Err(mex("StoreMember", "StoreMember on non-object"));
             }
             store_graphics_member(base, &field, rhs)
@@ -366,11 +366,10 @@ fn is_invalid_graphics_handle_error(err: &RuntimeError) -> bool {
         || text.contains("invalid figure handle")
 }
 
-fn is_encoded_graphics_handle_value(value: &Value) -> bool {
-    const MIN_ENCODED_GRAPHICS_HANDLE: f64 = (1u64 << 20) as f64;
+fn is_possible_graphics_handle_value(value: &Value) -> bool {
     match value {
-        Value::Num(v) => v.is_finite() && *v >= MIN_ENCODED_GRAPHICS_HANDLE,
-        Value::Int(i) => i.to_f64() >= MIN_ENCODED_GRAPHICS_HANDLE,
+        Value::Num(v) => v.is_finite() && *v > 0.0,
+        Value::Int(i) => i.to_f64() > 0.0,
         _ => false,
     }
 }

--- a/crates/runmat-vm/src/object/resolve.rs
+++ b/crates/runmat-vm/src/object/resolve.rs
@@ -75,6 +75,18 @@ pub async fn load_member(
             runmat_runtime::call_builtin_async("call_method", &args).await
         }
         Value::ClassRef(cls) => load_static_member(&cls, &field),
+        base @ (Value::Num(_) | Value::Int(_)) => {
+            if !is_encoded_graphics_handle_value(&base) {
+                return Err(mex("LoadMember", "LoadMember on non-object"));
+            }
+            load_graphics_member(base, &field).await.map_err(|err| {
+                if is_invalid_graphics_handle_error(&err) {
+                    mex("LoadMember", "LoadMember on non-object")
+                } else {
+                    err
+                }
+            })
+        }
         Value::Struct(st) => {
             if let Some(v) = st.fields.get(&field) {
                 Ok(v.clone())
@@ -252,6 +264,25 @@ where
             ];
             runmat_runtime::call_builtin_async("call_method", &args).await
         }
+        Value::Num(0.0) if allow_init => {
+            let mut st = StructValue::new();
+            st.fields.insert(field, rhs);
+            Ok(Value::Struct(st))
+        }
+        base @ (Value::Num(_) | Value::Int(_)) => {
+            if !is_encoded_graphics_handle_value(&base) {
+                return Err(mex("StoreMember", "StoreMember on non-object"));
+            }
+            store_graphics_member(base, &field, rhs)
+                .await
+                .map_err(|err| {
+                    if is_invalid_graphics_handle_error(&err) {
+                        mex("StoreMember", "StoreMember on non-object")
+                    } else {
+                        err
+                    }
+                })
+        }
         Value::Struct(mut st) => {
             if let Some(oldv) = st.fields.get(&field) {
                 on_write(oldv, &rhs);
@@ -294,11 +325,6 @@ where
             }
             Ok(Value::Cell(ca))
         }
-        Value::Num(0.0) if allow_init => {
-            let mut st = StructValue::new();
-            st.fields.insert(field, rhs);
-            Ok(Value::Struct(st))
-        }
         _ => Err(mex("StoreMember", "StoreMember on non-object")),
     }
 }
@@ -314,4 +340,38 @@ where
     OnWrite: FnMut(&Value, &Value),
 {
     store_member(base, name, rhs, allow_init, on_write).await
+}
+
+async fn load_graphics_member(base: Value, field: &str) -> Result<Value, RuntimeError> {
+    runmat_runtime::call_builtin_async("get", &[base, Value::String(field.to_string())]).await
+}
+
+async fn store_graphics_member(
+    base: Value,
+    field: &str,
+    rhs: Value,
+) -> Result<Value, RuntimeError> {
+    runmat_runtime::call_builtin_async("get", std::slice::from_ref(&base)).await?;
+    runmat_runtime::call_builtin_async(
+        "set",
+        &[base.clone(), Value::String(field.to_string()), rhs],
+    )
+    .await?;
+    Ok(base)
+}
+
+fn is_invalid_graphics_handle_error(err: &RuntimeError) -> bool {
+    let text = err.to_string().to_ascii_lowercase();
+    text.contains("unsupported or invalid plotting handle")
+        || text.contains("invalid plotting handle")
+        || text.contains("invalid figure handle")
+}
+
+fn is_encoded_graphics_handle_value(value: &Value) -> bool {
+    const MIN_ENCODED_GRAPHICS_HANDLE: f64 = (1u64 << 20) as f64;
+    match value {
+        Value::Num(v) => v.is_finite() && *v >= MIN_ENCODED_GRAPHICS_HANDLE,
+        Value::Int(i) => i.to_f64() >= MIN_ENCODED_GRAPHICS_HANDLE,
+        _ => false,
+    }
 }

--- a/crates/runmat-vm/src/object/resolve.rs
+++ b/crates/runmat-vm/src/object/resolve.rs
@@ -351,7 +351,6 @@ async fn store_graphics_member(
     field: &str,
     rhs: Value,
 ) -> Result<Value, RuntimeError> {
-    runmat_runtime::call_builtin_async("get", std::slice::from_ref(&base)).await?;
     runmat_runtime::call_builtin_async(
         "set",
         &[base.clone(), Value::String(field.to_string()), rhs],

--- a/crates/runmat-vm/tests/plotting.rs
+++ b/crates/runmat-vm/tests/plotting.rs
@@ -35,3 +35,27 @@ fn figure_dot_property_access_routes_to_graphics_get() {
     let vars = execute(&hir).expect("execute figure property script");
     assert_eq!(vars.last(), Some(&Value::String("figure".into())));
 }
+
+#[test]
+fn invalid_axes_shaped_handle_member_access_reports_non_object() {
+    unsafe {
+        std::env::set_var("RUNMAT_DISABLE_INTERACTIVE_PLOTS", "1");
+    }
+    let input = "bad_axes_handle = 1049575; out = bad_axes_handle.Type;";
+    let ast = parse(input).expect("parse invalid axes handle script");
+    let hir = lower(&ast).expect("lower invalid axes handle script");
+    let err = execute(&hir).expect_err("invalid axes handle should fail");
+    assert!(
+        err.to_string().contains("LoadMember on non-object"),
+        "unexpected error: {err:?}"
+    );
+
+    let input = "bad_axes_handle = 1049575; bad_axes_handle.Title = 'bad';";
+    let ast = parse(input).expect("parse invalid axes store script");
+    let hir = lower(&ast).expect("lower invalid axes store script");
+    let err = execute(&hir).expect_err("invalid axes store should fail");
+    assert!(
+        err.to_string().contains("StoreMember on non-object"),
+        "unexpected error: {err:?}"
+    );
+}

--- a/crates/runmat-vm/tests/plotting.rs
+++ b/crates/runmat-vm/tests/plotting.rs
@@ -1,0 +1,25 @@
+#[path = "support/mod.rs"]
+mod test_helpers;
+
+use runmat_builtins::Value;
+use runmat_parser::parse;
+use test_helpers::{execute, lower};
+
+#[test]
+fn heatmap_dot_property_assignment_routes_to_graphics_set() {
+    unsafe {
+        std::env::set_var("RUNMAT_DISABLE_INTERACTIVE_PLOTS", "1");
+    }
+    let input = "cdata = [45 60 32; 43 54 76; 32 94 68; 23 95 58]; \
+        xvalues = {'Small','Medium','Large'}; \
+        yvalues = {'Green','Red','Blue','Gray'}; \
+        h = heatmap(xvalues,yvalues,cdata); \
+        h.Title = 'T-Shirt Orders'; \
+        h.XLabel = 'Sizes'; \
+        h.YLabel = 'Colors'; \
+        out = h.Title;";
+    let ast = parse(input).expect("parse heatmap script");
+    let hir = lower(&ast).expect("lower heatmap script");
+    let vars = execute(&hir).expect("execute heatmap script");
+    assert_eq!(vars.last(), Some(&Value::String("T-Shirt Orders".into())));
+}

--- a/crates/runmat-vm/tests/plotting.rs
+++ b/crates/runmat-vm/tests/plotting.rs
@@ -23,3 +23,15 @@ fn heatmap_dot_property_assignment_routes_to_graphics_set() {
     let vars = execute(&hir).expect("execute heatmap script");
     assert_eq!(vars.last(), Some(&Value::String("T-Shirt Orders".into())));
 }
+
+#[test]
+fn figure_dot_property_access_routes_to_graphics_get() {
+    unsafe {
+        std::env::set_var("RUNMAT_DISABLE_INTERACTIVE_PLOTS", "1");
+    }
+    let input = "f = figure(); out = f.Type;";
+    let ast = parse(input).expect("parse figure property script");
+    let hir = lower(&ast).expect("lower figure property script");
+    let vars = execute(&hir).expect("execute figure property script");
+    assert_eq!(vars.last(), Some(&Value::String("figure".into())));
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `heatmap` plotting builtin plus new handle/property plumbing and VM dot-access routing; mistakes could break plotting handle semantics or axes metadata serialization but scope is mostly isolated to plotting/runtime.
> 
> **Overview**
> Adds MATLAB-compatible `heatmap` plotting support end-to-end: a new `heatmap` builtin renders a heatmap via the existing surface/image pipeline, returns a dedicated heatmap handle, and supports `get`/`set` plus property/value pairs (including validation for `XDisplayLabels`/`YDisplayLabels`, `Colormap`, and `ColorbarVisible`).
> 
> Extends plot/figure metadata and GUI overlays to carry and render explicit per-axes `x_tick_labels`/`y_tick_labels` (taking precedence over inferred categorical/bar labels), and wires these labels through figure serialization.
> 
> Updates the runtime plot-handle registry/state to track heatmap handles (including stored labels and `ColorData`) and to propagate label updates into axes tick-label metadata; also updates VM member load/store to route numeric/int “graphics handle”-looking values through plotting `get`/`set`, with tests covering heatmap dot-property assignment and invalid-handle errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001f9655a4b36dfa4ef66af5ce3676a515bb9520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->