### PR TITLE
cover plot vector orientation compatibility

### DIFF
--- a/crates/runmat-runtime/src/builtins/math/fft/forward.rs
+++ b/crates/runmat-runtime/src/builtins/math/fft/forward.rs
@@ -236,6 +236,28 @@ pub(crate) mod tests {
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[test]
+    fn fft_row_vector_default_dimension_preserves_orientation() {
+        let tensor = Tensor::new(vec![1.0, 2.0, 3.0, 4.0], vec![1, 4]).unwrap();
+        let result = fft_host(Value::Tensor(tensor), None, None).expect("fft");
+        match result {
+            Value::ComplexTensor(ct) => {
+                assert_eq!(ct.shape, vec![1, 4]);
+                let expected = [(10.0, 0.0), (-2.0, 2.0), (-2.0, 0.0), (-2.0, -2.0)];
+                for (idx, val) in ct.data.iter().enumerate() {
+                    assert!(
+                        approx_eq(*val, expected[idx], 1e-12),
+                        "idx {idx} {:?} ~= {:?}",
+                        val,
+                        expected[idx]
+                    );
+                }
+            }
+            other => panic!("expected complex tensor, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
     fn fft_matrix_default_dimension() {
         let tensor = Tensor::new(vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0], vec![2, 3]).unwrap();
         let result = fft_host(Value::Tensor(tensor), None, None).expect("fft");

--- a/crates/runmat-runtime/src/builtins/plotting/core/common.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/core/common.rs
@@ -52,6 +52,22 @@ pub fn numeric_triplet(
     Ok((x_vec, y_vec, z_vec))
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn numeric_pair_accepts_matching_numel_vectors_with_different_shapes() {
+        let row = Tensor::new(vec![1.0, 2.0, 3.0, 4.0], vec![1, 4]).unwrap();
+        let column = Tensor::new(vec![10.0, 20.0, 30.0, 40.0], vec![4, 1]).unwrap();
+
+        let (x, y) = numeric_pair(row, column, "plot").expect("matching numel vectors");
+
+        assert_eq!(x, vec![1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(y, vec![10.0, 20.0, 30.0, 40.0]);
+    }
+}
+
 pub fn value_as_f64(value: &Value) -> Option<f64> {
     match value {
         Value::Num(v) => Some(*v),

--- a/crates/runmat-runtime/src/builtins/plotting/ops/plot.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/plot.rs
@@ -576,6 +576,10 @@ pub(crate) mod tests {
         }
     }
 
+    fn tensor_with_shape(data: &[f64], shape: Vec<usize>) -> Tensor {
+        Tensor::new(data.to_vec(), shape).unwrap()
+    }
+
     fn assert_plotting_unavailable(err: &RuntimeError) {
         let lower = err.to_string().to_lowercase();
         assert!(
@@ -607,6 +611,34 @@ pub(crate) mod tests {
         ]));
         if let Err(flow) = result {
             assert_plotting_unavailable(&flow);
+        }
+    }
+
+    #[test]
+    fn plot_builtin_accepts_matching_numel_vectors_with_different_shapes() {
+        let _guard = setup_plot_tests();
+        let cases = [
+            (
+                tensor_with_shape(&[1.0, 2.0, 3.0, 4.0], vec![1, 4]),
+                tensor_with_shape(&[10.0, 20.0, 30.0, 40.0], vec![4, 1]),
+            ),
+            (
+                tensor_with_shape(&[1.0, 2.0, 3.0, 4.0], vec![4, 1]),
+                tensor_with_shape(&[10.0, 20.0, 30.0, 40.0], vec![1, 4]),
+            ),
+        ];
+
+        for (x, y) in cases {
+            let _ = clear_figure(None);
+            block_on(plot_builtin(vec![Value::Tensor(x), Value::Tensor(y)]))
+                .expect("plot should accept row/column vector pairs with matching numel");
+
+            let fig = clone_figure(current_figure_handle()).expect("figure exists");
+            let PlotElement::Line(line) = fig.plots().next().expect("plot created") else {
+                panic!("expected line plot");
+            };
+            assert_eq!(line.x_data, vec![1.0, 2.0, 3.0, 4.0]);
+            assert_eq!(line.y_data, vec![10.0, 20.0, 30.0, 40.0]);
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes that add coverage for row/column vector shape handling in `plot` and default-dimension `fft`, with no production logic modifications.
> 
> **Overview**
> Adds regression tests to ensure vector *orientation/shape differences* don’t break behavior when the element count matches.
> 
> Specifically, it adds coverage that `plot` accepts row-vs-column vector pairs with the same `numel` (and verifies the produced line data), and that `fft` preserves row-vector orientation when using the default transform dimension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0f1b63616e107802f6fa1ce1ff7626ed8509a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for FFT functionality to verify default-dimension behavior with different tensor shapes.
  * Improved test coverage for plotting operations to ensure vector inputs with matching element counts but different shapes are handled correctly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/334)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->