### PR TITLE
moving wasm file io to async

### DIFF
--- a/crates/runmat-filesystem/src/lib.rs
+++ b/crates/runmat-filesystem/src/lib.rs
@@ -32,9 +32,15 @@ use data_contract::{
     DataChunkUploadRequest, DataChunkUploadTarget, DataManifestDescriptor, DataManifestRequest,
 };
 
-pub trait FileHandle: Read + Write + Seek + Send + Sync {}
+#[async_trait(?Send)]
+pub trait FileHandle: Read + Write + Seek + Send + Sync {
+    async fn flush_async(&mut self) -> io::Result<()> {
+        self.flush()
+    }
+}
 
-impl<T> FileHandle for T where T: Read + Write + Seek + Send + Sync + 'static {}
+#[async_trait(?Send)]
+impl FileHandle for std::fs::File {}
 
 #[derive(Clone, Debug, Default)]
 pub struct OpenFlags {
@@ -91,6 +97,15 @@ impl OpenOptions {
     pub fn open(&self, path: impl AsRef<Path>) -> io::Result<File> {
         let resolved = resolve_path(path.as_ref());
         with_provider(|provider| provider.open(&resolved, &self.flags)).map(File::from_handle)
+    }
+
+    pub async fn open_async(&self, path: impl AsRef<Path>) -> io::Result<File> {
+        let resolved = resolve_path(path.as_ref());
+        let provider = current_provider();
+        provider
+            .open_async(&resolved, &self.flags)
+            .await
+            .map(File::from_handle)
     }
 
     pub fn flags(&self) -> &OpenFlags {
@@ -268,6 +283,9 @@ impl DirEntry {
 #[async_trait(?Send)]
 pub trait FsProvider: Send + Sync + 'static {
     fn open(&self, path: &Path, flags: &OpenFlags) -> io::Result<Box<dyn FileHandle>>;
+    async fn open_async(&self, path: &Path, flags: &OpenFlags) -> io::Result<Box<dyn FileHandle>> {
+        self.open(path, flags)
+    }
     async fn read(&self, path: &Path) -> io::Result<Vec<u8>>;
     async fn write(&self, path: &Path, data: &[u8]) -> io::Result<()>;
     async fn remove_file(&self, path: &Path) -> io::Result<()>;
@@ -352,10 +370,26 @@ impl File {
         opts.open(path)
     }
 
+    pub async fn open_async(path: impl AsRef<Path>) -> io::Result<Self> {
+        let mut opts = OpenOptions::new();
+        opts.read(true);
+        opts.open_async(path).await
+    }
+
     pub fn create(path: impl AsRef<Path>) -> io::Result<Self> {
         let mut opts = OpenOptions::new();
         opts.write(true).create(true).truncate(true);
         opts.open(path)
+    }
+
+    pub async fn create_async(path: impl AsRef<Path>) -> io::Result<Self> {
+        let mut opts = OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        opts.open_async(path).await
+    }
+
+    pub async fn flush_async(&mut self) -> io::Result<()> {
+        self.inner.flush_async().await
     }
 }
 
@@ -655,13 +689,73 @@ fn default_provider() -> Arc<dyn FsProvider> {
 mod tests {
     use super::*;
     use once_cell::sync::Lazy;
-    use std::io::{Read, Write};
+    use std::io::{Read, Seek, SeekFrom, Write};
     use std::sync::Mutex;
     use tempfile::tempdir;
 
     static TEST_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
     struct UnsupportedProvider;
+
+    struct AsyncOpenProvider {
+        opened_async: Arc<Mutex<bool>>,
+        flushed_async: Arc<Mutex<bool>>,
+    }
+
+    struct AsyncTestHandle {
+        cursor: usize,
+        data: Vec<u8>,
+        flushed_async: Arc<Mutex<bool>>,
+    }
+
+    impl Read for AsyncTestHandle {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let remaining = self.data.len().saturating_sub(self.cursor);
+            let to_read = remaining.min(buf.len());
+            buf[..to_read].copy_from_slice(&self.data[self.cursor..self.cursor + to_read]);
+            self.cursor += to_read;
+            Ok(to_read)
+        }
+    }
+
+    impl Write for AsyncTestHandle {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            let end = self.cursor + buf.len();
+            if end > self.data.len() {
+                self.data.resize(end, 0);
+            }
+            self.data[self.cursor..end].copy_from_slice(buf);
+            self.cursor = end;
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Seek for AsyncTestHandle {
+        fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+            let next = match pos {
+                SeekFrom::Start(offset) => offset as i64,
+                SeekFrom::End(offset) => self.data.len() as i64 + offset,
+                SeekFrom::Current(offset) => self.cursor as i64 + offset,
+            };
+            if next < 0 {
+                return Err(io::Error::new(ErrorKind::InvalidInput, "seek before start"));
+            }
+            self.cursor = next as usize;
+            Ok(self.cursor as u64)
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl FileHandle for AsyncTestHandle {
+        async fn flush_async(&mut self) -> io::Result<()> {
+            *self.flushed_async.lock().unwrap() = true;
+            Ok(())
+        }
+    }
 
     #[async_trait(?Send)]
     impl FsProvider for UnsupportedProvider {
@@ -744,6 +838,78 @@ mod tests {
         }
     }
 
+    #[async_trait(?Send)]
+    impl FsProvider for AsyncOpenProvider {
+        fn open(&self, _path: &Path, _flags: &OpenFlags) -> io::Result<Box<dyn FileHandle>> {
+            Err(unsupported())
+        }
+
+        async fn open_async(
+            &self,
+            _path: &Path,
+            _flags: &OpenFlags,
+        ) -> io::Result<Box<dyn FileHandle>> {
+            *self.opened_async.lock().unwrap() = true;
+            Ok(Box::new(AsyncTestHandle {
+                cursor: 0,
+                data: b"async contents".to_vec(),
+                flushed_async: self.flushed_async.clone(),
+            }))
+        }
+
+        async fn read(&self, _path: &Path) -> io::Result<Vec<u8>> {
+            Err(unsupported())
+        }
+
+        async fn write(&self, _path: &Path, _data: &[u8]) -> io::Result<()> {
+            Err(unsupported())
+        }
+
+        async fn remove_file(&self, _path: &Path) -> io::Result<()> {
+            Err(unsupported())
+        }
+
+        async fn metadata(&self, _path: &Path) -> io::Result<FsMetadata> {
+            Err(unsupported())
+        }
+
+        async fn symlink_metadata(&self, _path: &Path) -> io::Result<FsMetadata> {
+            Err(unsupported())
+        }
+
+        async fn read_dir(&self, _path: &Path) -> io::Result<Vec<DirEntry>> {
+            Err(unsupported())
+        }
+
+        async fn canonicalize(&self, _path: &Path) -> io::Result<PathBuf> {
+            Err(unsupported())
+        }
+
+        async fn create_dir(&self, _path: &Path) -> io::Result<()> {
+            Err(unsupported())
+        }
+
+        async fn create_dir_all(&self, _path: &Path) -> io::Result<()> {
+            Err(unsupported())
+        }
+
+        async fn remove_dir(&self, _path: &Path) -> io::Result<()> {
+            Err(unsupported())
+        }
+
+        async fn remove_dir_all(&self, _path: &Path) -> io::Result<()> {
+            Err(unsupported())
+        }
+
+        async fn rename(&self, _from: &Path, _to: &Path) -> io::Result<()> {
+            Err(unsupported())
+        }
+
+        async fn set_readonly(&self, _path: &Path, _readonly: bool) -> io::Result<()> {
+            Err(unsupported())
+        }
+    }
+
     fn unsupported() -> io::Error {
         io::Error::new(ErrorKind::Unsupported, "unsupported in test provider")
     }
@@ -796,6 +962,29 @@ mod tests {
         }
         let final_provider = current_provider();
         assert!(Arc::ptr_eq(&final_provider, &original));
+    }
+
+    #[test]
+    fn open_async_and_flush_async_use_provider_async_paths() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let opened_async = Arc::new(Mutex::new(false));
+        let flushed_async = Arc::new(Mutex::new(false));
+        let provider = Arc::new(AsyncOpenProvider {
+            opened_async: opened_async.clone(),
+            flushed_async: flushed_async.clone(),
+        });
+        let _provider_guard = replace_provider(provider);
+
+        let mut file =
+            futures::executor::block_on(OpenOptions::new().read(true).open_async("data.txt"))
+                .expect("async open");
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).expect("read contents");
+        futures::executor::block_on(file.flush_async()).expect("async flush");
+
+        assert_eq!(contents, "async contents");
+        assert!(*opened_async.lock().unwrap());
+        assert!(*flushed_async.lock().unwrap());
     }
 
     #[test]

--- a/crates/runmat-filesystem/src/remote/native.rs
+++ b/crates/runmat-filesystem/src/remote/native.rs
@@ -1257,6 +1257,9 @@ impl Seek for RemoteFileHandle {
     }
 }
 
+#[async_trait(?Send)]
+impl FileHandle for RemoteFileHandle {}
+
 impl Drop for RemoteFileHandle {
     fn drop(&mut self) {
         if self.dirty {

--- a/crates/runmat-filesystem/src/remote/wasm.rs
+++ b/crates/runmat-filesystem/src/remote/wasm.rs
@@ -1063,6 +1063,9 @@ impl Seek for RemoteFileHandle {
     }
 }
 
+#[async_trait(?Send)]
+impl FileHandle for RemoteFileHandle {}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct MetadataResponse {

--- a/crates/runmat-runtime/src/builtins/io/filetext/fclose.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/fclose.rs
@@ -133,31 +133,42 @@ impl FcloseEval {
 pub async fn evaluate(args: &[Value]) -> BuiltinResult<FcloseEval> {
     let gathered = gather_args(args).await?;
     match gathered.len() {
-        0 => Ok(close_all()),
-        1 => handle_single_argument(&gathered[0]),
+        0 => Ok(close_all().await),
+        1 => handle_single_argument(&gathered[0]).await,
         _ => Err(fclose_error("fclose: too many input arguments")),
     }
 }
 
-fn handle_single_argument(value: &Value) -> BuiltinResult<FcloseEval> {
+async fn handle_single_argument(value: &Value) -> BuiltinResult<FcloseEval> {
     if matches_keyword(value, "all") {
-        return Ok(close_all());
+        return Ok(close_all().await);
     }
     let fids = collect_file_ids(value).map_err(|err| fclose_error(format!("fclose: {err}")))?;
-    Ok(close_fids(&fids))
+    Ok(close_fids(&fids).await)
 }
 
-fn close_all() -> FcloseEval {
+async fn close_all() -> FcloseEval {
     let infos = registry::list_infos();
+    let mut status_ok = true;
+    let mut message = String::new();
     for info in infos {
         if info.id >= 3 {
-            let _ = registry::close(info.id);
+            if let Err(err) = registry::close_async(info.id).await {
+                status_ok = false;
+                if message.is_empty() {
+                    message = err.to_string();
+                }
+            }
         }
     }
-    FcloseEval::success()
+    if status_ok {
+        FcloseEval::success()
+    } else {
+        FcloseEval::failure(message)
+    }
 }
 
-fn close_fids(fids: &[i32]) -> FcloseEval {
+async fn close_fids(fids: &[i32]) -> FcloseEval {
     if fids.is_empty() {
         return FcloseEval::success();
     }
@@ -174,10 +185,19 @@ fn close_fids(fids: &[i32]) -> FcloseEval {
         if fid < 3 {
             continue;
         }
-        if registry::close(fid).is_none() {
-            status_ok = false;
-            if message.is_empty() {
-                message = INVALID_IDENTIFIER_MESSAGE.to_string();
+        match registry::close_async(fid).await {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                status_ok = false;
+                if message.is_empty() {
+                    message = INVALID_IDENTIFIER_MESSAGE.to_string();
+                }
+            }
+            Err(err) => {
+                status_ok = false;
+                if message.is_empty() {
+                    message = err.to_string();
+                }
             }
         }
     }

--- a/crates/runmat-runtime/src/builtins/io/filetext/fclose.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/fclose.rs
@@ -295,10 +295,122 @@ pub(crate) mod tests {
     use crate::builtins::io::filetext::{fopen, registry};
     use runmat_builtins::{CellArray, LogicalArray, StringArray, Tensor};
     use runmat_time::system_time_now;
-    use std::io::Write;
+    use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
+    use std::path::Path;
     use std::path::PathBuf;
-    use std::sync::MutexGuard;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, MutexGuard};
     use std::time::UNIX_EPOCH;
+
+    struct FailingFlushProvider {
+        fail_flush: Arc<AtomicBool>,
+    }
+
+    fn unsupported_provider_op() -> io::Error {
+        io::Error::new(io::ErrorKind::Unsupported, "unsupported test provider op")
+    }
+
+    #[async_trait::async_trait(?Send)]
+    impl runmat_filesystem::FsProvider for FailingFlushProvider {
+        fn open(
+            &self,
+            _path: &Path,
+            _flags: &runmat_filesystem::OpenFlags,
+        ) -> io::Result<Box<dyn runmat_filesystem::FileHandle>> {
+            Ok(Box::new(FailingFlushHandle {
+                inner: Cursor::new(Vec::new()),
+                fail_flush: self.fail_flush.clone(),
+            }))
+        }
+
+        async fn read(&self, _path: &Path) -> io::Result<Vec<u8>> {
+            Err(unsupported_provider_op())
+        }
+
+        async fn write(&self, _path: &Path, _data: &[u8]) -> io::Result<()> {
+            Err(unsupported_provider_op())
+        }
+
+        async fn remove_file(&self, _path: &Path) -> io::Result<()> {
+            Err(unsupported_provider_op())
+        }
+
+        async fn metadata(&self, _path: &Path) -> io::Result<runmat_filesystem::FsMetadata> {
+            Err(unsupported_provider_op())
+        }
+
+        async fn symlink_metadata(
+            &self,
+            _path: &Path,
+        ) -> io::Result<runmat_filesystem::FsMetadata> {
+            Err(unsupported_provider_op())
+        }
+
+        async fn read_dir(&self, _path: &Path) -> io::Result<Vec<runmat_filesystem::DirEntry>> {
+            Err(unsupported_provider_op())
+        }
+
+        async fn canonicalize(&self, _path: &Path) -> io::Result<PathBuf> {
+            Err(unsupported_provider_op())
+        }
+
+        async fn create_dir(&self, _path: &Path) -> io::Result<()> {
+            Err(unsupported_provider_op())
+        }
+
+        async fn create_dir_all(&self, _path: &Path) -> io::Result<()> {
+            Err(unsupported_provider_op())
+        }
+
+        async fn remove_dir(&self, _path: &Path) -> io::Result<()> {
+            Err(unsupported_provider_op())
+        }
+
+        async fn remove_dir_all(&self, _path: &Path) -> io::Result<()> {
+            Err(unsupported_provider_op())
+        }
+
+        async fn rename(&self, _from: &Path, _to: &Path) -> io::Result<()> {
+            Err(unsupported_provider_op())
+        }
+
+        async fn set_readonly(&self, _path: &Path, _readonly: bool) -> io::Result<()> {
+            Err(unsupported_provider_op())
+        }
+    }
+
+    struct FailingFlushHandle {
+        inner: Cursor<Vec<u8>>,
+        fail_flush: Arc<AtomicBool>,
+    }
+
+    impl Read for FailingFlushHandle {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            self.inner.read(buf)
+        }
+    }
+
+    impl Write for FailingFlushHandle {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.inner.write(buf)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            if self.fail_flush.load(Ordering::SeqCst) {
+                Err(io::Error::other("flush failed"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    impl Seek for FailingFlushHandle {
+        fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+            self.inner.seek(pos)
+        }
+    }
+
+    impl runmat_filesystem::FileHandle for FailingFlushHandle {}
 
     fn unwrap_error_message(err: crate::RuntimeError) -> String {
         err.message().to_string()
@@ -425,6 +537,34 @@ pub(crate) mod tests {
         assert_eq!(second.status(), -1.0);
         assert_eq!(second.message(), INVALID_IDENTIFIER_MESSAGE);
         test_support::fs::remove_file(path).unwrap();
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn fclose_keeps_file_registered_when_flush_fails() {
+        let _guard = registry_guard();
+        registry::reset_for_tests();
+        let fail_flush = Arc::new(AtomicBool::new(true));
+        let provider = Arc::new(FailingFlushProvider {
+            fail_flush: fail_flush.clone(),
+        });
+        let _provider_guard = runmat_filesystem::replace_provider(provider);
+
+        let eval = run_fopen(&[Value::from("flush_fail.txt"), Value::from("w")]).expect("fopen");
+        let fid = eval.as_open().expect("open result").fid;
+        assert!(fid >= 3.0);
+
+        let first = run_evaluate(&[Value::Num(fid)]).expect("first fclose");
+        assert_eq!(first.status(), -1.0);
+        assert!(first.message().contains("flush failed"));
+        assert!(registry::info_for(fid as i32).is_some());
+        let handle = registry::take_handle(fid as i32).expect("handle remains registered");
+        assert!(handle.lock().expect("handle lock").is_some());
+
+        fail_flush.store(false, Ordering::SeqCst);
+        let second = run_evaluate(&[Value::Num(fid)]).expect("second fclose");
+        assert_eq!(second.status(), 0.0);
+        assert!(registry::info_for(fid as i32).is_none());
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/runmat-runtime/src/builtins/io/filetext/feof.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/feof.rs
@@ -95,11 +95,14 @@ pub async fn evaluate(fid_value: &Value) -> BuiltinResult<bool> {
 
     let handle = registry::take_handle(fid)
         .ok_or_else(|| feof_error(format!("feof: {INVALID_IDENTIFIER_MESSAGE}")))?;
-    let mut file = handle
+    let mut guard = handle
         .lock()
         .map_err(|_| feof_error("feof: failed to lock file handle (poisoned mutex)"))?;
+    let file = guard
+        .as_mut()
+        .ok_or_else(|| feof_error(format!("feof: {INVALID_IDENTIFIER_MESSAGE}")))?;
 
-    let position = file.seek(SeekFrom::Current(0)).map_err(|err| {
+    let position = file.stream_position().map_err(|err| {
         build_runtime_error(format!("feof: failed to query file position: {err}"))
             .with_builtin(BUILTIN_NAME)
             .with_source(err)

--- a/crates/runmat-runtime/src/builtins/io/filetext/fgets.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/fgets.rs
@@ -138,13 +138,16 @@ pub async fn evaluate(fid_value: &Value, rest: &[Value]) -> BuiltinResult<FgetsE
     }
     let handle = registry::take_handle(fid)
         .ok_or_else(|| fgets_error(format!("fgets: {INVALID_IDENTIFIER_MESSAGE}")))?;
-    let mut file = handle
-        .lock()
-        .map_err(|_| fgets_error("fgets: failed to lock file handle (poisoned mutex)"))?;
 
     let nchar_limit = parse_nchar(rest).await?;
     let max_bytes = apply_matlab_nchar_limit(nchar_limit);
-    let read = read_line(&mut file, max_bytes)?;
+    let mut guard = handle
+        .lock()
+        .map_err(|_| fgets_error("fgets: failed to lock file handle (poisoned mutex)"))?;
+    let file = guard
+        .as_mut()
+        .ok_or_else(|| fgets_error(format!("fgets: {INVALID_IDENTIFIER_MESSAGE}")))?;
+    let read = read_line(file, max_bytes)?;
     if read.eof_before_any {
         return Ok(FgetsEval::end_of_file());
     }

--- a/crates/runmat-runtime/src/builtins/io/filetext/fopen.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/fopen.rs
@@ -456,7 +456,7 @@ async fn handle_open(path_value: &Value, rest: &[Value]) -> BuiltinResult<FopenE
 
     match options.open_async(&path).await {
         Ok(file) => {
-            let handle = Arc::new(StdMutex::new(file));
+            let handle = Arc::new(StdMutex::new(Some(file)));
             let registered = RegisteredFile {
                 path: path.clone(),
                 permission: permission.canonical.clone(),

--- a/crates/runmat-runtime/src/builtins/io/filetext/fopen.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/fopen.rs
@@ -433,10 +433,10 @@ pub async fn evaluate(args: &[Value]) -> BuiltinResult<FopenEval> {
     if is_numeric_value(first) {
         return handle_query(first, &gathered[1..]);
     }
-    handle_open(first, &gathered[1..])
+    handle_open(first, &gathered[1..]).await
 }
 
-fn handle_open(path_value: &Value, rest: &[Value]) -> BuiltinResult<FopenEval> {
+async fn handle_open(path_value: &Value, rest: &[Value]) -> BuiltinResult<FopenEval> {
     if rest.len() > 3 {
         return Err(fopen_error("fopen: too many input arguments"));
     }
@@ -454,7 +454,7 @@ fn handle_open(path_value: &Value, rest: &[Value]) -> BuiltinResult<FopenEval> {
     options.append(permission.append);
     options.truncate(permission.truncate);
 
-    match options.open(&path) {
+    match options.open_async(&path).await {
         Ok(file) => {
             let handle = Arc::new(StdMutex::new(file));
             let registered = RegisteredFile {

--- a/crates/runmat-runtime/src/builtins/io/filetext/fprintf.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/fprintf.rs
@@ -1,7 +1,6 @@
 //! MATLAB-compatible `fprintf` builtin enabling formatted text output to files and standard streams.
 
 use std::io::Write;
-use std::sync::{Arc, Mutex as StdMutex};
 
 use runmat_builtins::Value;
 use runmat_macros::runtime_builtin;
@@ -13,10 +12,9 @@ use crate::builtins::common::spec::{
     BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
     ReductionNaN, ResidencyPolicy, ShapeRequirements,
 };
-use crate::builtins::io::filetext::registry::{self, FileInfo};
+use crate::builtins::io::filetext::registry::{self, FileInfo, SharedFileHandle};
 use crate::console::{record_console_output, ConsoleStream};
 use crate::{build_runtime_error, gather_if_needed_async, BuiltinResult, RuntimeError};
-use runmat_filesystem::File;
 
 const INVALID_IDENTIFIER_MESSAGE: &str =
     "fprintf: Invalid file identifier. Use fopen to generate a valid file ID.";
@@ -260,7 +258,7 @@ enum OutputTarget {
     Stdout,
     Stderr,
     File {
-        handle: Arc<StdMutex<File>>,
+        handle: SharedFileHandle,
         encoding: String,
     },
 }
@@ -287,8 +285,10 @@ impl OutputTarget {
                 let mut guard = handle.lock().map_err(|_| {
                     "fprintf: failed to lock file handle (poisoned mutex)".to_string()
                 })?;
-                guard
-                    .write_all(bytes)
+                let file = guard
+                    .as_mut()
+                    .ok_or_else(|| INVALID_IDENTIFIER_MESSAGE.to_string())?;
+                file.write_all(bytes)
                     .map_err(|err| format!("fprintf: failed to write to file ({err})"))
             }
         }

--- a/crates/runmat-runtime/src/builtins/io/filetext/fread.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/fread.rs
@@ -139,9 +139,6 @@ pub async fn evaluate(fid_value: &Value, rest: &[Value]) -> BuiltinResult<FreadE
         .ok_or_else(|| fread_error(format!("fread: {INVALID_IDENTIFIER_MESSAGE}")))?;
     let handle = registry::take_handle(fid)
         .ok_or_else(|| fread_error(format!("fread: {INVALID_IDENTIFIER_MESSAGE}")))?;
-    let mut file = handle
-        .lock()
-        .map_err(|_| fread_error("fread: failed to lock file handle (poisoned mutex)"))?;
 
     let arg_refs: Vec<&Value> = rest.iter().collect();
     let (size_arg, precision_arg, skip_arg, machine_arg, like_arg) =
@@ -172,8 +169,15 @@ pub async fn evaluate(fid_value: &Value, rest: &[Value]) -> BuiltinResult<FreadE
         &info.machinefmt,
     ))?;
 
+    let mut guard = handle
+        .lock()
+        .map_err(|_| fread_error("fread: failed to lock file handle (poisoned mutex)"))?;
+    let file = guard
+        .as_mut()
+        .ok_or_else(|| fread_error(format!("fread: {INVALID_IDENTIFIER_MESSAGE}")))?;
+
     let mut eval = map_string_result(read_from_handle(
-        &mut file,
+        file,
         &size_spec,
         &precision,
         skip_bytes,

--- a/crates/runmat-runtime/src/builtins/io/filetext/frewind.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/frewind.rs
@@ -96,9 +96,12 @@ pub async fn evaluate(fid_value: &Value) -> BuiltinResult<()> {
 
     let handle = registry::take_handle(fid)
         .ok_or_else(|| frewind_error(format!("frewind: {INVALID_IDENTIFIER_MESSAGE}")))?;
-    let mut file = handle
+    let mut guard = handle
         .lock()
         .map_err(|_| frewind_error("frewind: failed to lock file handle (poisoned mutex)"))?;
+    let file = guard
+        .as_mut()
+        .ok_or_else(|| frewind_error(format!("frewind: {INVALID_IDENTIFIER_MESSAGE}")))?;
 
     file.seek(SeekFrom::Start(0)).map_err(|err| {
         build_runtime_error(format!("frewind: failed to rewind file: {err}"))

--- a/crates/runmat-runtime/src/builtins/io/filetext/fwrite.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/fwrite.rs
@@ -118,10 +118,6 @@ pub async fn evaluate(
         fwrite_error("fwrite: Invalid file identifier. Use fopen to generate a valid file ID.")
     })?;
 
-    let mut file = handle
-        .lock()
-        .map_err(|_| fwrite_error("fwrite: failed to lock file handle (poisoned mutex)"))?;
-
     let data_host = gather_value(data_value).await?;
     let rest_host = gather_args(rest).await?;
     let (precision_arg, skip_arg, machine_arg) = map_string_result(classify_arguments(&rest_host))?;
@@ -130,9 +126,16 @@ pub async fn evaluate(
     let skip_bytes = map_string_result(parse_skip(skip_arg))?;
     let machine_format = map_string_result(parse_machine_format(machine_arg, &info.machinefmt))?;
 
+    let mut guard = handle
+        .lock()
+        .map_err(|_| fwrite_error("fwrite: failed to lock file handle (poisoned mutex)"))?;
+    let file = guard.as_mut().ok_or_else(|| {
+        fwrite_error("fwrite: Invalid file identifier. Use fopen to generate a valid file ID.")
+    })?;
+
     let elements = map_string_result(flatten_elements(&data_host))?;
     let count = map_string_result(write_elements(
-        &mut file,
+        file,
         &elements,
         precision_spec,
         skip_bytes,

--- a/crates/runmat-runtime/src/builtins/io/filetext/registry.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/registry.rs
@@ -17,6 +17,11 @@ enum Resource {
     File(Arc<StdMutex<File>>),
 }
 
+struct RemovedEntry {
+    info: FileInfo,
+    handle: Option<Arc<StdMutex<File>>>,
+}
+
 struct Entry {
     id: i32,
     name: String,
@@ -157,12 +162,37 @@ pub(crate) fn take_handle(fid: i32) -> Option<Arc<StdMutex<File>>> {
         .and_then(|entry| entry.file_handle())
 }
 
+#[cfg(test)]
 pub(crate) fn close(fid: i32) -> Option<FileInfo> {
     if fid < 3 {
         return None;
     }
     let mut guard = REGISTRY.lock().expect("file registry poisoned");
     guard.entries.remove(&fid).map(|entry| entry.info())
+}
+
+pub(crate) async fn close_async(fid: i32) -> std::io::Result<Option<FileInfo>> {
+    let removed = {
+        if fid < 3 {
+            return Ok(None);
+        }
+        let mut guard = REGISTRY.lock().expect("file registry poisoned");
+        guard.entries.remove(&fid).map(|entry| RemovedEntry {
+            info: entry.info(),
+            handle: entry.file_handle(),
+        })
+    };
+
+    let Some(removed) = removed else {
+        return Ok(None);
+    };
+
+    if let Some(handle) = removed.handle {
+        let mut file = handle.lock().expect("registered file handle poisoned");
+        file.flush_async().await?;
+    }
+
+    Ok(Some(removed.info))
 }
 
 #[cfg(test)]

--- a/crates/runmat-runtime/src/builtins/io/filetext/registry.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/registry.rs
@@ -19,7 +19,7 @@ enum Resource {
     File(SharedFileHandle),
 }
 
-struct RemovedEntry {
+struct CloseEntry {
     info: FileInfo,
     handle: Option<SharedFileHandle>,
 }
@@ -174,32 +174,43 @@ pub(crate) fn close(fid: i32) -> Option<FileInfo> {
 }
 
 pub(crate) async fn close_async(fid: i32) -> std::io::Result<Option<FileInfo>> {
-    let removed = {
+    let entry = {
         if fid < 3 {
             return Ok(None);
         }
-        let mut guard = REGISTRY.lock().expect("file registry poisoned");
-        guard.entries.remove(&fid).map(|entry| RemovedEntry {
+        let guard = REGISTRY.lock().expect("file registry poisoned");
+        guard.entries.get(&fid).map(|entry| CloseEntry {
             info: entry.info(),
             handle: entry.file_handle(),
         })
     };
 
-    let Some(removed) = removed else {
+    let Some(entry) = entry else {
         return Ok(None);
     };
 
-    if let Some(handle) = removed.handle {
-        let mut file = {
+    if let Some(handle) = entry.handle {
+        let file = {
             let mut guard = handle.lock().expect("registered file handle poisoned");
             guard.take()
         };
-        if let Some(mut file) = file.take() {
-            file.flush_async().await?;
+        if let Some(mut file) = file {
+            if let Err(err) = file.flush_async().await {
+                let mut guard = handle.lock().expect("registered file handle poisoned");
+                if guard.is_none() {
+                    *guard = Some(file);
+                }
+                return Err(err);
+            }
         }
     }
 
-    Ok(Some(removed.info))
+    let removed = {
+        let mut guard = REGISTRY.lock().expect("file registry poisoned");
+        guard.entries.remove(&fid).map(|entry| entry.info())
+    };
+
+    Ok(removed.or(Some(entry.info)))
 }
 
 #[cfg(test)]

--- a/crates/runmat-runtime/src/builtins/io/filetext/registry.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/registry.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, Mutex as StdMutex};
 
+pub(crate) type SharedFileHandle = Arc<StdMutex<Option<File>>>;
+
 #[derive(Clone)]
 pub(crate) enum StandardStream {
     Stdin,
@@ -14,12 +16,12 @@ pub(crate) enum StandardStream {
 #[derive(Clone)]
 enum Resource {
     Standard,
-    File(Arc<StdMutex<File>>),
+    File(SharedFileHandle),
 }
 
 struct RemovedEntry {
     info: FileInfo,
-    handle: Option<Arc<StdMutex<File>>>,
+    handle: Option<SharedFileHandle>,
 }
 
 struct Entry {
@@ -64,7 +66,7 @@ impl Entry {
         }
     }
 
-    fn file_handle(&self) -> Option<Arc<StdMutex<File>>> {
+    fn file_handle(&self) -> Option<SharedFileHandle> {
         match &self.resource {
             Resource::File(handle) => Some(handle.clone()),
             Resource::Standard => None,
@@ -87,7 +89,7 @@ pub(crate) struct RegisteredFile {
     pub permission: String,
     pub machinefmt: String,
     pub encoding: String,
-    pub handle: Arc<StdMutex<File>>,
+    pub handle: SharedFileHandle,
 }
 
 impl RegisteredFile {
@@ -154,7 +156,7 @@ pub(crate) fn list_infos() -> Vec<FileInfo> {
     infos
 }
 
-pub(crate) fn take_handle(fid: i32) -> Option<Arc<StdMutex<File>>> {
+pub(crate) fn take_handle(fid: i32) -> Option<SharedFileHandle> {
     let guard = REGISTRY.lock().expect("file registry poisoned");
     guard
         .entries
@@ -188,8 +190,13 @@ pub(crate) async fn close_async(fid: i32) -> std::io::Result<Option<FileInfo>> {
     };
 
     if let Some(handle) = removed.handle {
-        let mut file = handle.lock().expect("registered file handle poisoned");
-        file.flush_async().await?;
+        let mut file = {
+            let mut guard = handle.lock().expect("registered file handle poisoned");
+            guard.take()
+        };
+        if let Some(mut file) = file.take() {
+            file.flush_async().await?;
+        }
     }
 
     Ok(Some(removed.info))

--- a/crates/runmat-runtime/src/builtins/math/signal/blackman.rs
+++ b/crates/runmat-runtime/src/builtins/math/signal/blackman.rs
@@ -52,7 +52,7 @@ async fn blackman_builtin(
     varargin: Vec<runmat_builtins::Value>,
 ) -> crate::BuiltinResult<runmat_builtins::Value> {
     let options = parse_window_options(BUILTIN_NAME, n, &varargin, true)?;
-    if provider_precision_matches(options.output_type) {
+    if options.len > 1 && provider_precision_matches(options.output_type) {
         if let Some(provider) = runmat_accelerate_api::provider() {
             if let Ok(handle) = provider.blackman_window(
                 options.len,

--- a/crates/runmat-runtime/src/builtins/math/signal/hamming.rs
+++ b/crates/runmat-runtime/src/builtins/math/signal/hamming.rs
@@ -51,7 +51,7 @@ async fn hamming_builtin(
     varargin: Vec<runmat_builtins::Value>,
 ) -> crate::BuiltinResult<runmat_builtins::Value> {
     let options = parse_window_options(BUILTIN_NAME, n, &varargin, false)?;
-    if provider_precision_matches(options.output_type) {
+    if options.len > 1 && provider_precision_matches(options.output_type) {
         if let Some(provider) = runmat_accelerate_api::provider() {
             if let Ok(handle) = provider.hamming_window(
                 options.len,

--- a/crates/runmat-runtime/src/builtins/math/signal/hann.rs
+++ b/crates/runmat-runtime/src/builtins/math/signal/hann.rs
@@ -52,7 +52,7 @@ async fn hann_builtin(
     varargin: Vec<runmat_builtins::Value>,
 ) -> crate::BuiltinResult<runmat_builtins::Value> {
     let options = parse_window_options(BUILTIN_NAME, n, &varargin, true)?;
-    if provider_precision_matches(options.output_type) {
+    if options.len > 1 && provider_precision_matches(options.output_type) {
         if let Some(provider) = runmat_accelerate_api::provider() {
             if let Ok(handle) = provider.hann_window(
                 options.len,

--- a/crates/runmat-wasm/src/runtime/filesystem/handle.rs
+++ b/crates/runmat-wasm/src/runtime/filesystem/handle.rs
@@ -3,6 +3,9 @@ use std::io::{self, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+use async_trait::async_trait;
+use runmat_filesystem::FileHandle;
+
 use super::bindings::JsFsFuncs;
 
 pub(super) struct JsFileState {
@@ -25,6 +28,26 @@ impl JsFileState {
             self.funcs.write_file(&path, &data)?;
         }
         Ok(())
+    }
+
+    async fn write_back_async(inner: Arc<Mutex<Self>>) -> io::Result<()> {
+        let Some((funcs, path, data)) = ({
+            let mut state = inner.lock().unwrap();
+            if state.can_write && state.dirty {
+                state.dirty = false;
+                Some((
+                    state.funcs.clone(),
+                    state.path.clone(),
+                    state.buffer.clone(),
+                ))
+            } else {
+                None
+            }
+        }) else {
+            return Ok(());
+        };
+
+        funcs.write_file_async(&path, &data).await
     }
 }
 
@@ -101,6 +124,13 @@ impl Seek for JsFileHandle {
         }
         state.cursor = new_pos as usize;
         Ok(state.cursor as u64)
+    }
+}
+
+#[async_trait(?Send)]
+impl FileHandle for JsFileHandle {
+    async fn flush_async(&mut self) -> io::Result<()> {
+        JsFileState::write_back_async(self.inner.clone()).await
     }
 }
 

--- a/crates/runmat-wasm/src/runtime/filesystem/handle.rs
+++ b/crates/runmat-wasm/src/runtime/filesystem/handle.rs
@@ -22,10 +22,10 @@ pub(super) struct JsFileState {
 impl JsFileState {
     fn write_back(&mut self) -> io::Result<()> {
         if self.can_write && self.dirty {
-            self.dirty = false;
             let data = self.buffer.clone();
             let path = self.path.clone();
             self.funcs.write_file(&path, &data)?;
+            self.dirty = false;
         }
         Ok(())
     }
@@ -47,7 +47,15 @@ impl JsFileState {
             return Ok(());
         };
 
-        funcs.write_file_async(&path, &data).await
+        match funcs.write_file_async(&path, &data).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                if let Ok(mut state) = inner.lock() {
+                    state.dirty = true;
+                }
+                Err(err)
+            }
+        }
     }
 }
 

--- a/crates/runmat-wasm/src/runtime/filesystem/provider.rs
+++ b/crates/runmat-wasm/src/runtime/filesystem/provider.rs
@@ -25,62 +25,21 @@ unsafe impl Sync for JsFsProvider {}
 #[async_trait(?Send)]
 impl FsProvider for JsFsProvider {
     fn open(&self, path: &Path, flags: &OpenFlags) -> io::Result<Box<dyn FileHandle>> {
-        let mut initial = Vec::new();
-        let mut exists = false;
-        let mut dirty = false;
-
-        if flags.read || (!flags.create && !flags.create_new) || flags.append {
-            match self.funcs.read_file(path) {
-                Ok(bytes) => {
-                    initial = bytes;
-                    exists = true;
-                }
-                Err(err) if err.kind() == ErrorKind::NotFound => {
-                    exists = false;
-                }
-                Err(err) => return Err(err),
-            }
-        }
-
-        if flags.create_new && exists {
-            return Err(io::Error::new(
-                ErrorKind::AlreadyExists,
-                format!("File already exists: {}", path.display()),
-            ));
-        }
-
-        if flags.create && !exists {
-            exists = true;
-            dirty = true;
-        }
-
-        if !exists && !flags.create {
-            return Err(io::Error::new(
-                ErrorKind::NotFound,
-                format!("File not found: {}", path.display()),
-            ));
-        }
-
-        if flags.truncate {
-            initial.clear();
-            dirty = true;
-        }
-
-        let cursor = if flags.append { initial.len() } else { 0 };
-
-        let inner = JsFileState {
-            funcs: self.funcs.clone(),
-            path: path.to_path_buf(),
-            buffer: initial,
-            cursor,
-            can_read: flags.read,
-            can_write: flags.write || flags.append,
-            append: flags.append,
-            dirty,
+        let read_result = if should_load_initial(flags) {
+            Some(self.funcs.read_file(path))
+        } else {
+            None
         };
-        #[allow(clippy::arc_with_non_send_sync)]
-        let inner = Arc::new(Mutex::new(inner));
-        Ok(Box::new(JsFileHandle { inner }))
+        self.open_with_initial(path, flags, read_result)
+    }
+
+    async fn open_async(&self, path: &Path, flags: &OpenFlags) -> io::Result<Box<dyn FileHandle>> {
+        let read_result = if should_load_initial(flags) {
+            Some(self.funcs.read_file_async(path).await)
+        } else {
+            None
+        };
+        self.open_with_initial(path, flags, read_result)
     }
 
     async fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
@@ -138,4 +97,74 @@ impl FsProvider for JsFsProvider {
     async fn read_many(&self, paths: &[PathBuf]) -> io::Result<Vec<ReadManyEntry>> {
         self.funcs.read_many(paths).await
     }
+}
+
+impl JsFsProvider {
+    fn open_with_initial(
+        &self,
+        path: &Path,
+        flags: &OpenFlags,
+        read_result: Option<io::Result<Vec<u8>>>,
+    ) -> io::Result<Box<dyn FileHandle>> {
+        let mut initial = Vec::new();
+        let mut exists = false;
+        let mut dirty = false;
+
+        if let Some(read_result) = read_result {
+            match read_result {
+                Ok(bytes) => {
+                    initial = bytes;
+                    exists = true;
+                }
+                Err(err) if err.kind() == ErrorKind::NotFound => {
+                    exists = false;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        if flags.create_new && exists {
+            return Err(io::Error::new(
+                ErrorKind::AlreadyExists,
+                format!("File already exists: {}", path.display()),
+            ));
+        }
+
+        if flags.create && !exists {
+            exists = true;
+            dirty = true;
+        }
+
+        if !exists && !flags.create {
+            return Err(io::Error::new(
+                ErrorKind::NotFound,
+                format!("File not found: {}", path.display()),
+            ));
+        }
+
+        if flags.truncate {
+            initial.clear();
+            dirty = true;
+        }
+
+        let cursor = if flags.append { initial.len() } else { 0 };
+
+        let inner = JsFileState {
+            funcs: self.funcs.clone(),
+            path: path.to_path_buf(),
+            buffer: initial,
+            cursor,
+            can_read: flags.read,
+            can_write: flags.write || flags.append,
+            append: flags.append,
+            dirty,
+        };
+        #[allow(clippy::arc_with_non_send_sync)]
+        let inner = Arc::new(Mutex::new(inner));
+        Ok(Box::new(JsFileHandle { inner }))
+    }
+}
+
+fn should_load_initial(flags: &OpenFlags) -> bool {
+    flags.read || (!flags.create && !flags.create_new) || flags.append
 }

--- a/website/app/matlab-online/page.tsx
+++ b/website/app/matlab-online/page.tsx
@@ -305,7 +305,7 @@ export default function MatlabOnlinePage() {
                 MATLAB online alternative
               </div>
               <h1 className="font-bold text-left leading-tight tracking-tight text-3xl sm:text-4xl md:text-5xl">
-                Run your MATLAB code in the browser blazing fast
+                Run MATLAB code in the browser blazing fast
               </h1>
               <p className="max-w-[42rem] leading-relaxed text-foreground text-[0.938rem]">
                 RunMat executes MATLAB-syntax code in your browser with auto GPU acceleration. No account or licence

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -219,10 +219,10 @@ export default function HomePage() {
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
             <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
-              See your math in 3D
+              GPU Accelerated Computing
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
-              GPU-accelerated 2D and 3D plotting, built into the same environment as your code. Your plots are part of the same computation chain as your math. No copying data between systems, no separate plotting library.
+              GPU-accelerated 2D and 3D plotting, designed as tensor projection operations on your data in GPU memory. Since your plots are part of the same computation chain as your math no data needs to be copied between systems, allowing you to plot your data as fast as you can compute it.
             </p>
           </div>
           <div className="mx-auto max-w-3xl">
@@ -292,10 +292,10 @@ export default function HomePage() {
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
             <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
-              The fastest runtime for your math
+              Blazing fast runtime for math
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground sm:leading-7">
-              RunMat runs math faster because of how the runtime is engineered. Fusion merges sequential operations into fewer GPU steps; residency keeps your arrays on-device between steps. That means less memory traffic, fewer program launches, and faster scripts.
+              RunMat automatically promotes tensor operations to GPUs where it helps. Fusion merges sequential operations into fewer GPU steps; residency keeps your arrays on-device between steps. That means your code runs on GPUs automatically where they're available, without you having to decide in your code what to run on what.
             </p>
           </div>
 

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
-import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { SiGithub } from "react-icons/si";
 import { Users, GitBranch, Camera, Lock, Shield, Eye, ClipboardCheck, Cpu, Monitor, HardDrive } from "lucide-react";
@@ -295,7 +294,7 @@ export default function HomePage() {
               Blazing fast runtime for math
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground sm:leading-7">
-              RunMat automatically promotes tensor operations to GPUs where it helps. Fusion merges sequential operations into fewer GPU steps; residency keeps your arrays on-device between steps. That means your code runs on GPUs automatically where they're available, without you having to decide in your code what to run on what.
+              RunMat automatically promotes tensor operations to GPUs where it helps. Fusion merges sequential operations into fewer GPU steps; residency keeps your arrays on-device between steps. That means your code runs on GPUs automatically where they&apos;re available, without you having to decide in your code what to run on what.
             </p>
           </div>
 

--- a/website/app/pricing/page.tsx
+++ b/website/app/pricing/page.tsx
@@ -121,7 +121,7 @@ export default function PricingPage() {
             <Card className="flex h-full flex-col border border-border/60">
               <CardHeader className="space-y-3 pb-4">
                 <Badge className="w-fit bg-green-500/20 text-green-800 border-green-600/50 dark:text-green-200 dark:border-green-400/40 hover:bg-green-500/20">
-                  Open Source Runtime
+                  OSS
                 </Badge>
                 <CardTitle className="text-lg font-semibold text-foreground">RunMat</CardTitle>
                 <p className="text-[0.938rem] text-foreground">Open-source, GPU-accelerated math runtime. MATLAB syntax, no account required.</p>
@@ -151,7 +151,7 @@ export default function PricingPage() {
                     asChild
                     className="w-full rounded-none border-0 bg-[hsl(var(--brand))] text-white transition-opacity shadow-none hover:bg-[hsl(var(--brand))]/90"
                   >
-                    <Link href="/sandbox">Open Sandbox</Link>
+                    <Link href="/sandbox">Open Browser Sandbox</Link>
                   </Button>
                 </div>
               </CardContent>
@@ -165,7 +165,7 @@ export default function PricingPage() {
                   Enterprise
                 </Badge>
                 <CardTitle className="text-lg font-semibold text-foreground">RunMat Enterprise</CardTitle>
-                <p className="text-[0.938rem] text-foreground">Everything in RunMat Cloud, plus on-prem deployment and compliance.</p>
+                <p className="text-[0.938rem] text-foreground">On-prem deployment and compliance.</p>
                 <p className="text-3xl font-bold text-foreground">Custom</p>
                 <p className="text-sm text-muted-foreground">Self-hosted deployment for secure, air-gapped environments.</p>
               </CardHeader>

--- a/website/app/pricing/page.tsx
+++ b/website/app/pricing/page.tsx
@@ -114,7 +114,7 @@ export default function PricingPage() {
               Pricing
             </h1>
             <h2>
-              Start for free. Upgrade to get the capacity that exactly matches your team's needs.
+              Start for free. Upgrade to get the capacity that exactly matches your team&apos;s needs.
             </h2>
           </div>
         </section>

--- a/website/app/pricing/page.tsx
+++ b/website/app/pricing/page.tsx
@@ -62,7 +62,7 @@ const pricingFaqItems: { question: string; answer: string; answerContent?: React
   {
     question: "What's included in Cloud Hobby vs Pro vs Team?",
     answer:
-      "Hobby: unlimited projects, 100 MB storage, version history (counts toward storage). Pro: unlimited projects, 10GB storage, version history (counts toward storage) ($30/mo per user). Team: unlimited projects, SSO / SAML (and SCIM), 100GB storage, version history (counts toward storage), priority support ($100/mo per user).",
+      "Hobby: unlimited projects, 100 MB storage, version history (counts toward storage). Pro: unlimited projects, 10GB storage, version history (counts toward storage) ($30/mo per user). Team: unlimited projects, SSO / SAML / SCIM, 100GB storage, version history (counts toward storage), priority support ($100/mo per user).",
   },
   {
     question: "How does RunMat Cloud billing work?",
@@ -111,8 +111,11 @@ export default function PricingPage() {
         <section className="w-full pt-16 md:pt-24 lg:pt-32 pb-10 md:pb-12">
           <div className="mx-auto max-w-3xl space-y-4 text-center">
             <h1 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
-              Simple, transparent pricing
+              Pricing
             </h1>
+            <h2>
+              Start for free. Upgrade to get the capacity that exactly matches your team's needs.
+            </h2>
           </div>
         </section>
 
@@ -123,7 +126,7 @@ export default function PricingPage() {
                 <Badge className="w-fit bg-green-500/20 text-green-800 border-green-600/50 dark:text-green-200 dark:border-green-400/40 hover:bg-green-500/20">
                   OSS
                 </Badge>
-                <CardTitle className="text-lg font-semibold text-foreground">RunMat</CardTitle>
+                <CardTitle className="text-lg font-semibold text-foreground">RunMat Runtime</CardTitle>
                 <p className="text-[0.938rem] text-foreground">Open-source, GPU-accelerated math runtime. MATLAB syntax, no account required.</p>
                 <p className="text-3xl font-bold text-foreground">Free, forever</p>
               </CardHeader>

--- a/website/components/BlogLayout.tsx
+++ b/website/components/BlogLayout.tsx
@@ -1,4 +1,3 @@
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { ArrowLeft, Calendar, Clock, User } from "lucide-react";
@@ -25,7 +24,6 @@ export function BlogLayout({
   dateModified,
   readTime,
   authors,
-  tags,
   rightAside,
   backLink = { href: '/blog', text: 'Back to Blog' },
   descriptionPlacement = 'beforeMeta'

--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -43,7 +43,7 @@ export default function Footer() {
             </Link>
           </div>
           <p className="text-sm text-muted-foreground leading-relaxed">
-            Run math, blazing fast
+            Run math blazing fast
           </p>
           <div className="flex items-center gap-3 mt-1">
             <Link href="https://github.com/runmat-org/runmat" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-foreground transition-colors">

--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -43,7 +43,7 @@ export default function Footer() {
             </Link>
           </div>
           <p className="text-sm text-muted-foreground leading-relaxed">
-            Run your math, blazing fast
+            Run math, blazing fast
           </p>
           <div className="flex items-center gap-3 mt-1">
             <Link href="https://github.com/runmat-org/runmat" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-foreground transition-colors">

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -9,7 +9,7 @@ export default function Hero() {
         <div className="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:items-center">
           <div className="flex flex-col space-y-6 text-left items-start">
             <p className="font-heading text-left leading-tight tracking-tight text-[clamp(2.6rem,4.8vw,4.25rem)] sm:text-[clamp(3rem,4vw,5rem)] lg:text-[clamp(3.25rem,3.6vw,5.25rem)]" role="heading" aria-level={2}>
-              Run your math, blazing fast
+              Run math, blazing fast
             </p>
             <p className="max-w-[42rem] leading-relaxed text-foreground text-[0.938rem] sm:text-base">
               Write MATLAB-syntax code and run it with GPU acceleration, in your browser, on the desktop, or from the CLI. No license required.

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -12,7 +12,7 @@ export default function Hero() {
               Run math blazing fast
             </p>
             <p className="max-w-[42rem] leading-relaxed text-foreground text-[0.938rem] sm:text-base">
-              Write MATLAB-syntax code and run it with GPU acceleration, in your browser, on the desktop, or from the CLI. No license required.
+              High performance, GPU-accelerated math. Run in your browser, on the desktop, or from the CLI.
             </p>
             <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
               <Button

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -9,7 +9,7 @@ export default function Hero() {
         <div className="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:items-center">
           <div className="flex flex-col space-y-6 text-left items-start">
             <p className="font-heading text-left leading-tight tracking-tight text-[clamp(2.6rem,4.8vw,4.25rem)] sm:text-[clamp(3rem,4vw,5rem)] lg:text-[clamp(3.25rem,3.6vw,5.25rem)]" role="heading" aria-level={2}>
-              Run math, blazing fast
+              Run math blazing fast
             </p>
             <p className="max-w-[42rem] leading-relaxed text-foreground text-[0.938rem] sm:text-base">
               Write MATLAB-syntax code and run it with GPU acceleration, in your browser, on the desktop, or from the CLI. No license required.

--- a/website/components/pricing/CloudPricingCard.tsx
+++ b/website/components/pricing/CloudPricingCard.tsx
@@ -53,7 +53,7 @@ const cloudTierConfig: Record<CloudTier, CloudTierDef> = {
     inheritsFrom: "Everything in Pro, plus:",
     features: [
       { label: "100 GB storage", href: "#compare-storage" },
-      "SSO / SAML (and SCIM)",
+      "SSO / SAML / SCIM",
       "$50/mo LLM tokens included",
       "Priority support",
     ],
@@ -76,9 +76,9 @@ export default function CloudPricingCard() {
     <Card className="relative flex h-full flex-col border border-[hsl(var(--brand))]/50 shadow-sm">
       <CardHeader className="space-y-3 pb-4">
         <Badge className="w-fit bg-secondary text-foreground border-border hover:bg-secondary">
-          Desktop
+          App
         </Badge>
-        <CardTitle className="text-lg font-semibold text-foreground">RunMat Desktop</CardTitle>
+        <CardTitle className="text-lg font-semibold text-foreground">RunMat App</CardTitle>
         <p className="text-[0.938rem] text-foreground">High performance computing platform.</p>
         <p className="text-3xl font-bold text-foreground">{currentTier.price}</p>
       </CardHeader>

--- a/website/components/pricing/CloudPricingCard.tsx
+++ b/website/components/pricing/CloudPricingCard.tsx
@@ -27,9 +27,9 @@ const cloudTierConfig: Record<CloudTier, CloudTierDef> = {
     price: "$0",
     description: "Sign up to get cloud storage and versioning.",
     features: [
-      "Unlimited projects",
+      { label: "GPU accelerated plotting", href: "#compare-plotting" },
+      "Plot, code and variable version history",
       { label: "100 MB storage", href: "#compare-storage" },
-      "Version history (uses storage)",
       "Community support",
     ],
     ctaLabel: "Start free",
@@ -38,9 +38,11 @@ const cloudTierConfig: Record<CloudTier, CloudTierDef> = {
   pro: {
     price: "$30/mo per user",
     description: "For individuals and small teams shipping real work.",
-    inheritsFrom: "Everything in Hobby, plus:",
     features: [
+      { label: "GPU accelerated plotting", href: "#compare-plotting" },
+      { label: "Plot, code and variable version history", href: "#compare-versioning" },
       { label: "10 GB storage", href: "#compare-storage" },
+      { label: "$10/mo LLM tokens included", href: "#compare-llm" },
     ],
     ctaLabel: "Get started",
     ctaHref: "/sandbox",
@@ -52,6 +54,7 @@ const cloudTierConfig: Record<CloudTier, CloudTierDef> = {
     features: [
       { label: "100 GB storage", href: "#compare-storage" },
       "SSO / SAML (and SCIM)",
+      "$50/mo LLM tokens included",
       "Priority support",
     ],
     ctaLabel: "Get started",
@@ -66,17 +69,17 @@ const cloudTierTabs: { id: CloudTier; label: string }[] = [
 ];
 
 export default function CloudPricingCard() {
-  const [activeTier, setActiveTier] = useState<CloudTier>("hobby");
+  const [activeTier, setActiveTier] = useState<CloudTier>("pro");
   const currentTier = cloudTierConfig[activeTier];
 
   return (
     <Card className="relative flex h-full flex-col border border-[hsl(var(--brand))]/50 shadow-sm">
       <CardHeader className="space-y-3 pb-4">
         <Badge className="w-fit bg-secondary text-foreground border-border hover:bg-secondary">
-          Cloud
+          Desktop
         </Badge>
-        <CardTitle className="text-lg font-semibold text-foreground">RunMat Cloud</CardTitle>
-        <p className="text-[0.938rem] text-foreground">Everything in RunMat, plus cloud storage and versioning.</p>
+        <CardTitle className="text-lg font-semibold text-foreground">RunMat Desktop</CardTitle>
+        <p className="text-[0.938rem] text-foreground">High performance computing platform.</p>
         <p className="text-3xl font-bold text-foreground">{currentTier.price}</p>
       </CardHeader>
       <CardContent className="flex flex-1 min-h-0 flex-col space-y-5">

--- a/website/components/pricing/ComparisonTables.tsx
+++ b/website/components/pricing/ComparisonTables.tsx
@@ -126,7 +126,7 @@ export function CompareProductsTable() {
       </h2>
       <div className="rounded-xl border border-border/60 overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="w-full min-w--[480px] text-sm">
+          <table className="w-full min-w-[480px] text-sm">
             <thead>
               <tr className="border-b border-border/40">
                 <th className="text-left py-4 px-5 text-sm font-medium text-muted-foreground w-[40%]">

--- a/website/components/pricing/ComparisonTables.tsx
+++ b/website/components/pricing/ComparisonTables.tsx
@@ -126,19 +126,19 @@ export function CompareProductsTable() {
       </h2>
       <div className="rounded-xl border border-border/60 overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[480px] text-sm">
+          <table className="w-full min-w--[480px] text-sm">
             <thead>
               <tr className="border-b border-border/40">
                 <th className="text-left py-4 px-5 text-sm font-medium text-muted-foreground w-[40%]">
                   Feature
                 </th>
                 <th className="text-center py-4 px-3 w-[20%]">
-                  <div className="text-sm font-semibold text-foreground">RunMat</div>
-                  <div className="text-xs font-normal text-muted-foreground mt-0.5">Essential runtime features</div>
+                  <div className="text-sm font-semibold text-foreground">Runtime</div>
+                  <div className="text-xs font-normal text-muted-foreground mt-0.5">GPU-accelerated math runtime</div>
                 </th>
                 <th className="text-center py-4 px-3 w-[20%]">
-                  <div className="text-sm font-semibold text-foreground">Cloud</div>
-                  <div className="text-xs font-normal text-muted-foreground mt-0.5">Cloud-based solution</div>
+                  <div className="text-sm font-semibold text-foreground">App</div>
+                  <div className="text-xs font-normal text-muted-foreground mt-0.5">High performance computing platform</div>
                 </th>
                 <th className="text-center py-4 px-3 w-[20%]">
                   <div className="text-sm font-semibold text-foreground">Enterprise</div>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -55,7 +55,6 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.4.5",
-        "playwright": "^1.49.0",
         "sharp": "^0.34.5",
         "tw-animate-css": "^1.3.6",
         "typescript": "^5"
@@ -5870,21 +5869,6 @@
         }
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -9098,38 +9082,6 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.58.2"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/points-on-curve": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core file I/O paths across filesystem providers and MATLAB-style runtime builtins, including new async open/flush and changed handle lifecycle semantics, which could affect correctness across platforms (notably wasm). Website copy and lockfile edits are low risk but bundled with the I/O refactor.
> 
> **Overview**
> **Filesystem I/O gains async entry points.** `runmat-filesystem` adds `FsProvider::open_async`, `OpenOptions::open_async`, `File::open_async`/`create_async`, and an async `FileHandle::flush_async` hook; wasm `JsFsProvider`/`JsFileHandle` now use async JS bindings for open and flush.
> 
> **Runtime file builtins now use async open/close and safer handle lifecycle.** `fopen` switches to async open and stores handles as `Option<File>` behind a mutex, while `fclose` uses new `registry::close_async` to `flush_async` before deregistering and to keep the file registered when flush fails (with new tests); other filetext builtins (`fprintf`, `fread`, `fwrite`, `fgets`, `feof`, `frewind`) are updated to error cleanly when the handle has been taken/closed.
> 
> **Small follow-ups.** GPU window builtins (`blackman`/`hann`/`hamming`) avoid provider paths for `len<=1`, and website pages adjust marketing/pricing copy plus remove `playwright` from `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba52e489cc52c3226b5819c3970252bd2e1398c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async file operations added (async open/create/flush) across filesystem/runtime enabling non-blocking I/O.

* **Bug Fixes**
  * I/O builtins now return explicit "invalid file identifier" errors when handles are closed/missing.
  * File close preserves state on flush failure and only deregisters after successful flush.

* **Performance**
  * Runtime open/close paths and file I/O use async execution for reduced blocking.

* **Tests**
  * New tests cover async provider/handle paths and flush-failure behavior.

* **UI Copy**
  * Updated homepage, pricing, footer, and hero copy and tier descriptions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/337)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->