### PR TITLE
add workflow dispatch for prod wasm

### DIFF
--- a/.github/workflows/wasm-bindings.yml
+++ b/.github/workflows/wasm-bindings.yml
@@ -42,6 +42,18 @@ on:
         required: true
         default: dev
         type: string
+      release_channel:
+        description: Publication channel
+        required: true
+        default: dev
+        type: choice
+        options:
+          - dev
+          - prod
+      version:
+        description: Exact package version for production releases (for example, 0.4.7)
+        required: false
+        type: string
       publish:
         description: Whether to publish to npm
         required: true
@@ -59,10 +71,8 @@ jobs:
   build-and-publish:
     runs-on: ["self-hosted", "linux", "GCP"]
     # Environment-scoped secrets (NPM_TOKEN) require the job to declare the
-    # correct environment.  When triggered by a direct push or workflow_dispatch
-    # the job runs in the Dev environment; when called from release.yml via
-    # workflow_call the caller already has Production in scope and passes the
-    # secret explicitly, so this resolves to Production here as well.
+    # correct environment. Direct dev pushes use Dev; workflow_dispatch and
+    # release.yml workflow_call can select Production via release_channel=prod.
     environment: ${{ inputs.release_channel == 'prod' && 'Production' || 'Dev' }}
     env:
       RUST_BACKTRACE: 1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts the WASM bindings publish workflow to optionally target the Production environment, which affects how npm credentials/secrets are selected and could impact release publishing if misconfigured.
> 
> **Overview**
> Adds manual `workflow_dispatch` inputs to the WASM bindings workflow to select a `release_channel` (`dev`/`prod`) and optionally provide an explicit `version` for production publishes.
> 
> Updates the job’s `environment` selection logic/comments so runs can opt into the `Production` environment when `release_channel=prod`, otherwise defaulting to `Dev`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d593cc4ad28581ed4caab5b082b2a0dd3311c790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to improve build and release process reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/339)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->