### PR TITLE
Agent mkt first

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,33 +1,21 @@
-# License
+# MIT License
 
-RunMat is licensed under the **MIT License** with **Attribution Requirements** and **Commercial Scientific Software Company Copyleft** Provisions.
+Copyright (c) 2024-2026 Dystr, Inc. and RunMat contributors
 
-## MIT License with Additional Terms
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Copyright (c) 2025 Dystr Inc. and RunMat contributors
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-### Attribution Requirement
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. Any distribution, fork, modification, or derivative work of this Software must maintain attribution to "RunMat by Dystr" in a prominent location visible to end users. This includes but is not limited to:
-
-1. **Startup messages** or **about dialogs** displaying "RunMat by Dystr"
-2. **Documentation** and **README files** crediting "RunMat by Dystr"  
-3. **Package names** or **project titles** indicating the RunMat origin
-4. **Web interfaces** showing "Powered by RunMat by Dystr"
-
-### Commercial Scientific Software Company Copyleft
-
-Any entity whose **primary business purpose** involves the development, licensing, or sale of scientific computing software, engineering simulation software, mathematical computing environments, or technical computing platforms (including but not limited to companies like MathWorks, Ansys, COMSOL Multiphysics, Dassault Systèmes, Autodesk, PTC, Siemens Digital Industries Software, Altair, and similar organizations) that creates a fork, derivative work, or modification of this Software **MUST** distribute their modified version under the same license terms as this license, making their modifications available as open source.
-
-This copyleft provision does **NOT** apply to:
-- Individual researchers, academic institutions, or educational organizations
-- Companies using RunMat as a dependency without modification
-- Companies whose primary business is not scientific/technical computing software
-- Internal modifications not distributed to third parties
-- Other open source projects and their maintainers
-
-### Disclaimer
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <p align="center">
   <a href="https://github.com/runmat-org/runmat/actions"><img src="https://img.shields.io/github/actions/workflow/status/runmat-org/runmat/ci.yml?branch=main" alt="Build Status"></a>
-  <a href="LICENSE.md"><img src="https://img.shields.io/badge/license-MIT%20with%20Attribution-blue.svg" alt="License"></a>
+  <a href="LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <a href="https://crates.io/crates/runmat"><img src="https://img.shields.io/crates/v/runmat.svg" alt="Crates.io"></a>
   <a href="https://crates.io/crates/runmat"><img src="https://img.shields.io/crates/d/runmat.svg" alt="Downloads"></a>
   <a href="https://github.com/runmat-org/runmat/stargazers"><img src="https://img.shields.io/github/stars/runmat-org/runmat" alt="GitHub Stars"></a>
@@ -504,25 +504,24 @@ RunMat is open source and contributions are welcome.
 
 ### Connect
 
