### PR TITLE
Added deg2rad and rad2deg builtins

### DIFF
--- a/crates/runmat-runtime/src/builtins/builtins-json/deg2rad.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/deg2rad.json
@@ -1,0 +1,87 @@
+{
+  "title": "deg2rad",
+  "category": "math/trigonometry",
+  "keywords": [
+    "deg2rad",
+    "degrees",
+    "radians",
+    "angle",
+    "trigonometry",
+    "elementwise"
+  ],
+  "summary": "Convert angles from degrees to radians.",
+  "references": [],
+  "gpu_support": {
+    "elementwise": true,
+    "reduction": false,
+    "precisions": [
+      "f32",
+      "f64"
+    ],
+    "broadcasting": "matlab",
+    "notes": "GPU inputs can be gathered to the host for the reference implementation. Fusion can keep compatible elementwise expressions on the active provider."
+  },
+  "fusion": {
+    "elementwise": true,
+    "reduction": false,
+    "max_inputs": 1,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::math::trigonometry::deg2rad::tests",
+    "integration": null
+  },
+  "description": "`r = deg2rad(d)` converts each angle in `d` from degrees to radians using `d*pi/180`.",
+  "behaviors": [
+    "Operates element-wise on scalars, vectors, matrices, and N-D tensors.",
+    "Integer and logical inputs are promoted to double precision before conversion.",
+    "Complex inputs are scaled component-wise, matching ordinary multiplication by `pi/180`.",
+    "Output shape matches the input shape.",
+    "String inputs are unsupported and raise a builtin-scoped error."
+  ],
+  "examples": [
+    {
+      "description": "Converting a scalar angle",
+      "input": "r = deg2rad(90)",
+      "output": "r = 1.5708"
+    },
+    {
+      "description": "Converting a vector of angles",
+      "input": "angles = [0 30 45 60 90];\nr = deg2rad(angles)",
+      "output": "r = [0 0.5236 0.7854 1.0472 1.5708]"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Is `deg2rad(x)` equivalent to `x*pi/180`?",
+      "answer": "Yes. The builtin exists for readability and MATLAB compatibility."
+    },
+    {
+      "question": "Does `deg2rad` preserve array shape?",
+      "answer": "Yes. Each element is converted independently and the original shape is preserved."
+    }
+  ],
+  "links": [
+    {
+      "label": "rad2deg",
+      "url": "./rad2deg"
+    },
+    {
+      "label": "sin",
+      "url": "./sin"
+    },
+    {
+      "label": "cos",
+      "url": "./cos"
+    },
+    {
+      "label": "tan",
+      "url": "./tan"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/math/trigonometry/deg2rad.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/math/trigonometry/deg2rad.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/builtins-json/rad2deg.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/rad2deg.json
@@ -1,0 +1,87 @@
+{
+  "title": "rad2deg",
+  "category": "math/trigonometry",
+  "keywords": [
+    "rad2deg",
+    "radians",
+    "degrees",
+    "angle",
+    "trigonometry",
+    "elementwise"
+  ],
+  "summary": "Convert angles from radians to degrees.",
+  "references": [],
+  "gpu_support": {
+    "elementwise": true,
+    "reduction": false,
+    "precisions": [
+      "f32",
+      "f64"
+    ],
+    "broadcasting": "matlab",
+    "notes": "GPU inputs can be gathered to the host for the reference implementation. Fusion can keep compatible elementwise expressions on the active provider."
+  },
+  "fusion": {
+    "elementwise": true,
+    "reduction": false,
+    "max_inputs": 1,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::math::trigonometry::rad2deg::tests",
+    "integration": null
+  },
+  "description": "`d = rad2deg(r)` converts each angle in `r` from radians to degrees using `r*180/pi`.",
+  "behaviors": [
+    "Operates element-wise on scalars, vectors, matrices, and N-D tensors.",
+    "Integer and logical inputs are promoted to double precision before conversion.",
+    "Complex inputs are scaled component-wise, matching ordinary multiplication by `180/pi`.",
+    "Output shape matches the input shape.",
+    "String inputs are unsupported and raise a builtin-scoped error."
+  ],
+  "examples": [
+    {
+      "description": "Converting a scalar angle",
+      "input": "d = rad2deg(pi)",
+      "output": "d = 180"
+    },
+    {
+      "description": "Converting a vector of angles",
+      "input": "angles = [0 pi/6 pi/4 pi/3 pi/2];\nd = rad2deg(angles)",
+      "output": "d = [0 30 45 60 90]"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Is `rad2deg(x)` equivalent to `x*180/pi`?",
+      "answer": "Yes. The builtin exists for readability and MATLAB compatibility."
+    },
+    {
+      "question": "Does `rad2deg` preserve array shape?",
+      "answer": "Yes. Each element is converted independently and the original shape is preserved."
+    }
+  ],
+  "links": [
+    {
+      "label": "deg2rad",
+      "url": "./deg2rad"
+    },
+    {
+      "label": "sin",
+      "url": "./sin"
+    },
+    {
+      "label": "cos",
+      "url": "./cos"
+    },
+    {
+      "label": "tan",
+      "url": "./tan"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/math/trigonometry/rad2deg.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/math/trigonometry/rad2deg.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/math/trigonometry/deg2rad.rs
+++ b/crates/runmat-runtime/src/builtins/math/trigonometry/deg2rad.rs
@@ -1,0 +1,206 @@
+//! MATLAB-compatible `deg2rad` builtin for RunMat.
+
+use runmat_accelerate_api::GpuTensorHandle;
+use runmat_builtins::{ComplexTensor, Tensor, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::random_args::complex_tensor_into_value;
+use crate::builtins::common::spec::{
+    BuiltinFusionSpec, ConstantStrategy, FusionError, FusionExprContext, FusionKernelTemplate,
+    ScalarType, ShapeRequirements,
+};
+use crate::builtins::common::{gpu_helpers, tensor};
+use crate::builtins::math::type_resolvers::numeric_unary_type;
+use crate::{build_runtime_error, BuiltinResult, RuntimeError};
+
+const BUILTIN_NAME: &str = "deg2rad";
+const DEG_TO_RAD: f64 = std::f64::consts::PI / 180.0;
+
+#[runmat_macros::register_fusion_spec(
+    builtin_path = "crate::builtins::math::trigonometry::deg2rad"
+)]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: "deg2rad",
+    shape: ShapeRequirements::BroadcastCompatible,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: Some(FusionKernelTemplate {
+        scalar_precisions: &[ScalarType::F32, ScalarType::F64],
+        wgsl_body: |ctx: &FusionExprContext| {
+            let input = ctx.inputs.first().ok_or(FusionError::MissingInput(0))?;
+            match ctx.scalar_ty {
+                ScalarType::F64 => Ok(format!("({input} * f64({DEG_TO_RAD}))")),
+                ScalarType::F32 => Ok(format!("({input} * {:.10})", std::f32::consts::PI / 180.0)),
+                other => Err(FusionError::UnsupportedPrecision(other)),
+            }
+        },
+    }),
+    reduction: None,
+    emits_nan: false,
+    notes: "Fusion emits a multiplication by pi/180 for degree-to-radian conversion.",
+};
+
+fn builtin_error(message: impl Into<String>) -> RuntimeError {
+    build_runtime_error(message)
+        .with_builtin(BUILTIN_NAME)
+        .build()
+}
+
+#[runtime_builtin(
+    name = "deg2rad",
+    category = "math/trigonometry",
+    summary = "Convert angles from degrees to radians.",
+    keywords = "deg2rad,degrees,radians,angle,trigonometry,gpu",
+    accel = "unary",
+    type_resolver(numeric_unary_type),
+    builtin_path = "crate::builtins::math::trigonometry::deg2rad"
+)]
+async fn deg2rad_builtin(value: Value) -> BuiltinResult<Value> {
+    match value {
+        Value::GpuTensor(handle) => deg2rad_gpu(handle).await,
+        Value::Complex(re, im) => Ok(Value::Complex(re * DEG_TO_RAD, im * DEG_TO_RAD)),
+        Value::ComplexTensor(tensor) => deg2rad_complex_tensor(tensor),
+        Value::String(_) | Value::StringArray(_) => {
+            Err(builtin_error("deg2rad: expected numeric input"))
+        }
+        other => deg2rad_real(other),
+    }
+}
+
+async fn deg2rad_gpu(handle: GpuTensorHandle) -> BuiltinResult<Value> {
+    let tensor = gpu_helpers::gather_tensor_async(&handle).await?;
+    deg2rad_tensor(tensor).map(tensor::tensor_into_value)
+}
+
+fn deg2rad_real(value: Value) -> BuiltinResult<Value> {
+    let tensor = tensor::value_into_tensor_for(BUILTIN_NAME, value).map_err(builtin_error)?;
+    deg2rad_tensor(tensor).map(tensor::tensor_into_value)
+}
+
+fn deg2rad_tensor(tensor: Tensor) -> BuiltinResult<Tensor> {
+    let data = tensor
+        .data
+        .iter()
+        .map(|&value| value * DEG_TO_RAD)
+        .collect::<Vec<_>>();
+    Tensor::new(data, tensor.shape.clone()).map_err(|err| builtin_error(format!("deg2rad: {err}")))
+}
+
+fn deg2rad_complex_tensor(tensor: ComplexTensor) -> BuiltinResult<Value> {
+    let data = tensor
+        .data
+        .iter()
+        .map(|&(re, im)| (re * DEG_TO_RAD, im * DEG_TO_RAD))
+        .collect::<Vec<_>>();
+    let converted = ComplexTensor::new(data, tensor.shape.clone())
+        .map_err(|err| builtin_error(format!("deg2rad: {err}")))?;
+    Ok(complex_tensor_into_value(converted))
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::{IntValue, LogicalArray, ResolveContext, Type};
+
+    fn deg2rad_builtin(value: Value) -> BuiltinResult<Value> {
+        block_on(super::deg2rad_builtin(value))
+    }
+
+    fn error_message(err: RuntimeError) -> String {
+        err.message().to_string()
+    }
+
+    #[test]
+    fn deg2rad_type_preserves_tensor_shape() {
+        let out = numeric_unary_type(
+            &[Type::Tensor {
+                shape: Some(vec![Some(2), Some(3)]),
+            }],
+            &ResolveContext::new(Vec::new()),
+        );
+        assert_eq!(
+            out,
+            Type::Tensor {
+                shape: Some(vec![Some(2), Some(3)])
+            }
+        );
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn deg2rad_scalar() {
+        let result = deg2rad_builtin(Value::Num(90.0)).expect("deg2rad");
+        match result {
+            Value::Num(value) => assert!((value - std::f64::consts::FRAC_PI_2).abs() < 1e-12),
+            other => panic!("expected scalar result, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn deg2rad_tensor_preserves_shape() {
+        let tensor = Tensor::new(vec![0.0, 30.0, 45.0, 60.0, 90.0], vec![1, 5]).unwrap();
+        let result = deg2rad_builtin(Value::Tensor(tensor)).expect("deg2rad");
+        match result {
+            Value::Tensor(tensor) => {
+                assert_eq!(tensor.shape, vec![1, 5]);
+                let expected = [
+                    0.0,
+                    std::f64::consts::PI / 6.0,
+                    std::f64::consts::PI / 4.0,
+                    std::f64::consts::PI / 3.0,
+                    std::f64::consts::FRAC_PI_2,
+                ];
+                for (actual, expected) in tensor.data.iter().zip(expected) {
+                    assert!((actual - expected).abs() < 1e-12);
+                }
+            }
+            other => panic!("expected tensor result, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn deg2rad_int_promotes() {
+        let result = deg2rad_builtin(Value::Int(IntValue::I32(180))).expect("deg2rad");
+        match result {
+            Value::Num(value) => assert!((value - std::f64::consts::PI).abs() < 1e-12),
+            other => panic!("expected scalar result, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn deg2rad_logical_array_promotes() {
+        let logical = LogicalArray::new(vec![0, 1], vec![1, 2]).unwrap();
+        let result = deg2rad_builtin(Value::LogicalArray(logical)).expect("deg2rad");
+        match result {
+            Value::Tensor(tensor) => {
+                assert_eq!(tensor.shape, vec![1, 2]);
+                assert_eq!(tensor.data[0], 0.0);
+                assert!((tensor.data[1] - DEG_TO_RAD).abs() < 1e-12);
+            }
+            other => panic!("expected tensor result, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn deg2rad_complex_scales_both_parts() {
+        let result = deg2rad_builtin(Value::Complex(180.0, 90.0)).expect("deg2rad");
+        match result {
+            Value::Complex(re, im) => {
+                assert!((re - std::f64::consts::PI).abs() < 1e-12);
+                assert!((im - std::f64::consts::FRAC_PI_2).abs() < 1e-12);
+            }
+            other => panic!("expected complex result, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn deg2rad_string_errors() {
+        let err = deg2rad_builtin(Value::String("90".into())).expect_err("expected error");
+        assert!(error_message(err).contains("deg2rad: expected numeric input"));
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/trigonometry/mod.rs
+++ b/crates/runmat-runtime/src/builtins/math/trigonometry/mod.rs
@@ -8,6 +8,8 @@ pub(crate) mod atan2;
 pub(crate) mod atanh;
 pub(crate) mod cos;
 pub(crate) mod cosh;
+pub(crate) mod deg2rad;
+pub(crate) mod rad2deg;
 pub(crate) mod sin;
 pub(crate) mod sinh;
 pub(crate) mod tan;

--- a/crates/runmat-runtime/src/builtins/math/trigonometry/rad2deg.rs
+++ b/crates/runmat-runtime/src/builtins/math/trigonometry/rad2deg.rs
@@ -1,0 +1,214 @@
+//! MATLAB-compatible `rad2deg` builtin for RunMat.
+
+use runmat_accelerate_api::GpuTensorHandle;
+use runmat_builtins::{ComplexTensor, Tensor, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::random_args::complex_tensor_into_value;
+use crate::builtins::common::spec::{
+    BuiltinFusionSpec, ConstantStrategy, FusionError, FusionExprContext, FusionKernelTemplate,
+    ScalarType, ShapeRequirements,
+};
+use crate::builtins::common::{gpu_helpers, tensor};
+use crate::builtins::math::type_resolvers::numeric_unary_type;
+use crate::{build_runtime_error, BuiltinResult, RuntimeError};
+
+const BUILTIN_NAME: &str = "rad2deg";
+const RAD_TO_DEG: f64 = 180.0 / std::f64::consts::PI;
+
+#[runmat_macros::register_fusion_spec(
+    builtin_path = "crate::builtins::math::trigonometry::rad2deg"
+)]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: "rad2deg",
+    shape: ShapeRequirements::BroadcastCompatible,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: Some(FusionKernelTemplate {
+        scalar_precisions: &[ScalarType::F32, ScalarType::F64],
+        wgsl_body: |ctx: &FusionExprContext| {
+            let input = ctx.inputs.first().ok_or(FusionError::MissingInput(0))?;
+            match ctx.scalar_ty {
+                ScalarType::F64 => Ok(format!("({input} * f64({RAD_TO_DEG}))")),
+                ScalarType::F32 => Ok(format!("({input} * {:.10})", 180.0 / std::f32::consts::PI)),
+                other => Err(FusionError::UnsupportedPrecision(other)),
+            }
+        },
+    }),
+    reduction: None,
+    emits_nan: false,
+    notes: "Fusion emits a multiplication by 180/pi for radian-to-degree conversion.",
+};
+
+fn builtin_error(message: impl Into<String>) -> RuntimeError {
+    build_runtime_error(message)
+        .with_builtin(BUILTIN_NAME)
+        .build()
+}
+
+#[runtime_builtin(
+    name = "rad2deg",
+    category = "math/trigonometry",
+    summary = "Convert angles from radians to degrees.",
+    keywords = "rad2deg,radians,degrees,angle,trigonometry,gpu",
+    accel = "unary",
+    type_resolver(numeric_unary_type),
+    builtin_path = "crate::builtins::math::trigonometry::rad2deg"
+)]
+async fn rad2deg_builtin(value: Value) -> BuiltinResult<Value> {
+    match value {
+        Value::GpuTensor(handle) => rad2deg_gpu(handle).await,
+        Value::Complex(re, im) => Ok(Value::Complex(re * RAD_TO_DEG, im * RAD_TO_DEG)),
+        Value::ComplexTensor(tensor) => rad2deg_complex_tensor(tensor),
+        Value::String(_) | Value::StringArray(_) => {
+            Err(builtin_error("rad2deg: expected numeric input"))
+        }
+        other => rad2deg_real(other),
+    }
+}
+
+async fn rad2deg_gpu(handle: GpuTensorHandle) -> BuiltinResult<Value> {
+    let tensor = gpu_helpers::gather_tensor_async(&handle).await?;
+    rad2deg_tensor(tensor).map(tensor::tensor_into_value)
+}
+
+fn rad2deg_real(value: Value) -> BuiltinResult<Value> {
+    let tensor = tensor::value_into_tensor_for(BUILTIN_NAME, value).map_err(builtin_error)?;
+    rad2deg_tensor(tensor).map(tensor::tensor_into_value)
+}
+
+fn rad2deg_tensor(tensor: Tensor) -> BuiltinResult<Tensor> {
+    let data = tensor
+        .data
+        .iter()
+        .map(|&value| value * RAD_TO_DEG)
+        .collect::<Vec<_>>();
+    Tensor::new(data, tensor.shape.clone()).map_err(|err| builtin_error(format!("rad2deg: {err}")))
+}
+
+fn rad2deg_complex_tensor(tensor: ComplexTensor) -> BuiltinResult<Value> {
+    let data = tensor
+        .data
+        .iter()
+        .map(|&(re, im)| (re * RAD_TO_DEG, im * RAD_TO_DEG))
+        .collect::<Vec<_>>();
+    let converted = ComplexTensor::new(data, tensor.shape.clone())
+        .map_err(|err| builtin_error(format!("rad2deg: {err}")))?;
+    Ok(complex_tensor_into_value(converted))
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::{IntValue, LogicalArray, ResolveContext, Type};
+
+    fn rad2deg_builtin(value: Value) -> BuiltinResult<Value> {
+        block_on(super::rad2deg_builtin(value))
+    }
+
+    fn error_message(err: RuntimeError) -> String {
+        err.message().to_string()
+    }
+
+    #[test]
+    fn rad2deg_type_preserves_tensor_shape() {
+        let out = numeric_unary_type(
+            &[Type::Tensor {
+                shape: Some(vec![Some(2), Some(3)]),
+            }],
+            &ResolveContext::new(Vec::new()),
+        );
+        assert_eq!(
+            out,
+            Type::Tensor {
+                shape: Some(vec![Some(2), Some(3)])
+            }
+        );
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn rad2deg_scalar() {
+        let result = rad2deg_builtin(Value::Num(std::f64::consts::PI)).expect("rad2deg");
+        match result {
+            Value::Num(value) => assert!((value - 180.0).abs() < 1e-12),
+            other => panic!("expected scalar result, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn rad2deg_tensor_preserves_shape() {
+        let tensor = Tensor::new(
+            vec![
+                0.0,
+                std::f64::consts::PI / 6.0,
+                std::f64::consts::PI / 4.0,
+                std::f64::consts::PI / 3.0,
+                std::f64::consts::FRAC_PI_2,
+            ],
+            vec![1, 5],
+        )
+        .unwrap();
+        let result = rad2deg_builtin(Value::Tensor(tensor)).expect("rad2deg");
+        match result {
+            Value::Tensor(tensor) => {
+                assert_eq!(tensor.shape, vec![1, 5]);
+                let expected = [0.0, 30.0, 45.0, 60.0, 90.0];
+                for (actual, expected) in tensor.data.iter().zip(expected) {
+                    assert!((actual - expected).abs() < 1e-12);
+                }
+            }
+            other => panic!("expected tensor result, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn rad2deg_int_promotes() {
+        let result = rad2deg_builtin(Value::Int(IntValue::I32(1))).expect("rad2deg");
+        match result {
+            Value::Num(value) => assert!((value - RAD_TO_DEG).abs() < 1e-12),
+            other => panic!("expected scalar result, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn rad2deg_logical_array_promotes() {
+        let logical = LogicalArray::new(vec![0, 1], vec![1, 2]).unwrap();
+        let result = rad2deg_builtin(Value::LogicalArray(logical)).expect("rad2deg");
+        match result {
+            Value::Tensor(tensor) => {
+                assert_eq!(tensor.shape, vec![1, 2]);
+                assert_eq!(tensor.data[0], 0.0);
+                assert!((tensor.data[1] - RAD_TO_DEG).abs() < 1e-12);
+            }
+            other => panic!("expected tensor result, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn rad2deg_complex_scales_both_parts() {
+        let result = rad2deg_builtin(Value::Complex(
+            std::f64::consts::PI,
+            std::f64::consts::FRAC_PI_2,
+        ))
+        .expect("rad2deg");
+        match result {
+            Value::Complex(re, im) => {
+                assert!((re - 180.0).abs() < 1e-12);
+                assert!((im - 90.0).abs() < 1e-12);
+            }
+            other => panic!("expected complex result, got {other:?}"),
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn rad2deg_string_errors() {
+        let err = rad2deg_builtin(Value::String("pi".into())).expect_err("expected error");
+        assert!(error_message(err).contains("rad2deg: expected numeric input"));
+    }
+}

--- a/crates/runmat-runtime/tests/builtins_variants.rs
+++ b/crates/runmat-runtime/tests/builtins_variants.rs
@@ -48,3 +48,20 @@ fn find_variants() {
     let _ = runmat_runtime::call_builtin("find", std::slice::from_ref(&v)).unwrap();
     let _ = runmat_runtime::call_builtin("find", &[v.clone(), Value::Num(1.0)]).unwrap();
 }
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn degree_radian_conversion_builtins_dispatch() {
+    let radians = runmat_runtime::call_builtin("deg2rad", &[Value::Num(90.0)]).unwrap();
+    match radians {
+        Value::Num(value) => assert!((value - std::f64::consts::FRAC_PI_2).abs() < 1e-12),
+        other => panic!("expected scalar result, got {other:?}"),
+    }
+
+    let degrees =
+        runmat_runtime::call_builtin("rad2deg", &[Value::Num(std::f64::consts::PI)]).unwrap();
+    match degrees {
+        Value::Num(value) => assert!((value - 180.0).abs() < 1e-12),
+        other => panic!("expected scalar result, got {other:?}"),
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds new, isolated elementwise math builtins plus docs/tests, with no changes to existing core execution paths beyond module registration and dispatch coverage.
> 
> **Overview**
> Adds MATLAB-compatible `deg2rad` and `rad2deg` builtins, including CPU implementations, GPU gather fallback, and fusion specs for elementwise WGSL codegen (f32/f64).
> 
> Registers both functions in the trigonometry module, adds builtin metadata JSON docs, and extends tests to cover numeric promotion, complex/scalar/tensor behavior, string input errors, and runtime dispatch via `call_builtin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b0b560cf0b2c19d1bf829bb4b71c55768e3f28f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `deg2rad`: Convert degrees to radians with support for scalars, arrays, and complex numbers.
  * `rad2deg`: Convert radians to degrees with GPU acceleration and automatic type promotion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/342)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->