### PR TITLE
Fix issues related to RM-410, silent failure:

### DIFF
--- a/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
@@ -144,8 +144,10 @@ mod compute_binding_count_tests {
 
     #[test]
     fn rejects_storage_bindings_over_adapter_stage_limit() {
-        let mut limits = wgpu::Limits::default();
-        limits.max_storage_buffers_per_shader_stage = 10;
+        let limits = wgpu::Limits {
+            max_storage_buffers_per_shader_stage: 10,
+            ..Default::default()
+        };
 
         let err = validate_compute_binding_counts("fused_elementwise_multi", 11, 12, &limits)
             .expect_err(
@@ -157,9 +159,11 @@ mod compute_binding_count_tests {
 
     #[test]
     fn accepts_bindings_at_adapter_limits() {
-        let mut limits = wgpu::Limits::default();
-        limits.max_storage_buffers_per_shader_stage = 10;
-        limits.max_bindings_per_bind_group = 11;
+        let limits = wgpu::Limits {
+            max_storage_buffers_per_shader_stage: 10,
+            max_bindings_per_bind_group: 11,
+            ..Default::default()
+        };
 
         validate_compute_binding_counts("fused_elementwise", 10, 11, &limits)
             .expect("limits are inclusive");

--- a/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
@@ -111,6 +111,61 @@ fn runtime_flow_to_anyhow(_context: &str, err: RuntimeError) -> anyhow::Error {
     anyhow::Error::new(err)
 }
 
+fn validate_compute_binding_counts(
+    operation: &str,
+    storage_bindings: usize,
+    total_bindings: usize,
+    limits: &wgpu::Limits,
+) -> Result<()> {
+    let storage_limit = limits.max_storage_buffers_per_shader_stage as usize;
+    ensure!(
+        storage_bindings <= storage_limit,
+        "{}: requires {} storage buffers, but this WebGPU adapter supports {} per shader stage",
+        operation,
+        storage_bindings,
+        storage_limit
+    );
+
+    let binding_limit = limits.max_bindings_per_bind_group as usize;
+    ensure!(
+        total_bindings <= binding_limit,
+        "{}: requires {} bind group entries, but this WebGPU adapter supports {} per bind group",
+        operation,
+        total_bindings,
+        binding_limit
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod compute_binding_count_tests {
+    use super::validate_compute_binding_counts;
+
+    #[test]
+    fn rejects_storage_bindings_over_adapter_stage_limit() {
+        let mut limits = wgpu::Limits::default();
+        limits.max_storage_buffers_per_shader_stage = 10;
+
+        let err = validate_compute_binding_counts("fused_elementwise_multi", 11, 12, &limits)
+            .expect_err(
+                "storage binding overflow should be rejected before creating a WGPU layout",
+            );
+
+        assert!(err.to_string().contains("requires 11 storage buffers"));
+    }
+
+    #[test]
+    fn accepts_bindings_at_adapter_limits() {
+        let mut limits = wgpu::Limits::default();
+        limits.max_storage_buffers_per_shader_stage = 10;
+        limits.max_bindings_per_bind_group = 11;
+
+        validate_compute_binding_counts("fused_elementwise", 10, 11, &limits)
+            .expect("limits are inclusive");
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct WgpuProviderOptions {
     pub power_preference: wgpu::PowerPreference,
@@ -3564,6 +3619,12 @@ impl WgpuProvider {
         if len > u32::MAX as usize {
             return Err(anyhow!("fused_elementwise: tensor too large"));
         }
+        validate_compute_binding_counts(
+            "fused_elementwise",
+            inputs.len() + 1,
+            inputs.len() + 2,
+            &self.adapter_limits,
+        )?;
         let entries = inputs
             .iter()
             .map(|h| self.get_entry(h))
@@ -3842,6 +3903,12 @@ impl WgpuProvider {
         if len > u32::MAX as usize {
             return Err(anyhow!("fused_elementwise_multi: tensor too large"));
         }
+        validate_compute_binding_counts(
+            "fused_elementwise_multi",
+            inputs.len() + num_outputs,
+            inputs.len() + num_outputs + 1,
+            &self.adapter_limits,
+        )?;
 
         let entries = inputs
             .iter()

--- a/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
@@ -175,6 +175,20 @@ mod compute_binding_count_tests {
     }
 
     #[test]
+    fn rejects_bindings_over_bind_group_limit() {
+        let limits = wgpu::Limits {
+            max_storage_buffers_per_shader_stage: 10,
+            max_bindings_per_bind_group: 11,
+            ..Default::default()
+        };
+
+        let err = validate_compute_binding_counts("fused_elementwise", 10, 12, &limits)
+            .expect_err("bind group entry overflow should be rejected");
+
+        assert!(err.to_string().contains("requires 12 bind group entries"));
+    }
+
+    #[test]
     fn rejects_binding_count_overflow() {
         let err = checked_binding_count("fused_elementwise", usize::MAX, 1)
             .expect_err("binding count overflow should be rejected");

--- a/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
@@ -138,9 +138,14 @@ fn validate_compute_binding_counts(
     Ok(())
 }
 
+fn checked_binding_count(operation: &str, left: usize, right: usize) -> Result<usize> {
+    left.checked_add(right)
+        .ok_or_else(|| anyhow!("{}: binding count overflow", operation))
+}
+
 #[cfg(test)]
 mod compute_binding_count_tests {
-    use super::validate_compute_binding_counts;
+    use super::{checked_binding_count, validate_compute_binding_counts};
 
     #[test]
     fn rejects_storage_bindings_over_adapter_stage_limit() {
@@ -167,6 +172,14 @@ mod compute_binding_count_tests {
 
         validate_compute_binding_counts("fused_elementwise", 10, 11, &limits)
             .expect("limits are inclusive");
+    }
+
+    #[test]
+    fn rejects_binding_count_overflow() {
+        let err = checked_binding_count("fused_elementwise", usize::MAX, 1)
+            .expect_err("binding count overflow should be rejected");
+
+        assert!(err.to_string().contains("binding count overflow"));
     }
 }
 
@@ -3623,10 +3636,12 @@ impl WgpuProvider {
         if len > u32::MAX as usize {
             return Err(anyhow!("fused_elementwise: tensor too large"));
         }
+        let storage_bindings = checked_binding_count("fused_elementwise", inputs.len(), 1)?;
+        let total_bindings = checked_binding_count("fused_elementwise", inputs.len(), 2)?;
         validate_compute_binding_counts(
             "fused_elementwise",
-            inputs.len() + 1,
-            inputs.len() + 2,
+            storage_bindings,
+            total_bindings,
             &self.adapter_limits,
         )?;
         let entries = inputs
@@ -3769,7 +3784,7 @@ impl WgpuProvider {
 
         let (mut uniform_state, uniform_buffer) = uniform_state;
 
-        let mut bind_entries = Vec::with_capacity(inputs.len() + 2);
+        let mut bind_entries = Vec::with_capacity(total_bindings);
         for (idx, entry) in entries.iter().enumerate() {
             bind_entries.push(wgpu::BindGroupEntry {
                 binding: idx as u32,
@@ -3781,7 +3796,7 @@ impl WgpuProvider {
             resource: output_buffer.as_ref().as_entire_binding(),
         });
         bind_entries.push(wgpu::BindGroupEntry {
-            binding: (inputs.len() + 1) as u32,
+            binding: storage_bindings as u32,
             resource: uniform_buffer.as_ref().as_entire_binding(),
         });
 
@@ -3907,10 +3922,13 @@ impl WgpuProvider {
         if len > u32::MAX as usize {
             return Err(anyhow!("fused_elementwise_multi: tensor too large"));
         }
+        let storage_bindings =
+            checked_binding_count("fused_elementwise_multi", inputs.len(), num_outputs)?;
+        let total_bindings = checked_binding_count("fused_elementwise_multi", storage_bindings, 1)?;
         validate_compute_binding_counts(
             "fused_elementwise_multi",
-            inputs.len() + num_outputs,
-            inputs.len() + num_outputs + 1,
+            storage_bindings,
+            total_bindings,
             &self.adapter_limits,
         )?;
 
@@ -4046,7 +4064,7 @@ impl WgpuProvider {
             template: bytes,
         };
 
-        let mut bind_entries = Vec::with_capacity(inputs.len() + num_outputs + 1);
+        let mut bind_entries = Vec::with_capacity(total_bindings);
         for (idx, entry) in entries.iter().enumerate() {
             bind_entries.push(wgpu::BindGroupEntry {
                 binding: idx as u32,
@@ -4060,7 +4078,7 @@ impl WgpuProvider {
             });
         }
         bind_entries.push(wgpu::BindGroupEntry {
-            binding: (inputs.len() + num_outputs) as u32,
+            binding: storage_bindings as u32,
             resource: uniform_buffer.as_ref().as_entire_binding(),
         });
 

--- a/crates/runmat-core/src/session/run.rs
+++ b/crates/runmat-core/src/session/run.rs
@@ -375,14 +375,19 @@ impl RunMatSession {
                             } else {
                                 self.stats.interpreter_fallback += 1;
                             }
-                            if let Some(runmat_hir::HirStmt::Assign(var_id, _, _, _)) =
-                                hir.body.first()
-                            {
-                                if let Some(name) = id_to_name.get(&var_id.0) {
+                            for instr in &bytecode.instructions {
+                                if let runmat_vm::Instr::StoreVar(var_id) = instr {
+                                    if let Some(name) = id_to_name.get(var_id) {
+                                        assigned_this_execution.insert(name.clone());
+                                    }
+                                }
+                            }
+                            if let Some(var_id) = single_assign_var {
+                                if let Some(name) = id_to_name.get(&var_id) {
                                     assigned_this_execution.insert(name.clone());
                                 }
-                                if var_id.0 < self.variable_array.len() {
-                                    let assignment_value = self.variable_array[var_id.0].clone();
+                                if var_id < self.variable_array.len() {
+                                    let assignment_value = self.variable_array[var_id].clone();
                                     if !is_semicolon_suppressed {
                                         result_value = Some(assignment_value);
                                         if self.verbose {

--- a/crates/runmat-core/tests/integration.rs
+++ b/crates/runmat-core/tests/integration.rs
@@ -7,6 +7,7 @@ use futures::executor::block_on;
 use runmat_core::RunMatSession;
 use runmat_gc::{gc_test_context, GcConfig};
 use runmat_time::Instant;
+use std::convert::TryInto;
 use std::thread;
 
 #[test]
@@ -60,6 +61,47 @@ fn test_hotspot_compilation_simulation() {
             interp_executions > 0 || _jit_executions > 0,
             "Should have some executions"
         );
+    });
+}
+
+#[test]
+fn exact_stop_time_regression_stays_numeric_after_session_execution() {
+    gc_test_context(|| {
+        let mut engine = RunMatSession::with_options(true, false).unwrap();
+        let code = "\
+g = 9.81;
+h0 = 2.0;
+ratio = sqrt(0.8);
+t0 = sqrt(2*h0/g);
+t1 = 2*sqrt(2*(0.8*h0)/g);
+exactStopTime = t0 + t1/(1-ratio)";
+
+        for _ in 0..12 {
+            let result = block_on(engine.execute(code)).unwrap();
+            assert!(result.error.is_none());
+            let value = result.value.as_ref().expect("final assignment emits value");
+            let numeric: f64 = value.try_into().unwrap();
+            assert!(
+                (numeric - 11.458330203035164).abs() < 1e-10,
+                "unexpected result: {numeric}"
+            );
+            let exact_entry = result
+                .workspace
+                .values
+                .iter()
+                .find(|entry| entry.name == "exactStopTime")
+                .expect("workspace includes exactStopTime");
+            let preview = exact_entry
+                .preview
+                .as_ref()
+                .expect("exactStopTime has scalar preview");
+            assert_eq!(preview.values.len(), 1);
+            assert!(
+                (preview.values[0] - 11.458330203035164).abs() < 1e-10,
+                "unexpected workspace preview: {}",
+                preview.values[0]
+            );
+        }
     });
 }
 

--- a/crates/runmat-parser/src/parser/expr.rs
+++ b/crates/runmat-parser/src/parser/expr.rs
@@ -245,13 +245,24 @@ impl Parser {
                     break;
                 }
                 self.pos += 1;
-                let name_token = match self.next() {
+                let name_token = match self.peek().cloned() {
                     Some(TokenInfo {
                         token: Token::Ident,
                         lexeme,
                         position,
                         end,
-                    }) => (lexeme, position, end),
+                    }) => {
+                        self.pos += 1;
+                        (lexeme, position, end)
+                    }
+                    Some(token) => {
+                        return Err(SyntaxError {
+                            message: "expected member name after '.'".to_string(),
+                            position: token.position,
+                            found_token: Some(token.lexeme),
+                            expected: Some("identifier".to_string()),
+                        })
+                    }
                     _ => {
                         return Err(self
                             .error_with_expected("expected member name after '.'", "identifier"))

--- a/crates/runmat-parser/src/parser/expr.rs
+++ b/crates/runmat-parser/src/parser/expr.rs
@@ -320,7 +320,7 @@ impl Parser {
             // Meta-class query with controlled qualified name consumption to allow postfix chaining.
             // Consume packages (lowercase-leading) and exactly one Class segment (uppercase-leading), then stop.
             let mut parts: Vec<String> = Vec::new();
-            let first = self.expect_ident().map_err(|e| self.error(&e))?;
+            let first = self.expect_ident_syntax()?;
             let class_consumed = first
                 .chars()
                 .next()
@@ -344,7 +344,7 @@ impl Parser {
                     break;
                 }
                 self.pos += 1;
-                let seg = self.expect_ident().map_err(|e| self.error(&e))?;
+                let seg = self.expect_ident_syntax()?;
                 parts.push(seg);
                 if is_upper {
                     break;
@@ -393,9 +393,9 @@ impl Parser {
                     if self.consume(&Token::LParen) {
                         let mut params = Vec::new();
                         if !self.consume(&Token::RParen) {
-                            params.push(self.expect_ident().map_err(|e| self.error(&e))?);
+                            params.push(self.expect_ident_syntax()?);
                             while self.consume(&Token::Comma) {
-                                params.push(self.expect_ident().map_err(|e| self.error(&e))?);
+                                params.push(self.expect_ident_syntax()?);
                             }
                             if !self.consume(&Token::RParen) {
                                 return Err(self.error_with_expected(
@@ -412,7 +412,7 @@ impl Parser {
                             span,
                         })
                     } else {
-                        let name = self.expect_ident().map_err(|e| self.error(&e))?;
+                        let name = self.expect_ident_syntax()?;
                         let end = self.last_token_end();
                         let span = self.span_from(start, end);
                         Ok(Expr::FuncHandle(name, span))

--- a/crates/runmat-parser/src/parser/expr.rs
+++ b/crates/runmat-parser/src/parser/expr.rs
@@ -80,7 +80,7 @@ impl Parser {
         Ok(node)
     }
 
-    fn parse_add_sub(&mut self) -> Result<Expr, String> {
+    fn parse_add_sub(&mut self) -> Result<Expr, SyntaxError> {
         let mut node = self.parse_mul_div()?;
         loop {
             if self.in_matrix_expr
@@ -133,7 +133,7 @@ impl Parser {
         Ok(node)
     }
 
-    fn parse_mul_div(&mut self) -> Result<Expr, String> {
+    fn parse_mul_div(&mut self) -> Result<Expr, SyntaxError> {
         let mut node = self.parse_unary()?;
         loop {
             if self.peek_token() == Some(&Token::Ident) && self.pos > 0 {
@@ -165,7 +165,7 @@ impl Parser {
         Ok(node)
     }
 
-    fn parse_pow(&mut self) -> Result<Expr, String> {
+    fn parse_pow(&mut self) -> Result<Expr, SyntaxError> {
         let node = self.parse_postfix()?;
         if let Some(token) = self.peek_token() {
             let op = match token {
@@ -181,7 +181,7 @@ impl Parser {
         }
     }
 
-    fn parse_postfix_with_base(&mut self, mut expr: Expr) -> Result<Expr, String> {
+    fn parse_postfix_with_base(&mut self, mut expr: Expr) -> Result<Expr, SyntaxError> {
         loop {
             if self.consume(&Token::LParen) {
                 let start = expr.span().start;
@@ -192,7 +192,7 @@ impl Parser {
                         args.push(self.parse_expr()?);
                     }
                     if !self.consume(&Token::RParen) {
-                        return Err("expected ')' after arguments".into());
+                        return Err(self.error_with_expected("expected ')' after arguments", "')'"));
                     }
                 }
                 let end = self.last_token_end();
@@ -213,7 +213,7 @@ impl Parser {
                     indices.push(self.parse_expr()?);
                 }
                 if !self.consume(&Token::RBracket) {
-                    return Err("expected ']'".into());
+                    return Err(self.error_with_expected("expected ']'", "']'"));
                 }
                 let end = self.last_token_end();
                 let span = self.span_from(start, end);
@@ -226,7 +226,7 @@ impl Parser {
                     indices.push(self.parse_expr()?);
                 }
                 if !self.consume(&Token::RBrace) {
-                    return Err("expected '}'".into());
+                    return Err(self.error_with_expected("expected '}'", "'}'"));
                 }
                 let end = self.last_token_end();
                 let span = self.span_from(start, end);
@@ -252,7 +252,10 @@ impl Parser {
                         position,
                         end,
                     }) => (lexeme, position, end),
-                    _ => return Err("expected member name after '.'".into()),
+                    _ => {
+                        return Err(self
+                            .error_with_expected("expected member name after '.'", "identifier"))
+                    }
                 };
                 if self.consume(&Token::LParen) {
                     let mut args = Vec::new();
@@ -262,7 +265,10 @@ impl Parser {
                             args.push(self.parse_expr()?);
                         }
                         if !self.consume(&Token::RParen) {
-                            return Err("expected ')' after method arguments".into());
+                            return Err(self.error_with_expected(
+                                "expected ')' after method arguments",
+                                "')'",
+                            ));
                         }
                     }
                     let end = self.last_token_end();
@@ -287,12 +293,12 @@ impl Parser {
         Ok(expr)
     }
 
-    fn parse_postfix(&mut self) -> Result<Expr, String> {
+    fn parse_postfix(&mut self) -> Result<Expr, SyntaxError> {
         let expr = self.parse_primary()?;
         self.parse_postfix_with_base(expr)
     }
 
-    fn parse_unary(&mut self) -> Result<Expr, String> {
+    fn parse_unary(&mut self) -> Result<Expr, SyntaxError> {
         if self.peek_token() == Some(&Token::Plus) {
             let start = self.tokens[self.pos].position;
             self.pos += 1;
@@ -314,7 +320,7 @@ impl Parser {
             // Meta-class query with controlled qualified name consumption to allow postfix chaining.
             // Consume packages (lowercase-leading) and exactly one Class segment (uppercase-leading), then stop.
             let mut parts: Vec<String> = Vec::new();
-            let first = self.expect_ident()?;
+            let first = self.expect_ident().map_err(|e| self.error(&e))?;
             let class_consumed = first
                 .chars()
                 .next()
@@ -338,7 +344,7 @@ impl Parser {
                     break;
                 }
                 self.pos += 1;
-                let seg = self.expect_ident()?;
+                let seg = self.expect_ident().map_err(|e| self.error(&e))?;
                 parts.push(seg);
                 if is_upper {
                     break;
@@ -353,7 +359,7 @@ impl Parser {
         }
     }
 
-    fn parse_primary(&mut self) -> Result<Expr, String> {
+    fn parse_primary(&mut self) -> Result<Expr, SyntaxError> {
         match self.next() {
             Some(info) => match info.token {
                 Token::Integer | Token::Float => {
@@ -387,17 +393,18 @@ impl Parser {
                     if self.consume(&Token::LParen) {
                         let mut params = Vec::new();
                         if !self.consume(&Token::RParen) {
-                            params.push(self.expect_ident()?);
+                            params.push(self.expect_ident().map_err(|e| self.error(&e))?);
                             while self.consume(&Token::Comma) {
-                                params.push(self.expect_ident()?);
+                                params.push(self.expect_ident().map_err(|e| self.error(&e))?);
                             }
                             if !self.consume(&Token::RParen) {
-                                return Err(
-                                    "expected ')' after anonymous function parameters".into()
-                                );
+                                return Err(self.error_with_expected(
+                                    "expected ')' after anonymous function parameters",
+                                    "')'",
+                                ));
                             }
                         }
-                        let body = self.parse_expr().map_err(|e| e.message)?;
+                        let body = self.parse_expr()?;
                         let span = self.span_from(start, body.span().end);
                         Ok(Expr::AnonFunc {
                             params,
@@ -405,7 +412,7 @@ impl Parser {
                             span,
                         })
                     } else {
-                        let name = self.expect_ident()?;
+                        let name = self.expect_ident().map_err(|e| self.error(&e))?;
                         let end = self.last_token_end();
                         let span = self.span_from(start, end);
                         Ok(Expr::FuncHandle(name, span))
@@ -415,7 +422,9 @@ impl Parser {
                     let start = info.position;
                     let expr = self.parse_expr()?;
                     if !self.consume(&Token::RParen) {
-                        return Err("expected ')' to close parentheses".into());
+                        return Err(
+                            self.error_with_expected("expected ')' to close parentheses", "')'")
+                        );
                     }
                     let end = self.last_token_end();
                     let span = self.span_from(start, end);
@@ -425,7 +434,9 @@ impl Parser {
                     let start = info.position;
                     let matrix = self.parse_matrix()?;
                     if !self.consume(&Token::RBracket) {
-                        return Err("expected ']' to close matrix literal".into());
+                        return Err(
+                            self.error_with_expected("expected ']' to close matrix literal", "']'")
+                        );
                     }
                     let end = self.last_token_end();
                     let span = self.span_from(start, end);
@@ -435,7 +446,9 @@ impl Parser {
                     let start = info.position;
                     let cell = self.parse_cell()?;
                     if !self.consume(&Token::RBrace) {
-                        return Err("expected '}' to close cell literal".into());
+                        return Err(
+                            self.error_with_expected("expected '}' to close cell literal", "'}'")
+                        );
                     }
                     let end = self.last_token_end();
                     let span = self.span_from(start, end);
@@ -445,13 +458,18 @@ impl Parser {
                     let span = self.span_from(info.position, info.end);
                     Ok(Expr::Colon(span))
                 }
-                _ => Err(format!("unexpected token: {:?}", info.token)),
+                _ => Err(SyntaxError {
+                    message: format!("unexpected token: {:?}", info.token),
+                    position: info.position,
+                    found_token: Some(info.lexeme),
+                    expected: None,
+                }),
             },
-            None => Err("unexpected end of input".into()),
+            None => Err(self.error("unexpected end of input")),
         }
     }
 
-    fn parse_matrix(&mut self) -> Result<Expr, String> {
+    fn parse_matrix(&mut self) -> Result<Expr, SyntaxError> {
         self.skip_newlines();
         let mut rows = Vec::new();
         if self.peek_token() == Some(&Token::RBracket) {
@@ -513,15 +531,15 @@ impl Parser {
         Ok(Expr::Tensor(rows, Span::default()))
     }
 
-    fn parse_matrix_expr(&mut self) -> Result<Expr, String> {
+    fn parse_matrix_expr(&mut self) -> Result<Expr, SyntaxError> {
         let prior = self.in_matrix_expr;
         self.in_matrix_expr = true;
-        let expr = self.parse_expr().map_err(|e| e.message);
+        let expr = self.parse_expr();
         self.in_matrix_expr = prior;
         expr
     }
 
-    fn parse_cell(&mut self) -> Result<Expr, String> {
+    fn parse_cell(&mut self) -> Result<Expr, SyntaxError> {
         let mut rows = Vec::new();
         self.skip_newlines();
         if self.peek_token() == Some(&Token::RBrace) {

--- a/crates/runmat-parser/src/parser/stmt.rs
+++ b/crates/runmat-parser/src/parser/stmt.rs
@@ -64,7 +64,7 @@ impl Parser {
                     let span = self.span_from(name_token.position, expr.span().end);
                     Ok(Stmt::Assign(name_token.lexeme, expr, false, span))
                 } else if self.is_simple_assignment_ahead() {
-                    let name = self.expect_ident().map_err(|e| self.error(&e))?;
+                    let name = self.expect_ident_syntax()?;
                     let start = self.tokens[self.pos.saturating_sub(1)].position;
                     if !self.consume(&Token::Assign) {
                         return Err(self.error_with_expected("expected assignment operator", "'='"));
@@ -430,6 +430,19 @@ impl Parser {
             }) => Ok(lexeme),
             _ => Err("expected identifier".into()),
         }
+    }
+
+    pub(super) fn expect_ident_syntax(&mut self) -> Result<String, SyntaxError> {
+        let token = self.peek().cloned();
+        self.expect_ident().map_err(|message| SyntaxError {
+            message,
+            position: token
+                .as_ref()
+                .map(|token| token.position)
+                .unwrap_or_else(|| self.input.len()),
+            found_token: token.map(|token| token.lexeme),
+            expected: None,
+        })
     }
 
     pub(super) fn expect_ident_or_tilde(&mut self) -> Result<String, String> {

--- a/crates/runmat-parser/src/parser/stmt.rs
+++ b/crates/runmat-parser/src/parser/stmt.rs
@@ -441,7 +441,7 @@ impl Parser {
                 .map(|token| token.position)
                 .unwrap_or_else(|| self.input.len()),
             found_token: token.map(|token| token.lexeme),
-            expected: None,
+            expected: Some("identifier".into()),
         })
     }
 

--- a/crates/runmat-parser/tests/parser.rs
+++ b/crates/runmat-parser/tests/parser.rs
@@ -466,6 +466,16 @@ fn expected_identifier_reports_offending_token_position() {
 }
 
 #[test]
+fn expected_member_name_reports_offending_token_position() {
+    let src = "x = a.(";
+    let err = parse(src).unwrap_err();
+    assert_eq!(err.message, "expected member name after '.'");
+    assert_eq!(err.position, src.find('(').unwrap());
+    assert_eq!(err.found_token.as_deref(), Some("("));
+    assert_eq!(err.expected.as_deref(), Some("identifier"));
+}
+
+#[test]
 fn invalid_token_produces_error() {
     assert!(parse("1 + $").is_err());
 }

--- a/crates/runmat-parser/tests/parser.rs
+++ b/crates/runmat-parser/tests/parser.rs
@@ -447,6 +447,16 @@ fn missing_closing_paren_produces_error() {
 }
 
 #[test]
+fn unclosed_call_argument_reports_current_token_position() {
+    let src = "t0 = sqrt(2h0/g);";
+    let err = parse(src).unwrap_err();
+    assert_eq!(err.message, "expected ')' after arguments");
+    assert_eq!(err.position, src.find("h0").unwrap());
+    assert_eq!(err.found_token.as_deref(), Some("h0"));
+    assert_eq!(err.expected.as_deref(), Some("')'"));
+}
+
+#[test]
 fn invalid_token_produces_error() {
     assert!(parse("1 + $").is_err());
 }

--- a/crates/runmat-parser/tests/parser.rs
+++ b/crates/runmat-parser/tests/parser.rs
@@ -457,6 +457,15 @@ fn unclosed_call_argument_reports_current_token_position() {
 }
 
 #[test]
+fn expected_identifier_reports_offending_token_position() {
+    let src = "?1";
+    let err = parse(src).unwrap_err();
+    assert_eq!(err.message, "expected identifier");
+    assert_eq!(err.position, src.find('1').unwrap());
+    assert_eq!(err.found_token.as_deref(), Some("1"));
+}
+
+#[test]
 fn invalid_token_produces_error() {
     assert!(parse("1 + $").is_err());
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches GPU bind-group setup, REPL/JIT assignment tracking, and parser error propagation; mistakes could change runtime behavior or surfaced error positions, though changes are guarded with validations and new regression tests.
> 
> **Overview**
> Prevents silent WebGPU failures by validating computed bind-group/storage binding counts against `wgpu::Limits` (and guarding against overflow) before creating fusion pipelines, with targeted unit tests.
> 
> Fixes REPL/JIT runs to record all variables written via `StoreVar` instructions (not just the first HIR assignment) so workspace updates remain correct, and adds an integration regression ensuring repeated session execution keeps a computed scalar (`exactStopTime`) numeric.
> 
> Refactors expression/statement parsing to consistently return structured `SyntaxError` (message + position + found/expected), improving diagnostics for missing delimiters and invalid member/identifier tokens, with new parser tests asserting exact error positions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d4249e6ea79b49fb1d2a7b4d138fa84c1b2c990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GPU execution now validates adapter limits to prevent bind/layout creation failures.
  * JIT execution correctly records variables assigned during a run.
  * Parser now produces consistent, structured syntax errors with clearer messages and positions.

* **Tests**
  * Added regression tests for GPU binding limits, assignment tracking, numeric time preservation after execution, and parser error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/340)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->