-- **GitHub Discussions**: [Share ideas and get help](https://github.com/runmat-org/runmat/discussions)  
-- **X (Twitter)**: [@runmat_com](https://x.com/runmat_com) for updates and announcements  
+- **GitHub Discussions**: [Share ideas and get help](https://github.com/runmat-org/runmat/discussions)
+- **X (Twitter)**: [@runmat_com](https://x.com/runmat_com) for updates and announcements
 - **LinkedIn**: [RunMat](https://www.linkedin.com/company/runmat)
 
 ---
 
 ## License
 
-The RunMat runtime is open source and licensed under the **MIT License with Attribution Requirements**. This means:
+The RunMat runtime is open source under the **MIT License** — the same license used by Julia, VS Code, TypeScript, and Bun. This means:
 
-- **Free for everyone** - individuals, academics, most companies  
-- **Open source forever** - the runtime will always be free and open  
-- **Commercial use allowed** - embed in your products freely  
-- **Attribution required** - credit "RunMat by Dystr" in public distributions  
-- **Special provisions** - large scientific software companies must keep modifications open source  
+- **Free for everyone** — individuals, academics, companies of any size
+- **Use anywhere** — commercial products, internal tools, research, teaching
+- **Modify and redistribute freely** — fork it, embed it, ship it
+- **Open source forever** — the runtime will always be free and open
 
-RunMat Cloud and the desktop app are separate products built on top of this open-source runtime. See [runmat.com/pricing](https://runmat.com/pricing) for details.
+The Dystr AI assistant and Dystr Cloud are commercial products built on top of this open-source runtime. See [runmat.com/pricing](https://runmat.com/pricing) for details.
 
-See [LICENSE.md](LICENSE.md) for complete terms or visit [runmat.com/license](https://runmat.com/license) for FAQs.
+See [LICENSE.md](LICENSE.md) for the full license text or visit [runmat.com/license](https://runmat.com/license) for FAQs.
 
 ---
 

--- a/bindings/LICENSE.md
+++ b/bindings/LICENSE.md
@@ -1,33 +1,21 @@
-# License
+# MIT License
 
-RunMat is licensed under the **MIT License** with **Attribution Requirements** and **Commercial Scientific Software Company Copyleft** Provisions.
+Copyright (c) 2024-2026 Dystr, Inc. and RunMat contributors
 
-## MIT License with Additional Terms
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Copyright (c) 2025 Dystr Inc. and RunMat contributors
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-### Attribution Requirement
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. Any distribution, fork, modification, or derivative work of this Software must maintain attribution to "RunMat by Dystr" in a prominent location visible to end users. This includes but is not limited to:
-
-1. **Startup messages** or **about dialogs** displaying "RunMat by Dystr"
-2. **Documentation** and **README files** crediting "RunMat by Dystr"  
-3. **Package names** or **project titles** indicating the RunMat origin
-4. **Web interfaces** showing "Powered by RunMat by Dystr"
-
-### Commercial Scientific Software Company Copyleft
-
-Any entity whose **primary business purpose** involves the development, licensing, or sale of scientific computing software, engineering simulation software, mathematical computing environments, or technical computing platforms (including but not limited to companies like MathWorks, Ansys, COMSOL Multiphysics, Dassault Systèmes, Autodesk, PTC, Siemens Digital Industries Software, Altair, and similar organizations) that creates a fork, derivative work, or modification of this Software **MUST** distribute their modified version under the same license terms as this license, making their modifications available as open source.
-
-This copyleft provision does **NOT** apply to:
-- Individual researchers, academic institutions, or educational organizations
-- Companies using RunMat as a dependency without modification
-- Companies whose primary business is not scientific/technical computing software
-- Internal modifications not distributed to third parties
-- Other open source projects and their maintainers
-
-### Disclaimer
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/DESIGN_PHILOSOPHY.md
+++ b/docs/DESIGN_PHILOSOPHY.md
@@ -114,7 +114,7 @@ RunMat is for people who want a fast, pleasant MATLAB-style environment that evo
 ## Related
 
 - [High-Level Architecture](/docs/architecture) -- RunMat's V8-inspired execution model and subsystems.
-- [Package Manager](/docs/package-manager) -- the package system for extending RunMat.
+- [Package system](/docs/how-it-works) -- the package system for extending RunMat.
 - [Introduction to RunMat Fusion](/docs/accelerate/fusion-intro) -- GPU data residency and fusion.
 - [Correctness & Trust](/docs/correctness) -- how we validate every numerical path, with the full coverage table and parity-test index.
 - [Language Reference](/docs/language) -- compatibility modes and MATLAB syntax support.

--- a/website/app/license/page.tsx
+++ b/website/app/license/page.tsx
@@ -1,12 +1,13 @@
 import { Metadata } from "next";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CheckCircle, AlertCircle, HelpCircle, Mail } from "lucide-react";
+import { CheckCircle, Code, Sparkles, Mail } from "lucide-react";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "RunMat License",
-  description: "RunMat is licensed under the MIT License with Attribution Requirements and Commercial Scientific Software Company Copyleft Provisions. See runmat.com/license for the full license text.",
+  title: "RunMat License — MIT, Open Source",
+  description:
+    "The RunMat runtime is open source under the MIT License — the same license used by Julia, VS Code, TypeScript, and Bun. Free to use, modify, and redistribute for any purpose.",
   alternates: { canonical: "https://runmat.com/license" },
   openGraph: {
     url: "https://runmat.com/license",
@@ -20,9 +21,9 @@ const jsonLd = {
       "@type": "WebPage",
       "@id": "https://runmat.com/license#webpage",
       url: "https://runmat.com/license",
-      name: "RunMat License",
+      name: "RunMat License — MIT, Open Source",
       description:
-        "RunMat is licensed under the MIT License with Attribution Requirements and Commercial Scientific Software Company Copyleft Provisions. Free for everyone with clear terms.",
+        "The RunMat runtime is open source under the MIT License. Free for everyone — individuals, academics, and companies of any size — with no attribution requirements or field-of-use restrictions.",
       inLanguage: "en",
       isPartOf: { "@id": "https://runmat.com/#website" },
       author: { "@id": "https://runmat.com/#organization" },
@@ -37,42 +38,74 @@ const jsonLd = {
       mainEntity: [
         {
           "@type": "Question",
+          name: "Is RunMat open source?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Yes. The RunMat runtime is licensed under the MIT License, which is approved by the Open Source Initiative (OSI). It is the same license used by Julia, VS Code, TypeScript, Bun, and Node.js.",
+          },
+        },
+        {
+          "@type": "Question",
           name: "Can I use RunMat for free?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "Yes! RunMat is completely free for individual researchers and scientists, academic institutions and educational organizations, students for learning and coursework, most commercial companies and startups, open source projects, and government agencies and non-profits.",
+            text: "Yes. The MIT License lets anyone use RunMat for any purpose — individuals, researchers, students, startups, large enterprises, and government organizations. There are no fees, no usage limits, and no field-of-use restrictions.",
           },
         },
         {
           "@type": "Question",
-          name: "What does attribution required mean?",
+          name: "Can I use RunMat in a commercial product?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "Any distribution or modification of RunMat must credit 'RunMat by Dystr'. This includes startup messages or about dialogs, documentation and README files, package names or project titles, and web interfaces showing 'Powered by RunMat by Dystr'.",
+            text: "Yes. The MIT License explicitly permits commercial use. You can embed RunMat in proprietary software, ship it inside paid products, integrate it into internal tools, or use it as a dependency in any commercial context. Your own code that uses RunMat remains your own.",
           },
         },
         {
           "@type": "Question",
-          name: "What are the special rules for scientific software companies?",
+          name: "Can I fork RunMat or modify it?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "Companies whose primary business involves developing, licensing, or selling scientific computing software (like MathWorks, Ansys, COMSOL, etc.) must distribute any RunMat modifications as open source under the same license. This does NOT apply to companies using RunMat without modification, companies whose primary business is not scientific computing software, internal modifications not distributed to third parties, or academic institutions.",
+            text: "Yes. You can fork, modify, redistribute, and sublicense RunMat. The only requirement is that you preserve the MIT copyright notice in source files. There are no attribution requirements in startup messages, documentation, or user interfaces.",
           },
         },
         {
           "@type": "Question",
-          name: "Can I create proprietary software that uses RunMat?",
+          name: "What about the Dystr AI assistant — is that open source?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "Yes! Most users can create proprietary software that uses or embeds RunMat. The license only requires that if you distribute or modify RunMat itself, you provide attribution to 'RunMat by Dystr', include the license notice, and share any modifications to RunMat itself if you're a scientific software company. Your own code that calls RunMat functions remains proprietary.",
+            text: "No. The Dystr AI assistant and Dystr Cloud are commercial products built on top of the open-source RunMat runtime. This is a standard open-core model, similar to VS Code (open source) plus Pylance and GitHub Copilot (commercial). See runmat.com/pricing for details.",
           },
         },
         {
           "@type": "Question",
-          name: "How does this compare to other open source licenses?",
+          name: "Do I need to credit RunMat?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "RunMat's license is based on the MIT License with two additional requirements: Attribution (similar to BSD licenses, ensures credit is maintained) and Targeted copyleft (only applies to large scientific software companies, ensuring community contributions). For most users, it's as permissive as MIT.",
+            text: "Beyond preserving the copyright notice in source files (a standard MIT requirement), no. We appreciate attribution in your README or about page, but it is not legally required.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Is the MIT License OSI-approved?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Yes. The MIT License is one of the original licenses approved by the Open Source Initiative and is on every major enterprise legal team's pre-approved license list. This means RunMat can be adopted at organizations that require formally OSI-approved open-source software.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Will the license ever change?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "We have no plans to change the license of the RunMat runtime away from MIT. Past releases will always remain available under the MIT terms they were originally published under, regardless of any future changes.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Is 'RunMat' a trademark?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Yes. 'RunMat' is a trademark of Dystr, Inc. The MIT License covers the source code but does not grant rights to the RunMat name or logo. You can fork the code freely; please don't call your fork 'RunMat'. For trademark questions, contact legal@dystr.com.",
           },
         },
       ],
@@ -90,7 +123,7 @@ export default function LicensePage() {
         }}
       />
       <div className="container mx-auto max-w-4xl px-4 md:px-6 py-16 md:py-24 lg:py-32">
-        
+
         {/* Header */}
         <div className="mb-12">
           <Badge variant="secondary" className="mb-4">Legal</Badge>
@@ -98,8 +131,9 @@ export default function LicensePage() {
             RunMat License
           </h1>
           <p className="text-[0.938rem] text-foreground leading-relaxed">
-            RunMat is free and open source software with clear, fair licensing terms. 
-            This page explains what you can and cannot do with RunMat.
+            The RunMat runtime is open source under the <strong>MIT License</strong> —
+            the same license used by Julia, VS Code, TypeScript, and Bun.
+            Free to use, modify, and redistribute for any purpose.
           </p>
         </div>
 
@@ -108,35 +142,35 @@ export default function LicensePage() {
           <Card className="border-green-300 dark:border-green-800 bg-green-50 dark:bg-green-950/50 shadow-sm">
             <CardHeader className="text-center pb-3">
               <CheckCircle className="h-8 w-8 mx-auto mb-2 text-green-600 dark:text-green-400" />
-              <CardTitle className="text-lg text-foreground dark:text-green-100 font-semibold">Free for Most Uses</CardTitle>
+              <CardTitle className="text-lg text-foreground dark:text-green-100 font-semibold">Open Source (MIT)</CardTitle>
             </CardHeader>
             <CardContent className="text-center">
               <p className="text-sm text-foreground dark:text-green-200 font-medium">
-                Individuals, researchers, students, and most companies can use RunMat freely
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card className="border-orange-300 dark:border-orange-800 bg-orange-50 dark:bg-orange-950/50 shadow-sm">
-            <CardHeader className="text-center pb-3">
-              <AlertCircle className="h-8 w-8 mx-auto mb-2 text-orange-600 dark:text-orange-400" />
-              <CardTitle className="text-lg text-foreground dark:text-orange-100 font-semibold">Attribution Required</CardTitle>
-            </CardHeader>
-            <CardContent className="text-center">
-              <p className="text-sm text-foreground dark:text-orange-200 font-medium">
-                Must credit &ldquo;RunMat by Dystr&rdquo; in distributions and derivative works
+                Free for everyone — individuals, academics, and companies of any size
               </p>
             </CardContent>
           </Card>
 
           <Card className="bg-card border-border">
             <CardHeader className="text-center pb-3">
-              <HelpCircle className="h-8 w-8 mx-auto mb-2 text-[hsl(var(--brand))]" />
-              <CardTitle className="text-lg text-foreground font-semibold">Special Rules</CardTitle>
+              <Code className="h-8 w-8 mx-auto mb-2 text-[hsl(var(--brand))]" />
+              <CardTitle className="text-lg text-foreground font-semibold">No Restrictions</CardTitle>
             </CardHeader>
             <CardContent className="text-center">
               <p className="text-sm text-foreground font-medium">
-                Commercial scientific software companies must keep modifications open source
+                Use commercially, modify, redistribute. No attribution display required.
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-card border-border">
+            <CardHeader className="text-center pb-3">
+              <Sparkles className="h-8 w-8 mx-auto mb-2 text-[hsl(var(--brand))]" />
+              <CardTitle className="text-lg text-foreground font-semibold">AI Assistant Separate</CardTitle>
+            </CardHeader>
+            <CardContent className="text-center">
+              <p className="text-sm text-foreground font-medium">
+                The Dystr AI assistant is a commercial product — like VS Code + Copilot
               </p>
             </CardContent>
           </Card>
@@ -147,8 +181,31 @@ export default function LicensePage() {
           <h2 className="text-xl sm:text-2xl font-bold mb-8 text-foreground">
             Frequently Asked Questions
           </h2>
-          
+
           <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg font-semibold text-foreground">
+                  Is RunMat open source?
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-foreground">
+                  <strong>Yes.</strong> The RunMat runtime is licensed under the MIT License,
+                  which is approved by the{" "}
+                  <Link
+                    href="https://opensource.org/license/mit"
+                    className="underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Open Source Initiative
+                  </Link>
+                  . It is the same license used by Julia, VS Code, TypeScript, Bun, and Node.js.
+                </p>
+              </CardContent>
+            </Card>
+
             <Card>
               <CardHeader>
                 <CardTitle className="text-lg font-semibold text-foreground">
@@ -157,37 +214,18 @@ export default function LicensePage() {
               </CardHeader>
               <CardContent>
                 <p className="text-foreground mb-3">
-                  <strong>Yes!</strong> RunMat is completely free for:
+                  <strong>Yes.</strong> The MIT License lets anyone use RunMat for any purpose:
                 </p>
                 <ul className="list-disc list-inside space-y-1 text-foreground/80 ml-4">
-                  <li>Individual researchers and scientists</li>
+                  <li>Individual researchers, scientists, and engineers</li>
                   <li>Academic institutions and educational organizations</li>
                   <li>Students for learning and coursework</li>
-                  <li>Most commercial companies and startups</li>
-                  <li>Open source projects</li>
+                  <li>Companies of any size, including direct competitors</li>
+                  <li>Open source projects and their maintainers</li>
                   <li>Government agencies and non-profits</li>
                 </ul>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg font-semibold text-foreground">
-                  What does &quot;attribution required&quot; mean?
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-foreground mb-3">
-                  Any distribution or modification of RunMat must credit <strong>&quot;RunMat by Dystr&quot;</strong>. This includes:
-                </p>
-                <ul className="list-disc list-inside space-y-1 text-foreground/80 ml-4">
-                  <li>Startup messages or about dialogs</li>
-                  <li>Documentation and README files</li>
-                  <li>Package names or project titles</li>
-                  <li>Web interfaces showing &quot;Powered by RunMat by Dystr&quot;</li>
-                </ul>
                 <p className="text-foreground/90 mt-3">
-                  This ensures Dystr receives appropriate credit for creating RunMat.
+                  There are no fees, no usage limits, and no field-of-use restrictions.
                 </p>
               </CardContent>
             </Card>
@@ -195,44 +233,16 @@ export default function LicensePage() {
             <Card>
               <CardHeader>
                 <CardTitle className="text-lg font-semibold text-foreground">
-                  What are the special rules for scientific software companies?
+                  Can I use RunMat in a commercial product?
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-foreground mb-3">
-                  Companies whose <strong>primary business</strong> involves developing, licensing, or selling scientific computing software 
-                  (like MathWorks, Ansys, COMSOL, etc.) must distribute any RunMat modifications as open source under the same license.
-                </p>
-                <p className="text-foreground mb-3">
-                  <strong>This does NOT apply to:</strong>
-                </p>
-                <ul className="list-disc list-inside space-y-1 text-foreground/80 ml-4">
-                  <li>Companies using RunMat without modification</li>
-                  <li>Companies whose primary business is not scientific computing software</li>
-                  <li>Internal modifications not distributed to third parties</li>
-                  <li>Academic institutions or research organizations</li>
-                </ul>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg font-semibold text-foreground">
-                  Can I create proprietary software that uses RunMat?
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-foreground mb-3">
-                  <strong>Yes!</strong> Most users can create proprietary software that uses or embeds RunMat. 
-                  The license only requires that if you distribute or modify RunMat itself, you must:
-                </p>
-                <ul className="list-disc list-inside space-y-1 text-foreground/80 ml-4">
-                  <li>You provide attribution to &quot;RunMat by Dystr&quot;</li>
-                  <li>You include the license notice</li>
-                  <li>Any modifications to RunMat itself are shared (if you&apos;re a scientific software company)</li>
-                </ul>
-                <p className="text-foreground/90 mt-3">
-                  Your own code that calls RunMat functions remains proprietary.
+                <p className="text-foreground">
+                  <strong>Yes.</strong> The MIT License explicitly permits commercial use.
+                  You can embed RunMat in proprietary software, ship it inside paid products,
+                  integrate it into internal tools, or use it as a dependency in any commercial
+                  context. Your own code that uses RunMat remains your own — RunMat does not
+                  impose copyleft on derivative works.
                 </p>
               </CardContent>
             </Card>
@@ -240,20 +250,15 @@ export default function LicensePage() {
             <Card>
               <CardHeader>
                 <CardTitle className="text-lg font-semibold text-foreground">
-                  How does this compare to other open source licenses?
+                  Can I fork RunMat or modify it?
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-foreground mb-3">
-                  RunMat&apos;s license is based on the MIT License with two additional requirements:
-                </p>
-                <ul className="list-disc list-inside space-y-1 text-foreground/80 ml-4">
-                  <li><strong>Attribution:</strong> Similar to BSD licenses, ensures credit is maintained</li>
-                  <li><strong>Targeted copyleft:</strong> Only applies to large scientific software companies, ensuring community contributions</li>
-                </ul>
-                <p className="text-foreground/90 mt-3">
-                  For most users, it&apos;s as permissive as MIT. For the few companies it affects, 
-                  it encourages open source contribution rather than proprietary appropriation.
+                <p className="text-foreground">
+                  <strong>Yes.</strong> You can fork, modify, redistribute, and sublicense RunMat.
+                  The only requirement is that you preserve the MIT copyright notice in source files.
+                  There are no attribution requirements in startup messages, documentation, or user
+                  interfaces.
                 </p>
               </CardContent>
             </Card>
@@ -261,20 +266,95 @@ export default function LicensePage() {
             <Card>
               <CardHeader>
                 <CardTitle className="text-lg font-semibold text-foreground">
-                  I&apos;m still not sure if my use case is allowed. What should I do?
+                  What about the Dystr AI assistant — is that open source?
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-foreground/90 mb-4">
-                  When in doubt, reach out! We&apos;re happy to clarify licensing questions and work with you 
-                  to ensure your use case is properly covered.
+                <p className="text-foreground mb-3">
+                  <strong>No.</strong> The Dystr AI assistant and Dystr Cloud are commercial
+                  products built on top of the open-source RunMat runtime.
                 </p>
-                <div className="flex items-center space-x-2 text-[hsl(var(--brand))]">
-                  <Mail className="h-4 w-4" />
-                  <Link href="mailto:legal@dystr.com" className="hover:underline">
+                <p className="text-foreground mb-3">
+                  This is a standard open-core model, similar to VS Code (open source under MIT)
+                  paired with Pylance and GitHub Copilot (commercial). The runtime is free forever;
+                  the AI assistant is a paid Dystr product.
+                </p>
+                <p className="text-foreground/90">
+                  See{" "}
+                  <Link href="/pricing" className="underline">
+                    runmat.com/pricing
+                  </Link>{" "}
+                  for details on the AI assistant.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg font-semibold text-foreground">
+                  Do I need to credit RunMat?
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-foreground">
+                  Beyond preserving the copyright notice in source files (a standard MIT requirement),
+                  <strong> no</strong>. We appreciate attribution in your README or about page,
+                  but it is not legally required.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg font-semibold text-foreground">
+                  Is the MIT License OSI-approved?
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-foreground">
+                  <strong>Yes.</strong> The MIT License is one of the original licenses approved by
+                  the Open Source Initiative and is on every major enterprise legal team&apos;s
+                  pre-approved license list. RunMat can be adopted at organizations that require
+                  formally OSI-approved open-source software.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg font-semibold text-foreground">
+                  Will the license ever change?
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-foreground">
+                  We have no plans to change the license of the RunMat runtime away from MIT.
+                  Past releases will always remain available under the MIT terms they were
+                  originally published under, regardless of any future changes.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg font-semibold text-foreground">
+                  Is &quot;RunMat&quot; a trademark?
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-foreground mb-3">
+                  Yes. <strong>&quot;RunMat&quot;</strong> is a trademark of Dystr, Inc.
+                  The MIT License covers the source code but does not grant rights to the RunMat
+                  name or logo.
+                </p>
+                <p className="text-foreground/90">
+                  You can fork the code freely; please don&apos;t call your fork &quot;RunMat&quot;.
+                  For trademark questions, contact{" "}
+                  <Link href="mailto:legal@dystr.com" className="underline">
                     legal@dystr.com
                   </Link>
-                </div>
+                  .
+                </p>
               </CardContent>
             </Card>
           </div>
@@ -283,43 +363,19 @@ export default function LicensePage() {
         {/* Full License Text */}
         <section className="mb-12">
           <h2 className="text-xl sm:text-2xl font-bold mb-8 text-foreground">
-            Full License Text         
+            Full License Text
           </h2>
-          
+
           <Card className="p-0">
             <CardContent className="p-6">
               <div className="font-mono text-sm text-foreground/90 whitespace-pre-line leading-relaxed">
-{`# License
+{`MIT License
 
-RunMat is licensed under the **MIT License** with **Attribution Requirements** and **Commercial Scientific Software Company Copyleft** Provisions.
-
-## MIT License with Additional Terms
-
-Copyright (c) 2025 Dystr Inc. and RunMat contributors
+Copyright (c) 2024-2026 Dystr, Inc. and RunMat contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-### Attribution Requirement
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. Any distribution, fork, modification, or derivative work of this Software must maintain attribution to "RunMat by Dystr" in a prominent location visible to end users. This includes but is not limited to:
-
-1. **Startup messages** or **about dialogs** displaying "RunMat by Dystr"
-2. **Documentation** and **README files** crediting "RunMat by Dystr"  
-3. **Package names** or **project titles** indicating the RunMat origin
-4. **Web interfaces** showing "Powered by RunMat by Dystr"
-
-### Commercial Scientific Software Company Copyleft
-
-Any entity whose **primary business purpose** involves the development, licensing, or sale of scientific computing software, engineering simulation software, mathematical computing environments, or technical computing platforms (including but not limited to companies like MathWorks, Ansys, COMSOL Multiphysics, Dassault Systèmes, Autodesk, PTC, Siemens Digital Industries Software, Altair, and similar organizations) that creates a fork, derivative work, or modification of this Software **MUST** distribute their modified version under the same license terms as this license, making their modifications available as open source.
-
-This copyleft provision does **NOT** apply to:
-- Individual researchers, academic institutions, or educational organizations
-- Companies using RunMat as a dependency without modification
-- Companies whose primary business is not scientific/technical computing software
-- Internal modifications not distributed to third parties
-- Other open source projects and their maintainers
-
-### Disclaimer
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.`}
               </div>
@@ -332,10 +388,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
           <Card className="bg-card border-border">
             <CardContent className="p-6 text-center">
               <h3 className="text-lg font-semibold mb-3 text-foreground">
-                Need Legal Clarification?
+                Questions about commercial products or trademarks?
               </h3>
               <p className="text-[0.938rem] text-foreground mb-4">
-                Our legal team is happy to help clarify licensing questions or discuss commercial licensing options.
+                The MIT License covers the runtime. For questions about the Dystr AI assistant,
+                Dystr Cloud, enterprise agreements, or trademark use, get in touch.
               </p>
               <p className="text-xs text-foreground mb-4">
                 New to MATLAB? Read the primer{" "}
@@ -346,8 +403,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
               </p>
               <div className="flex items-center justify-center space-x-2">
                 <Mail className="h-4 w-4 text-[hsl(var(--brand))]" />
-                <Link 
-                  href="mailto:legal@dystr.com" 
+                <Link
+                  href="mailto:legal@dystr.com"
                   className="text-[hsl(var(--brand))] hover:underline font-medium"
                 >
                   legal@dystr.com

--- a/website/app/matlab-online/page.tsx
+++ b/website/app/matlab-online/page.tsx
@@ -367,18 +367,27 @@ export default function MatlabOnlinePage() {
               </div>
             </div>
             <div className="rounded-xl border border-border bg-card p-2">
-              <video
-                className="w-full h-auto rounded-lg"
-                autoPlay
-                muted
-                loop
-                playsInline
-                preload="none"
-                poster={heroPosterSrc}
-                aria-label="RunMat MATLAB-style code example demo"
+              <Link
+                href="/sandbox"
+                className="block rounded-lg overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                data-ph-capture-attribute-destination="sandbox"
+                data-ph-capture-attribute-source="matlab-online-hero-video"
+                data-ph-capture-attribute-cta="try-runmat-browser"
+                aria-label="Open the RunMat sandbox"
               >
-                <source src={heroVideoSrc} type="video/mp4" />
-              </video>
+                <video
+                  className="w-full h-auto rounded-lg"
+                  autoPlay
+                  muted
+                  loop
+                  playsInline
+                  preload="none"
+                  poster={heroPosterSrc}
+                  aria-label="RunMat MATLAB-style code example demo"
+                >
+                  <source src={heroVideoSrc} type="video/mp4" />
+                </video>
+              </Link>
             </div>
           </div>
         </div>

--- a/website/app/matlab-online/page.tsx
+++ b/website/app/matlab-online/page.tsx
@@ -92,20 +92,26 @@ const faqItems: { question: string; answer: string; answerContent?: React.ReactN
     answer:
       "Yes. RunMat ships with a built-in agent in the sandbox. You describe what you want to compute; the agent writes MATLAB-syntax code, runs it on the same GPU-accelerated runtime, reads workspace variables and 2D/3D plot scenes, and iterates. Every change comes back as a diff you can accept or reject.",
   },
+  // Reviewer tag: legal/product. MathWorks license and product claims are source-linked in answerContent.
   {
     question: "Does MathWorks have an AI assistant?",
     answer:
-      "MathWorks ships the MATLAB Agentic Toolkit, which connects an external AI coding agent (Claude Code, GitHub Copilot, OpenAI Codex, Gemini CLI, or Sourcegraph Amp) to a local MATLAB R2020b+ installation via an MCP server. The toolkit does not include the agent or the MATLAB license — both are brought separately. Per the LICENSE, the MCP server is not permitted to be shared across multiple users.",
+      "As of May 2026, MathWorks publishes the MATLAB Agentic Toolkit for Claude Code, GitHub Copilot, OpenAI Codex, Gemini CLI, and Sourcegraph Amp. MathWorks lists MATLAB R2020b or later, a supported AI coding agent, and Git as prerequisites, and its product page says the toolkit requires a local MATLAB installation and an AI service subscription. MathWorks' README says MCP servers must be used with MATLAB under the MathWorks Software License Agreement and must not be shared by multiple users; the repository license also limits the software to use with MathWorks products and service offerings.",
     answerContent: (
       <>
-        MathWorks ships the <Link href="https://github.com/matlab/matlab-agentic-toolkit" target="_blank" rel="noopener nofollow" className="underline hover:text-foreground">MATLAB Agentic Toolkit</Link>, which connects an external AI coding agent (Claude Code, GitHub Copilot, OpenAI Codex, Gemini CLI, or Sourcegraph Amp) to a local MATLAB R2020b+ installation via an MCP server. The toolkit does not include the agent or the MATLAB license — both are brought separately. Per the LICENSE, the MCP server is not permitted to be shared across multiple users.
+        As of May 2026, MathWorks publishes the <Link href="https://github.com/matlab/matlab-agentic-toolkit" target="_blank" rel="noopener nofollow" className="underline hover:text-foreground">MATLAB Agentic Toolkit</Link> for Claude Code, GitHub Copilot, OpenAI Codex, Gemini CLI, and Sourcegraph Amp. MathWorks lists MATLAB R2020b or later, a supported AI coding agent, and Git as prerequisites, and its <Link href="https://www.mathworks.com/products/matlab-agentic-toolkit.html" target="_blank" rel="noopener nofollow" className="underline hover:text-foreground">product page</Link> says the toolkit requires a local MATLAB installation and an AI service subscription. MathWorks&apos; README says MCP servers must be used with MATLAB under the MathWorks Software License Agreement and must not be shared by multiple users; the repository <Link href="https://github.com/matlab/matlab-agentic-toolkit/blob/main/LICENSE.md" target="_blank" rel="noopener nofollow" className="underline hover:text-foreground">license</Link> also limits the software to use with MathWorks products and service offerings.
       </>
     ),
   },
   {
     question: "How is RunMat's agent different from the MATLAB Agentic Toolkit?",
     answer:
-      "RunMat's runtime is open source under MIT and runs without a MATLAB license. The Agentic Toolkit requires paid MATLAB R2020b+ plus a third-party agent connected via MCP, and the MCP only exposes command-window text. Because RunMat ships the agent and runtime together, the agent reads workspace variables, tensor shapes, and plot scenes directly. RunMat is also browser-first and cloud-shareable; the Agentic Toolkit is local-only, and its license restricts the MCP server to a single user.",
+      "RunMat's runtime is open source under MIT and runs without a MATLAB license. MathWorks documents the Agentic Toolkit as skills plus a MATLAB MCP Core Server connection to a local MATLAB installation and a supported third-party agent. The MCP Core Server exposes five built-in tools for static analysis, code evaluation, file execution, test execution, and toolbox detection; MathWorks also says MCP servers must not be shared by multiple users. RunMat ships the agent and runtime together in the browser, so the agent can inspect RunMat workspace variables, tensor shapes, and plot scenes directly.",
+    answerContent: (
+      <>
+        RunMat&apos;s runtime is open source under MIT and runs without a MATLAB license. MathWorks documents the Agentic Toolkit as skills plus a <Link href="https://github.com/matlab/matlab-mcp-core-server#tools" target="_blank" rel="noopener nofollow" className="underline hover:text-foreground">MATLAB MCP Core Server</Link> connection to a local MATLAB installation and a supported third-party agent. The MCP Core Server exposes five built-in tools for static analysis, code evaluation, file execution, test execution, and toolbox detection; MathWorks also says MCP servers must not be shared by multiple users. RunMat ships the agent and runtime together in the browser, so the agent can inspect RunMat workspace variables, tensor shapes, and plot scenes directly.
+      </>
+    ),
   },
   {
     question: "Can I run my existing MATLAB scripts in RunMat?",

--- a/website/app/matlab-online/page.tsx
+++ b/website/app/matlab-online/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SandboxCta } from "@/components/SandboxCta";
+import LazyVideo from "@/components/LazyVideo";
 import dynamic from "next/dynamic";
 
 const MatlabInlineCodeBlock = dynamic(() => import("@/components/MatlabInlineCodeBlock"), {
@@ -16,7 +17,6 @@ const BenchmarkShowcaseBlock = dynamic(
 );
 import {
   BarChart3,
-  Globe,
   Code2,
   Zap,
   CheckCircle,
@@ -29,23 +29,29 @@ import {
   Shield,
   Eye,
   ClipboardCheck,
+  Wand2,
+  FlaskConical,
+  FileDiff,
 } from "lucide-react";
 
 export const metadata: Metadata = {
   title: "Run MATLAB Code Online - Instant GPU Sandbox",
   description:
-    "Execute MATLAB-syntax code instantly in your browser. Open-source runtime with automatic GPU acceleration. No install required—start coding now.",
+    "Run MATLAB-syntax code in your browser with a built-in coding agent and automatic GPU acceleration. Open-source runtime. No license required.",
   alternates: { canonical: "https://runmat.com/matlab-online" },
   keywords: [
     "matlab online", "matlab online free", "run matlab online",
     "matlab alternative", "free matlab", "matlab browser",
     "matlab no license", "matlab gpu", "octave alternative",
     "webgpu matlab", "matlab web app",
+    "matlab ai", "matlab ai assistant", "matlab ai agent",
+    "matlab coding agent", "matlab copilot alternative",
+    "matlab agentic toolkit", "matlab mcp",
   ],
   openGraph: {
     title: "Run MATLAB Code Online - Instant GPU Sandbox",
     description:
-      "Execute MATLAB-syntax code instantly in your browser. Open-source runtime with automatic GPU acceleration. No install required—start coding now.",
+      "Run MATLAB-syntax code in your browser with a built-in coding agent and automatic GPU acceleration. Open-source runtime. No license required.",
     url: "/matlab-online",
     siteName: "RunMat",
     type: "website",
@@ -54,7 +60,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Run MATLAB Code Online - Instant GPU Sandbox",
     description:
-      "Execute MATLAB-syntax code instantly in your browser. Open-source runtime with automatic GPU acceleration. No install required—start coding now.",
+      "Run MATLAB-syntax code in your browser with a built-in coding agent and automatic GPU acceleration. Open-source runtime. No license required.",
   },
   robots: {
     index: true,
@@ -72,6 +78,9 @@ export const metadata: Metadata = {
 const heroVideoSrc = "https://web.runmatstatic.com/video/3d-interactive-plotting-runmat.mp4";
 const heroPosterSrc = "https://web.runmatstatic.com/video/posters/3d-interactive-plotting-runmat.webp";
 
+const agentVideoSrc = "https://web.runmatstatic.com/video/runmat-agent-demo-speaker.mp4";
+const agentPosterSrc = "https://web.runmatstatic.com/video/posters/runmat-agent-demo-speaker.webp";
+
 const faqItems: { question: string; answer: string; answerContent?: React.ReactNode }[] = [
   {
     question: "Is RunMat the same as MATLAB?",
@@ -79,9 +88,29 @@ const faqItems: { question: string; answer: string; answerContent?: React.ReactN
       "No. RunMat is an independent project with an open-source runtime that executes MATLAB-syntax code. It is not affiliated with or endorsed by MathWorks, the makers of MATLAB.",
   },
   {
+    question: "Does RunMat have an AI assistant?",
+    answer:
+      "Yes. RunMat ships with a built-in agent in the sandbox. You describe what you want to compute; the agent writes MATLAB-syntax code, runs it on the same GPU-accelerated runtime, reads workspace variables and 2D/3D plot scenes, and iterates. Every change comes back as a diff you can accept or reject.",
+  },
+  {
+    question: "Does MathWorks have an AI assistant?",
+    answer:
+      "MathWorks ships the MATLAB Agentic Toolkit, which connects an external AI coding agent (Claude Code, GitHub Copilot, OpenAI Codex, Gemini CLI, or Sourcegraph Amp) to a local MATLAB R2020b+ installation via an MCP server. The toolkit does not include the agent or the MATLAB license — both are brought separately. Per the LICENSE, the MCP server is not permitted to be shared across multiple users.",
+    answerContent: (
+      <>
+        MathWorks ships the <Link href="https://github.com/matlab/matlab-agentic-toolkit" target="_blank" rel="noopener nofollow" className="underline hover:text-foreground">MATLAB Agentic Toolkit</Link>, which connects an external AI coding agent (Claude Code, GitHub Copilot, OpenAI Codex, Gemini CLI, or Sourcegraph Amp) to a local MATLAB R2020b+ installation via an MCP server. The toolkit does not include the agent or the MATLAB license — both are brought separately. Per the LICENSE, the MCP server is not permitted to be shared across multiple users.
+      </>
+    ),
+  },
+  {
+    question: "How is RunMat's agent different from the MATLAB Agentic Toolkit?",
+    answer:
+      "RunMat's runtime is open source under MIT and runs without a MATLAB license. The Agentic Toolkit requires paid MATLAB R2020b+ plus a third-party agent connected via MCP, and the MCP only exposes command-window text. Because RunMat ships the agent and runtime together, the agent reads workspace variables, tensor shapes, and plot scenes directly. RunMat is also browser-first and cloud-shareable; the Agentic Toolkit is local-only, and its license restricts the MCP server to a single user.",
+  },
+  {
     question: "Can I run my existing MATLAB scripts in RunMat?",
     answer:
-      "Many MATLAB scripts run without modification, especially those using core language features and common built-in functions. Scripts relying on specialized toolboxes or advanced features may need adjustments. Try your script in the sandbox to see what works.",
+      "Many MATLAB scripts run without modification, especially those using core language features and common built-in functions. For scripts that depend on toolboxes or builtins RunMat doesn't yet ship, the built-in agent can rewrite the code to use what's supported — usually preserving the intent. Try your script in the sandbox; if something doesn't run, ask the agent to adapt it.",
   },
   {
     question: "Is RunMat really free?",
@@ -175,7 +204,7 @@ const jsonLd = {
       url: "https://runmat.com/matlab-online",
       name: "Run MATLAB Code Online - Instant GPU Sandbox",
       description:
-        "Execute MATLAB-syntax code instantly in your browser. Open-source runtime with automatic GPU acceleration. No install required—start coding now.",
+        "Run MATLAB-syntax code in your browser with a built-in coding agent and automatic GPU acceleration. Open-source runtime. No license required.",
       inLanguage: "en",
       datePublished: "2026-02-03T00:00:00Z",
       dateModified: "2026-04-21T00:00:00Z",
@@ -219,11 +248,12 @@ const jsonLd = {
       "@id": "https://runmat.com/matlab-online#software",
       name: "RunMat",
       description:
-        "RunMat is a high-performance, open-source runtime for math that runs MATLAB-syntax code in the browser with GPU acceleration and no license required.",
+        "RunMat is a high-performance, open-source runtime for math with a built-in coding agent that runs MATLAB-syntax code in the browser with GPU acceleration and no license required.",
       applicationCategory: "ScientificApplication",
       applicationSubCategory: "EngineeringApplication",
       operatingSystem: ["Browser", "Windows", "macOS", "Linux"],
       featureList: [
+        "Built-in coding agent with access to workspace variables, tensor shapes, and 2D/3D plot scenes",
         "Interactive 2D and 3D plotting with GPU acceleration",
         "Real-time type and shape tracking with dimension error detection",
         "Execution tracing and diagnostic logging",
@@ -267,14 +297,14 @@ const jsonLd = {
         {
           "@type": "HowToStep",
           position: 2,
-          name: "Write or paste code",
-          text: "Enter MATLAB-style code in the editor.",
+          name: "Write code or ask the agent",
+          text: "Type MATLAB-syntax code, or describe what you want to compute and let the built-in agent write it.",
         },
         {
           "@type": "HowToStep",
           position: 3,
-          name: "Run and see results",
-          text: "Execute the script and view outputs instantly.",
+          name: "Run on GPU and iterate",
+          text: "Execute on the GPU-accelerated runtime. Inspect plots and variables, then iterate.",
         },
       ],
     },
@@ -394,6 +424,18 @@ export default function MatlabOnlinePage() {
                       Code runs on MathWorks&apos; servers, so you cannot use your own GPU for acceleration.
                     </p>
                   </div>
+                  <div className="rounded-lg border border-amber-500/30 bg-card px-5 py-4">
+                    <p className="text-sm font-semibold text-foreground">Specialty toolboxes cost extra</p>
+                    <p className="text-sm text-foreground mt-1">
+                      Specialty toolboxes (Image Processing, Signal Processing, Optimization, etc.) are paid add-ons on top of base MATLAB.
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-amber-500/30 bg-card px-5 py-4">
+                    <p className="text-sm font-semibold text-foreground">No built-in agent</p>
+                    <p className="text-sm text-foreground mt-1">
+                      MathWorks&apos; <Link href="https://github.com/matlab/matlab-agentic-toolkit" target="_blank" rel="noopener nofollow" className="underline hover:text-foreground/80">Agentic Toolkit</Link> is a separate product for local MATLAB installs (Claude Code, Copilot, Codex, Gemini, or Amp). Its MCP returns command-window text — no plot or workspace introspection.
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -418,6 +460,15 @@ export default function MatlabOnlinePage() {
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
               <div className="rounded-lg border border-border bg-muted/40 p-6">
                 <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
+                  <Wand2 className="h-5 w-5" />
+                </span>
+                <p className="text-base font-medium text-foreground">Built-in agent</p>
+                <p className="text-[0.938rem] text-foreground mt-1">
+                  Describe the math, or paste an existing MATLAB script. The agent writes new code or rewrites around toolboxes and builtins RunMat doesn&apos;t yet ship. Every change comes back as a diff.
+                </p>
+              </div>
+              <div className="rounded-lg border border-border bg-muted/40 p-6">
+                <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
                   <CheckCircle className="h-5 w-5" />
                 </span>
                 <p className="text-base font-medium text-foreground">No account required</p>
@@ -429,7 +480,7 @@ export default function MatlabOnlinePage() {
                 </span>
                 <p className="text-base font-medium text-foreground">Client-side execution</p>
                 <p className="text-[0.938rem] text-foreground mt-1">
-                  Your code compiles to WebAssembly and runs locally in your browser. Nothing leaves your device unless you choose to save to the cloud.
+                  Your code compiles to WebAssembly and runs locally in your browser. Nothing leaves your device unless you save to the cloud, and after the initial page load it works offline.
                 </p>
               </div>
               <div className="rounded-lg border border-border bg-muted/40 p-6">
@@ -456,15 +507,6 @@ export default function MatlabOnlinePage() {
                 <p className="text-base font-medium text-foreground">Type &amp; shape tracking</p>
                 <p className="text-[0.938rem] text-foreground mt-1">Hover any variable to see its dimensions. Mismatched matrix sizes get red underlines before you run.</p>
               </div>
-              <div className="rounded-lg border border-border bg-muted/40 p-6">
-                <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
-                  <Globe className="h-5 w-5" />
-                </span>
-                <p className="text-base font-medium text-foreground">Works offline</p>
-                <p className="text-[0.938rem] text-foreground mt-1">
-                  After the initial page load, RunMat runs without an internet connection. The CLI provides full local file access today; the desktop app is coming soon.
-                </p>
-              </div>
             </div>
             <div className="mt-10 flex justify-center">
               <Button
@@ -486,6 +528,58 @@ export default function MatlabOnlinePage() {
         </div>
       </section>
 
+      {/* Agent: built into the runtime */}
+      <section className="w-full py-16 md:py-24 lg:py-32">
+        <div className="container mx-auto px-4 md:px-6 lg:px-8">
+          <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
+            <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl text-foreground">
+              An agent built into the runtime, not on top of your files
+            </h2>
+            <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
+              The agent runs your code, inspects workspace variables, and reads 3D plot data. You review every change as a diff before it lands.
+            </p>
+          </div>
+          <div className="mx-auto max-w-3xl mb-8">
+            <div className="rounded-lg border border-border overflow-hidden elevated-panel">
+              <Link
+                href="/sandbox"
+                className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-b-none rounded-t-lg overflow-hidden"
+                data-ph-capture-attribute-destination="sandbox"
+                data-ph-capture-attribute-source="matlab-online-agent-video"
+                data-ph-capture-attribute-cta="try-runmat-agent"
+              >
+                <LazyVideo
+                  className="w-full h-auto"
+                  muted
+                  loop
+                  playsInline
+                  poster={agentPosterSrc}
+                  aria-label="RunMat agent exploring a speaker interference pattern in 3D — opens the sandbox"
+                >
+                  <source src={agentVideoSrc} type="video/mp4" />
+                </LazyVideo>
+              </Link>
+            </div>
+          </div>
+          <div className="mx-auto max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+            <div className="rounded-lg border border-border bg-card p-6">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
+                <FlaskConical className="h-5 w-5" />
+              </span>
+              <h3 className="text-lg font-semibold text-foreground">Runtime-aware inspection</h3>
+              <p className="text-[0.938rem] text-foreground mt-1">Checks tensors for NaN, verifies shapes against expected dimensions, and reads plot data from any 3D camera angle.</p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-6">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
+                <FileDiff className="h-5 w-5" />
+              </span>
+              <h3 className="text-lg font-semibold text-foreground">Every change is reviewable</h3>
+              <p className="text-[0.938rem] text-foreground mt-1">Edits are presented as diffs. Accept or reject each change. Conversations are stored as searchable project files.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* How it works */}
       <section className="w-full py-16 md:py-24 lg:py-32">
         <div className="container mx-auto px-4 md:px-6 lg:px-8">
@@ -501,7 +595,7 @@ export default function MatlabOnlinePage() {
                 </span>
                 <div>
                   <h3 className="text-lg font-semibold text-foreground">Open the sandbox</h3>
-                  <p className="text-[0.938rem] text-foreground mt-1">Go to <Link href="/sandbox" className="underline text-[hsl(var(--brand))] hover:text-[hsl(var(--brand))]/80">runmat.com/sandbox</Link>. No downloads, no sign-up, no license key.</p>
+                  <p className="text-[0.938rem] text-foreground mt-1">Go to <Link href="/sandbox" className="underline text-[hsl(var(--brand))] hover:text-[hsl(var(--brand))]/80">runmat.com/sandbox</Link>. The editor loads in your browser; no account or license needed.</p>
                 </div>
               </div>
               <div className="flex items-start gap-4">
@@ -509,8 +603,8 @@ export default function MatlabOnlinePage() {
                   2
                 </span>
                 <div>
-                  <h3 className="text-lg font-semibold text-foreground">Write or paste code</h3>
-                  <p className="text-[0.938rem] text-foreground mt-1">Type MATLAB-style code directly in the editor, or paste existing scripts from your projects.</p>
+                  <h3 className="text-lg font-semibold text-foreground">Write code, or ask the agent</h3>
+                  <p className="text-[0.938rem] text-foreground mt-1">Type MATLAB-syntax code directly, or describe what you want to compute and let the built-in agent write it for you.</p>
                 </div>
               </div>
               <div className="flex items-start gap-4">
@@ -518,8 +612,8 @@ export default function MatlabOnlinePage() {
                   3
                 </span>
                 <div>
-                  <h3 className="text-lg font-semibold text-foreground">Run and see results</h3>
-                  <p className="text-[0.938rem] text-foreground mt-1">Execute your code instantly. View outputs, plots, and results in real time, all in your browser.</p>
+                  <h3 className="text-lg font-semibold text-foreground">Run on GPU and iterate</h3>
+                  <p className="text-[0.938rem] text-foreground mt-1">Execute on the same GPU-accelerated runtime. Inspect plots and variables, then iterate until the math is right.</p>
                 </div>
               </div>
             </div>
@@ -617,86 +711,70 @@ export default function MatlabOnlinePage() {
         <div className="container mx-auto px-4 md:px-6 lg:px-8">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
             <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl text-foreground">RunMat vs. MATLAB Online</h2>
-            <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">RunMat runs client-side with GPU acceleration and no account. MATLAB Online requires a license, runs on MathWorks&apos; servers, and caps free usage.</p>
+            <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">RunMat runs in your browser with a built-in agent and GPU acceleration, no account needed. MATLAB Online runs on MathWorks&apos; servers behind a paid license and caps free usage.</p>
           </div>
           <div className="mx-auto grid max-w-5xl gap-6 md:grid-cols-2">
             <Card className="border border-border bg-card shadow-sm">
               <CardContent className="p-6 space-y-4">
                 <div>
                   <h3 className="text-lg font-semibold text-foreground">RunMat</h3>
-                  <p className="text-[0.938rem] text-foreground">High-performance, open-source runtime for math</p>
+                  <p className="text-[0.938rem] text-foreground">Open-source runtime with a built-in agent</p>
                 </div>
                 <ul className="space-y-2 text-sm">
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
-                    Open-source runtime
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
+                    Open-source runtime (MIT)
                   </li>
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
-                    No account required
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
+                    No account or license required
                   </li>
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
+                    Built-in agent
+                  </li>
+                  <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
+                    Agent reads workspace variables and 2D/3D plot scenes
+                  </li>
+                  <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
                     Client-side execution
                   </li>
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
                     Cross-platform GPU (Metal, Vulkan, DX12, WebGPU)
                   </li>
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
                     Works offline
                   </li>
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
-                    Core matrix operations
-                  </li>
-                  <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
                     Interactive 2D &amp; 3D plotting
                   </li>
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
                     Real-time type &amp; shape tracking
                   </li>
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
                     Execution tracing &amp; diagnostics
                   </li>
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
                     Automatic file versioning &amp; snapshots (Cloud)
                   </li>
+                  <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
+                    Agent rewrites scripts around unsupported toolboxes &amp; builtins
+                  </li>
                   <li className="flex items-start gap-3 text-foreground">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-foreground">
-                      –
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-foreground">–</span>
                     Limited package / toolbox support
                   </li>
                   <li className="flex items-start gap-3 text-foreground">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-foreground">
-                      –
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-foreground">–</span>
                     Subset of MATLAB functions
                   </li>
                 </ul>
@@ -706,61 +784,51 @@ export default function MatlabOnlinePage() {
               <CardContent className="p-6 space-y-4">
                 <div>
                   <h3 className="text-lg font-semibold text-foreground">MATLAB Online</h3>
-                  <p className="text-[0.938rem] text-foreground">MathWorks official platform</p>
+                  <p className="text-[0.938rem] text-foreground">MathWorks&apos; cloud-hosted MATLAB IDE</p>
                 </div>
                 <ul className="space-y-2 text-sm">
                   <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">
-                      ✕
-                    </span>
-                    Requires paid license
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
+                    Requires paid MATLAB license
                   </li>
                   <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">
-                      ✕
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
                     Account &amp; sign-in required
                   </li>
                   <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">
-                      ✕
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
+                    No built-in agent
+                  </li>
+                  <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
+                    Free tier capped at 20 hours/month, 15-min idle timeout
+                  </li>
+                  <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
                     Cloud-based execution
                   </li>
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
                     GPU support available
                   </li>
                   <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">
-                      ✕
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
                     Requires internet connection
                   </li>
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
                     Full MATLAB language
                   </li>
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
                     Complete toolbox ecosystem
                   </li>
                   <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">
-                      ✓
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
                     Official MathWorks support
                   </li>
                   <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">
-                      ✕
-                    </span>
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
                     No built-in file versioning
                   </li>
                 </ul>
@@ -864,6 +932,14 @@ export default function MatlabOnlinePage() {
                       <span className="mt-1 text-muted-foreground">•</span>
                       <p>Java/COM interop</p>
                     </div>
+                  </div>
+                </div>
+                <div className="border-t border-border/60 pt-4">
+                  <div className="flex items-start gap-2">
+                    <Wand2 className="mt-0.5 h-4 w-4 shrink-0 text-foreground" />
+                    <p className="text-foreground">
+                      For toolboxes and builtins in the &ldquo;in progress&rdquo; list above, the built-in agent can often rewrite scripts to use what RunMat already ships, usually preserving the intent.
+                    </p>
                   </div>
                 </div>
               </CardContent>

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { SiGithub } from "react-icons/si";
-import { Users, GitBranch, Camera, Lock, Shield, Eye, ClipboardCheck, Cpu, Monitor, HardDrive } from "lucide-react";
+import { Users, GitBranch, Camera, Lock, Shield, Eye, ClipboardCheck, Cpu, Monitor, HardDrive, FlaskConical, FileDiff, ShieldCheck, History, Layers } from "lucide-react";
 
 import dynamic from "next/dynamic";
 import Hero from "@/components/Hero";
@@ -83,12 +83,15 @@ const jsonLd = {
       "softwareVersion": "Beta",
       "featureList": [
         "JIT-accelerated MATLAB-style syntax",
-        "RunMat Desktop: Full IDE experience with code editor, file explorer, and live plotting in-browser",
+        "Full IDE experience with code editor, file explorer, and live plotting in-browser",
         "Automatic GPU Fusion & Memory Management",
         "Cross-platform binary (Metal, Vulkan, DX12) and CLI support",
         "Interactive 2D and 3D plotting with GPU acceleration",
         "Real-time type and shape tracking with dimension error detection",
-        "Execution tracing and diagnostic logging"
+        "Execution tracing and diagnostic logging",
+        "Built-in agent with runtime execution and workspace inspection",
+        "OS-level sandboxed agent execution",
+        "Deterministic session replay and audit journal"
       ],
       "offers": {
         "@type": "Offer",
@@ -120,9 +123,9 @@ const jsonLd = {
 };
 
 export const metadata: Metadata = {
-  title: "RunMat: Free Runtime for MATLAB Code (Browser & Desktop)",
+  title: "RunMat: GPU Computing Platform for Engineering Math",
   description:
-    "Execute .m files instantly with automatic GPU acceleration. An open-source runtime built on MATLAB semantics. No license or installation required.",
+    "GPU-accelerated MATLAB-syntax math with a built-in agent that runs code, checks results, and iterates. Open source, browser or CLI. No license required.",
   keywords: [
     "run matlab online",
     "free matlab runtime",
@@ -147,6 +150,11 @@ export const metadata: Metadata = {
     "matlab vs julia",
     "matlab vs scilab",
     "matlab blas lapack",
+    "matlab ai",
+    "matlab ai assistant",
+    "matlab copilot alternative",
+    "ai for matlab",
+    "ai engineering math",
   ],
   alternates: { canonical: "/" },
   robots: {
@@ -161,9 +169,9 @@ export const metadata: Metadata = {
     },
   },
   openGraph: {
-    title: "RunMat: Free Runtime for MATLAB Code (Browser & Desktop)",
+    title: "RunMat: GPU Computing Platform for Engineering Math",
     description:
-      "Execute .m files instantly with automatic GPU acceleration. An open-source runtime built on MATLAB semantics. No license or installation required.",
+      "GPU-accelerated MATLAB-syntax math with a built-in agent that runs code, checks results, and iterates. Open source, browser or CLI. No license required.",
     url: "/",
     siteName: "RunMat",
     type: "website",
@@ -176,9 +184,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "RunMat: Free Runtime for MATLAB Code (Browser & Desktop)",
+    title: "RunMat: GPU Computing Platform for Engineering Math",
     description:
-      "Execute .m files instantly with automatic GPU acceleration. An open-source runtime built on MATLAB semantics. No license or installation required.",
+      "GPU-accelerated MATLAB-syntax math with a built-in agent that runs code, checks results, and iterates. Open source, browser or CLI. No license required.",
   },
 };
 
@@ -206,9 +214,9 @@ export default function HomePage() {
         }}
       />
       <div className="sr-only">
-        <h1>RunMat: Free Runtime for MATLAB Code (Browser & Desktop)</h1>
+        <h1>RunMat: GPU Computing Platform for Engineering Math</h1>
         <p>
-          Execute .m files instantly with automatic GPU acceleration. An open-source runtime built on MATLAB semantics. No license or installation required.
+          GPU-accelerated MATLAB-syntax math with a built-in agent that runs code, checks results, and iterates. Open source, browser or CLI. No license required.
         </p>
       </div>
 
@@ -218,11 +226,11 @@ export default function HomePage() {
       <section className="w-full py-16 md:py-24 lg:py-32">
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
-            <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
+            <h2 className="font-bold tracking-tight text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
               See your math in 3D
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
-              GPU-accelerated 2D and 3D plotting, built into the same environment as your code. Your plots are part of the same computation chain as your math. No copying data between systems, no separate plotting library.
+              Render millions of points straight from a GPU tensor. 2D and 3D plots run on the same compute chain as your math, in the same runtime. The platform's agent has its own camera and can rotate, zoom, and inspect plots while you work on something else.
             </p>
           </div>
           <div className="mx-auto max-w-3xl">
@@ -257,11 +265,63 @@ export default function HomePage() {
         </div>
       </section>
 
+      {/* Agent: works inside the runtime */}
+      <section className="w-full py-16 md:py-24 lg:py-32">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
+            <h2 className="font-bold tracking-tight text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
+              An agent built into the runtime, not on top of your files
+            </h2>
+            <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground sm:leading-7">
+              The agent runs your code, inspects workspace variables, and reads 3D plot data. You review every change as a diff before it lands.
+            </p>
+          </div>
+          {/* TODO: replace placeholder wave-simulation video with a proper agent demo recording when ready */}
+          <div className="mx-auto max-w-3xl mb-8">
+            <div className="rounded-lg border border-border overflow-hidden elevated-panel">
+              <Link href="/sandbox" className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-b-none rounded-t-lg overflow-hidden">
+                <LazyVideo
+                  className="w-full h-auto"
+                  muted
+                  loop
+                  playsInline
+                  poster="https://web.runmatstatic.com/video/posters/runmat-wave-simulation.webp"
+                  aria-label="RunMat agent exploration demo (placeholder)"
+                >
+                  <source src="https://web.runmatstatic.com/video/runmat-wave-simulation.mp4" type="video/mp4" />
+                </LazyVideo>
+              </Link>
+            </div>
+          </div>
+          <div className="mx-auto max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+            <div className="rounded-lg border border-border bg-card p-6">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
+                <FlaskConical className="h-5 w-5" />
+              </span>
+              <h3 className="text-lg font-semibold text-foreground">Runtime-aware inspection</h3>
+              <p className="text-[0.938rem] text-foreground mt-1">Checks tensors for NaN, verifies shapes against expected dimensions, and reads plot data from any 3D camera angle.</p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-6">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
+                <FileDiff className="h-5 w-5" />
+              </span>
+              <h3 className="text-lg font-semibold text-foreground">Every change is reviewable</h3>
+              <p className="text-[0.938rem] text-foreground mt-1">Edits are presented as diffs. Accept or reject each change. Conversations are stored as searchable project files.</p>
+            </div>
+          </div>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center flex-wrap text-center mt-8">
+            <Link href="/sandbox" className="text-[0.938rem] text-foreground underline hover:text-foreground/80">
+              Try it in the sandbox
+            </Link>
+          </div>
+        </div>
+      </section>
+
       {/* Fastest to Read: Syntax you already know */}
       <section className="w-full py-16 md:py-24 lg:py-32">
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
-            <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
+            <h2 className="font-bold tracking-tight text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
               Syntax you already know.
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground sm:leading-8">
@@ -291,11 +351,12 @@ export default function HomePage() {
       <section id="benchmarks" className="w-full py-16 md:py-24 lg:py-32">
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
-            <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
+            <h2 className="font-bold tracking-tight text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
               The fastest runtime for your math
             </h2>
+            {/* VERIFY: confirm benchmark numbers (150-180x Octave, 10x NumPy, 3.8x PyTorch) are current and approved for public copy before deploy */}
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground sm:leading-7">
-              RunMat runs math faster because of how the runtime is engineered. Fusion merges sequential operations into fewer GPU steps; residency keeps your arrays on-device between steps. That means less memory traffic, fewer program launches, and faster scripts.
+              RunMat runs 150-180x faster than GNU Octave, up to 10x faster than NumPy, and up to 3.8x faster than PyTorch on GPU image pipelines. The runtime fuses sequential operations into fewer GPU steps and keeps your arrays on-device between them.
             </p>
           </div>
 
@@ -319,17 +380,15 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* Future: Fastest to Write (LLM / agent section) — insert here when ready */}
-
       {/* Fastest to Debug: shape tracking, diagnostics */}
       <section className="w-full py-16 md:py-24 lg:py-32">
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
-            <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
+            <h2 className="font-bold tracking-tight text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
               Debug with full visibility
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
-              Debug faster by seeing everything as you write. Hover any variable to see its shape and type. Click on an intermediate value to inspect it. Dimension mismatches are flagged in the editor before you run.
+              Debug faster by seeing everything as you write. Hover any variable to see its shape and type. Click on an intermediate value to inspect it. Dimension mismatches are flagged in the editor before you run. The agent uses the same inspection tools: materializing variables, checking shapes, and locating where a computation went wrong.
             </p>
           </div>
           <div className="mx-auto max-w-3xl">
@@ -355,11 +414,11 @@ export default function HomePage() {
       <section className="w-full py-16 md:py-24 lg:py-32">
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
-            <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
+            <h2 className="font-bold tracking-tight text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
               Every change versioned. No git required.
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
-              Every save is a version, automatically. Per-file history and full project snapshots track every change, even on terabyte-scale datasets. Share projects with your team, no git setup, no merge conflicts.
+              Every save is a version, automatically. Per-file history and full project snapshots track every change, even on terabyte-scale datasets. Share projects with your team, no git setup, no merge conflicts. Agent-generated edits get the same treatment: versioned and reversible.
             </p>
           </div>
           <div className="mx-auto max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
@@ -416,7 +475,7 @@ export default function HomePage() {
       <section className="w-full py-16 md:py-24 lg:py-32">
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
-            <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
+            <h2 className="font-bold tracking-tight text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
               Scale your math, not your toolchain
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
@@ -462,7 +521,7 @@ export default function HomePage() {
       <section className="w-full py-16 md:py-24 lg:py-32">
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto max-w-2xl text-center">
-            <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl mb-8">
+            <h2 className="font-bold tracking-tight text-3xl leading-[1.1] sm:text-3xl md:text-5xl mb-8">
               Open source, MIT licensed
             </h2>
             <Card className="border border-border bg-card">
@@ -476,7 +535,7 @@ export default function HomePage() {
                   <SiGithub className="h-8 w-8" />
                 </Link>
                 <p className="text-[0.938rem] text-foreground">
-                  Read every line of code that runs your math. Fork it, audit it, self-host it. No vendor lock-in, no black boxes. The runtime is on{" "}
+                  Read every line of code that runs your math. Fork the runtime to audit or self-host. No vendor lock-in, no black boxes. The runtime is on{" "}
                   <Link href="https://github.com/runmat-org/runmat" className="underline text-[hsl(var(--brand))] hover:text-[hsl(var(--brand))]/80" target="_blank" rel="noreferrer">
                     GitHub
                   </Link>
@@ -496,7 +555,7 @@ export default function HomePage() {
       <section className="w-full py-16 md:py-24 lg:py-32">
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
-            <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
+            <h2 className="font-bold tracking-tight text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
               Secure by design
             </h2>
             <p className="max-w-[42rem] text-[0.938rem] leading-relaxed text-foreground">
@@ -540,6 +599,33 @@ export default function HomePage() {
                   <div>
                     <p className="text-xl font-medium text-foreground">SOC 2 ready</p>
                     <p className="text-[0.938rem] text-foreground">Built to SOC 2 standards. Audit planned for Q2 2026.</p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-4">
+                  <span className="mt-1 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-foreground/10 text-foreground">
+                    <ShieldCheck className="h-5 w-5" />
+                  </span>
+                  <div>
+                    <p className="text-xl font-medium text-foreground">Sandboxed agent execution</p>
+                    <p className="text-[0.938rem] text-foreground">Agent commands run inside OS-level sandboxes (Seatbelt on macOS, bubblewrap on Linux). Network is denied by default. Filesystem access is scoped to the project root. Secrets are redacted from the environment before any process runs.</p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-4">
+                  <span className="mt-1 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-foreground/10 text-foreground">
+                    <History className="h-5 w-5" />
+                  </span>
+                  <div>
+                    <p className="text-xl font-medium text-foreground">Replayable agent sessions</p>
+                    <p className="text-[0.938rem] text-foreground">Every agent action is journaled with content hashes. Replay a session to verify exactly what the agent did, step by step. Built for environments where audit trails are mandatory.</p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-4">
+                  <span className="mt-1 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-foreground/10 text-foreground">
+                    <Layers className="h-5 w-5" />
+                  </span>
+                  <div>
+                    <p className="text-xl font-medium text-foreground">Provider-agnostic architecture</p>
+                    <p className="text-[0.938rem] text-foreground">The agent runs on a model-agnostic harness. No lock-in to one provider's roadmap.</p>
                   </div>
                 </div>
               </div>

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -226,10 +226,10 @@ export default function HomePage() {
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
             <h2 className="font-bold tracking-tight text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
-              See your math in 3D
+              GPU accelerated plotting
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
-              Render millions of points straight from GPU memory. 2D and 3D plots run on the same compute chain as your math, so data does not need to be copied between systems while you visualize it.
+              Render millions of points straight from a GPU tensor. 2D and 3D plots run on the same compute chain as your math, in the same runtime. The platform&apos;s agent has its own camera and can rotate, zoom, and inspect plots while you work on something else.
             </p>
           </div>
           <div className="mx-auto max-w-3xl">
@@ -275,7 +275,6 @@ export default function HomePage() {
               The agent runs your code, inspects workspace variables, and reads 3D plot data. You review every change as a diff before it lands.
             </p>
           </div>
-          {/* TODO: replace placeholder wave-simulation video with a proper agent demo recording when ready */}
           <div className="mx-auto max-w-3xl mb-8">
             <div className="rounded-lg border border-border overflow-hidden elevated-panel">
               <Link href="/sandbox" className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-b-none rounded-t-lg overflow-hidden">
@@ -284,10 +283,10 @@ export default function HomePage() {
                   muted
                   loop
                   playsInline
-                  poster="https://web.runmatstatic.com/video/posters/runmat-wave-simulation.webp"
-                  aria-label="RunMat agent exploration demo (placeholder)"
+                  poster="https://web.runmatstatic.com/video/posters/runmat-agent-demo-speaker.webp"
+                  aria-label="RunMat agent exploring a speaker interference pattern in 3D — opens the sandbox"
                 >
-                  <source src="https://web.runmatstatic.com/video/runmat-wave-simulation.mp4" type="video/mp4" />
+                  <source src="https://web.runmatstatic.com/video/runmat-agent-demo-speaker.mp4" type="video/mp4" />
                 </LazyVideo>
               </Link>
             </div>
@@ -307,11 +306,6 @@ export default function HomePage() {
               <h3 className="text-lg font-semibold text-foreground">Every change is reviewable</h3>
               <p className="text-[0.938rem] text-foreground mt-1">Edits are presented as diffs. Accept or reject each change. Conversations are stored as searchable project files.</p>
             </div>
-          </div>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center flex-wrap text-center mt-8">
-            <Link href="/sandbox" className="text-[0.938rem] text-foreground underline hover:text-foreground/80">
-              Try it in the sandbox
-            </Link>
           </div>
         </div>
       </section>
@@ -351,10 +345,10 @@ export default function HomePage() {
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
             <h2 className="font-bold tracking-tight text-3xl leading-[1.1] sm:text-3xl md:text-5xl">
-              Blazing fast runtime for math
+              The fastest runtime for your math
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground sm:leading-7">
-              RunMat automatically promotes tensor operations to GPUs where it helps. Fusion merges sequential operations into fewer GPU steps; residency keeps your arrays on-device between steps. That means your code runs on GPUs automatically where they&apos;re available, without you having to decide in your code what to run on what.
+              RunMat runs 150-180x faster than GNU Octave, up to 10x faster than NumPy, and up to 3.8x faster than PyTorch on GPU image pipelines. The runtime fuses sequential operations into fewer GPU steps and keeps your arrays on-device between them.
             </p>
           </div>
 

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
-import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { SiGithub } from "react-icons/si";
 import { Users, GitBranch, Camera, Lock, Shield, Eye, ClipboardCheck, Cpu, Monitor, HardDrive, FlaskConical, FileDiff, ShieldCheck, History, Layers } from "lucide-react";
@@ -230,7 +229,7 @@ export default function HomePage() {
               See your math in 3D
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
-              Render millions of points straight from a GPU tensor. 2D and 3D plots run on the same compute chain as your math, in the same runtime. The platform's agent has its own camera and can rotate, zoom, and inspect plots while you work on something else.
+              Render millions of points straight from a GPU tensor. 2D and 3D plots run on the same compute chain as your math, in the same runtime. The platform&apos;s agent has its own camera and can rotate, zoom, and inspect plots while you work on something else.
             </p>
           </div>
           <div className="mx-auto max-w-3xl">
@@ -625,7 +624,7 @@ export default function HomePage() {
                   </span>
                   <div>
                     <p className="text-xl font-medium text-foreground">Provider-agnostic architecture</p>
-                    <p className="text-[0.938rem] text-foreground">The agent runs on a model-agnostic harness. No lock-in to one provider's roadmap.</p>
+                    <p className="text-[0.938rem] text-foreground">The agent runs on a model-agnostic harness. No lock-in to one provider&apos;s roadmap.</p>
                   </div>
                 </div>
               </div>

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -599,7 +599,7 @@ export default function HomePage() {
                   </span>
                   <div>
                     <p className="text-xl font-medium text-foreground">Sandboxed agent execution</p>
-                    <p className="text-[0.938rem] text-foreground">Agent commands run inside OS-level sandboxes (Seatbelt on macOS, bubblewrap on Linux). Network is denied by default. Filesystem access is scoped to the project root. Secrets are redacted from the environment before any process runs.</p>
+                    <p className="text-[0.938rem] text-foreground">In default deployments, agent commands run inside OS-level sandboxes (Seatbelt on macOS, bubblewrap on Linux), with network denied by default, filesystem scoped to your project, and known secret patterns stripped from the child process environment. Behavior is profile-driven and configurable per deployment.</p>
                   </div>
                 </div>
                 <div className="flex items-start gap-4">
@@ -608,7 +608,7 @@ export default function HomePage() {
                   </span>
                   <div>
                     <p className="text-xl font-medium text-foreground">Replayable agent sessions</p>
-                    <p className="text-[0.938rem] text-foreground">Every agent action is journaled with content hashes. Replay a session to verify exactly what the agent did, step by step. Built for environments where audit trails are mandatory.</p>
+                    <p className="text-[0.938rem] text-foreground">When durable persistence is enabled, agent actions are journaled in append-only order, and artifacts are content-addressed by hash. Replay a session to reconstruct what the agent did, step by step. Designed for environments that need audit trails.</p>
                   </div>
                 </div>
                 <div className="flex items-start gap-4">

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -348,7 +348,7 @@ export default function HomePage() {
               The fastest runtime for your math
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground sm:leading-7">
-              RunMat runs 150-180x faster than GNU Octave, up to 10x faster than NumPy, and up to 3.8x faster than PyTorch on GPU image pipelines. The runtime fuses sequential operations into fewer GPU steps and keeps your arrays on-device between them.
+              In verified benchmarks, RunMat runs 150-180x faster than GNU Octave, up to 10x faster than NumPy, and up to 3.8x faster than PyTorch on GPU image pipelines. The runtime fuses sequential operations into fewer GPU steps and keeps your arrays on-device between them.
             </p>
           </div>
 

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -8,11 +8,11 @@ export default function Hero() {
       <div className="container mx-auto px-4 md:px-6">
         <div className="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:items-center">
           <div className="flex flex-col space-y-6 text-left items-start">
-            <p className="font-heading text-left leading-tight tracking-tight text-[clamp(2.6rem,4.8vw,4.25rem)] sm:text-[clamp(3rem,4vw,5rem)] lg:text-[clamp(3.25rem,3.6vw,5.25rem)]" role="heading" aria-level={2}>
+            <p className="font-bold text-left leading-tight tracking-tight text-[clamp(2.6rem,4.8vw,4.25rem)] sm:text-[clamp(3rem,4vw,5rem)] lg:text-[clamp(3.25rem,3.6vw,5.25rem)]" role="heading" aria-level={2}>
               Run your math, blazing fast
             </p>
             <p className="max-w-[42rem] leading-relaxed text-foreground text-[0.938rem] sm:text-base">
-              Write MATLAB-syntax code and run it with GPU acceleration, in your browser, on the desktop, or from the CLI. No license required.
+              MATLAB-syntax math on GPU, in your browser or from the CLI. With the built-in agent, sweep fifty parameter variations in the time it used to take for one.
             </p>
             <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
               <Button

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -8,11 +8,11 @@ export default function Hero() {
       <div className="container mx-auto px-4 md:px-6">
         <div className="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:items-center">
           <div className="flex flex-col space-y-6 text-left items-start">
-            <p className="font-heading text-left leading-tight tracking-tight text-[clamp(2.6rem,4.8vw,4.25rem)] sm:text-[clamp(3rem,4vw,5rem)] lg:text-[clamp(3.25rem,3.6vw,5.25rem)]" role="heading" aria-level={2}>
-              Run your math blazing fast
+            <p className="font-bold text-left leading-tight tracking-tight text-[clamp(2.6rem,4.8vw,4.25rem)] sm:text-[clamp(3rem,4vw,5rem)] lg:text-[clamp(3.25rem,3.6vw,5.25rem)]" role="heading" aria-level={2}>
+              Run math blazing fast
             </p>
             <p className="max-w-[42rem] leading-relaxed text-foreground text-[0.938rem] sm:text-base">
-              GPU-accelerated MATLAB-syntax math in your browser, on the desktop, or from the CLI. With the built-in agent, sweep fifty parameter variations in the time it used to take for one.
+              MATLAB-syntax math on GPU, in your browser or from the CLI. With the built-in agent, sweep fifty parameter variations in the time it used to take for one.
             </p>
             <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
               <Button

--- a/website/components/SandboxCta.tsx
+++ b/website/components/SandboxCta.tsx
@@ -18,7 +18,7 @@ export function SandboxCta({
         Try RunMat for free
       </h3>
       <p className="text-foreground text-[0.938rem] max-w-md mx-auto">
-        Open the sandbox and start running MATLAB code in seconds. No account required.
+        Write code or describe what you want to compute. The sandbox is free, no account required.
       </p>
       <div className="flex flex-col sm:flex-row items-center justify-center gap-3 pt-1">
         <Button

--- a/website/components/benchmarks/HeroBenchmarkClient.tsx
+++ b/website/components/benchmarks/HeroBenchmarkClient.tsx
@@ -85,7 +85,7 @@ export default function HeroBenchmarkClient({ slides }: HeroBenchmarkClientProps
             <div className="mb-2 p-0">
               🚀 Open Source • MIT Licensed • Pre-Release
             </div>
-            <h1 className="font-heading text-left leading-tight whitespace-nowrap tracking-tight text-[clamp(2.6rem,4.8vw,4.25rem)] sm:text-[clamp(3rem,4vw,5rem)] lg:text-[clamp(3.25rem,3.6vw,5.25rem)]">
+            <h1 className="font-bold text-left leading-tight whitespace-nowrap tracking-tight text-[clamp(2.6rem,4.8vw,4.25rem)] sm:text-[clamp(3rem,4vw,5rem)] lg:text-[clamp(3.25rem,3.6vw,5.25rem)]">
               Fastest runtime for
             </h1>
             <BenchmarkTicker slides={slides} activeIndex={activeIndex} onSelect={goToIndex} />

--- a/website/components/pricing/CloudPricingCard.tsx
+++ b/website/components/pricing/CloudPricingCard.tsx
@@ -29,7 +29,9 @@ const cloudTierConfig: Record<CloudTier, CloudTierDef> = {
     features: [
       { label: "GPU accelerated plotting", href: "#compare-plotting" },
       "Plot, code and variable version history",
+      "Project sharing and team workspaces",
       { label: "100 MB storage", href: "#compare-storage" },
+      "Limited LLM tokens included",
       "Community support",
     ],
     ctaLabel: "Start free",
@@ -41,6 +43,7 @@ const cloudTierConfig: Record<CloudTier, CloudTierDef> = {
     features: [
       { label: "GPU accelerated plotting", href: "#compare-plotting" },
       { label: "Plot, code and variable version history", href: "#compare-versioning" },
+      "Project sharing and team workspaces",
       { label: "10 GB storage", href: "#compare-storage" },
       { label: "$10/mo LLM tokens included", href: "#compare-llm" },
     ],

--- a/website/components/pricing/ComparisonTables.tsx
+++ b/website/components/pricing/ComparisonTables.tsx
@@ -121,7 +121,7 @@ function ExpandableRow({
 export function CompareProductsTable() {
   return (
     <section className="pb-16 md:pb-24">
-      <h2 className="font-heading text-3xl leading-[1.1] sm:text-3xl md:text-5xl text-foreground mb-10 text-center">
+      <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl text-foreground mb-10 text-center">
         Compare products
       </h2>
       <div className="rounded-xl border border-border/60 overflow-hidden">

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -35,6 +35,51 @@ function loadBuiltinAliasRedirects() {
   return redirects;
 }
 
+const missingBuiltinReferenceSlugs = [
+  "__make_cell",
+  "accumarray",
+  "convertStringsToChars",
+  "isprop",
+  "mat2str",
+  "new_object",
+  "notify",
+  "null",
+  "num2cell",
+  "ops",
+  "overidx.and",
+  "overidx.eq",
+  "overidx.gt",
+  "overidx.ldivide",
+  "overidx.lt",
+  "overidx.mtimes",
+  "overidx.or",
+  "overidx.plus",
+  "overidx.rdivide",
+  "overidx.subsasgn",
+  "overidx.subsref",
+  "overidx.times",
+  "overidx.uplus",
+  "overidx.xor",
+  "pkgf.foo",
+  "pkgg.foo",
+  "point.move",
+  "point.origin",
+  "profile",
+  "residue",
+  "set.p",
+  "shape.area",
+  "spdiags",
+  "writecell",
+];
+
+const legacyIgnitionDocSlugs = [
+  "compiler-pipeline",
+  "error-model",
+  "indexing-and-slicing",
+  "instr-set",
+  "oop-semantics",
+];
+
 const nextConfig: NextConfig = {
   // Allow API routes to run on Vercel (no static export)
   images: {
@@ -62,6 +107,16 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       ...loadBuiltinAliasRedirects(),
+      ...missingBuiltinReferenceSlugs.map((slug) => ({
+        source: `/docs/reference/builtins/${slug}`,
+        destination: '/docs/matlab-function-reference',
+        permanent: false,
+      })),
+      ...legacyIgnitionDocSlugs.map((slug) => ({
+        source: `/docs/ignition/${slug}`,
+        destination: '/docs/architecture',
+        permanent: false,
+      })),
       {
         source: '/run-matlab-online',
         destination: '/matlab-online',
@@ -101,6 +156,11 @@ const nextConfig: NextConfig = {
         source: '/docs/elements-of-matlab',
         destination: '/docs/matlab-function-reference',
         permanent: true,
+      },
+      {
+        source: '/docs/package-manager',
+        destination: '/docs/how-it-works',
+        permanent: false,
       },
 
       // Privacy — no dedicated page yet; temporary redirect until one is created


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the project’s licensing terms and public-facing legal/marketing content, which can impact downstream distribution/compliance despite minimal runtime code risk.
> 
> **Overview**
> Standardizes the repo and `bindings/` license text to plain **MIT** (removing prior attribution/copyleft addenda) and updates README/docs to reflect the new licensing and product split (runtime vs Dystr AI/Cloud).
> 
> Refreshes website pages (home, `matlab-online`, `license`) with new agent-forward positioning, expanded FAQs/structured data, and updated pricing copy.
> 
> Adds/adjusts Next.js redirects to reduce doc/reference 404s (missing builtin reference slugs, legacy ignition docs, and `/docs/package-manager` -> `/docs/how-it-works`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb413e78f157ff02dcc673fdd21d831aaf7c440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in agent features: runtime inspection, sandboxed execution, replayable/versioned agent sessions
  * Expanded enterprise security feature set
  * Project sharing & team workspaces added to cloud tiers

* **Content & Marketing**
  * Revised homepage, hero, MATLAB Online and product pages with new marketing copy, sections and demos
  * Updated SEO metadata, titles, descriptions and keywords

* **Licensing**
  * Project license and docs standardized to MIT

* **Chores**
  * Added temporary redirects for legacy docs and missing references

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/338)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->