### PR TITLE
Fix errorbar parsing for line specs before name-value pairs

### DIFF
--- a/crates/runmat-runtime/src/builtins/plotting/ops/errorbar.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/errorbar.rs
@@ -437,29 +437,29 @@ fn parse_errorbar_args(args: Vec<Value>) -> crate::BuiltinResult<ErrorBarArgs> {
                     rest,
                 ))
             } else {
-                let fifth = it.next();
-                let sixth = it.next();
-                match (fifth, sixth) {
-                    (Some(fifth), Some(sixth)) => Ok((
-                        target_axes,
-                        first,
-                        second,
-                        Some(fifth),
-                        Some(sixth),
-                        third,
-                        fourth,
-                        it.collect(),
+                let rest = it.collect::<Vec<_>>();
+                match rest.as_slice() {
+                    [] => Ok((target_axes, first, second, None, None, third, fourth, rest)),
+                    [fifth, ..] if is_styleish(fifth) => {
+                        Ok((target_axes, first, second, None, None, third, fourth, rest))
+                    }
+                    [fifth, sixth, tail @ ..] if is_numericish(fifth) && is_numericish(sixth) => {
+                        Ok((
+                            target_axes,
+                            first,
+                            second,
+                            Some(fifth.clone()),
+                            Some(sixth.clone()),
+                            third,
+                            fourth,
+                            tail.to_vec(),
+                        ))
+                    }
+                    [fifth, ..] if is_numericish(fifth) => Err(plotting_error(
+                        BUILTIN_NAME,
+                        "errorbar: expected positive X error data after negative X error data",
                     )),
-                    _ => Ok((
-                        target_axes,
-                        first,
-                        second,
-                        None,
-                        None,
-                        third,
-                        fourth,
-                        it.collect(),
-                    )),
+                    _ => Ok((target_axes, first, second, None, None, third, fourth, rest)),
                 }
             }
         }
@@ -468,6 +468,13 @@ fn parse_errorbar_args(args: Vec<Value>) -> crate::BuiltinResult<ErrorBarArgs> {
 
 fn is_styleish(value: &Value) -> bool {
     matches!(value, Value::String(_) | Value::CharArray(_))
+}
+
+fn is_numericish(value: &Value) -> bool {
+    matches!(
+        value,
+        Value::Tensor(_) | Value::GpuTensor(_) | Value::Num(_) | Value::Int(_) | Value::Bool(_)
+    )
 }
 
 #[cfg(test)]
@@ -552,6 +559,101 @@ mod tests {
         );
         assert_eq!(error.x_neg, vec![0.1, 0.2]);
         assert_eq!(error.y_pos, vec![0.2, 0.3]);
+    }
+
+    #[test]
+    fn errorbar_accepts_line_spec_before_name_value_pairs() {
+        let _guard = lock_plot_registry();
+        ensure_plot_test_env();
+        reset_hold_state_for_run();
+        let _ = clear_figure(None);
+        errorbar_builtin(vec![
+            Value::Tensor(vec_tensor(&[1.0, 2.0])),
+            Value::Tensor(vec_tensor(&[3.0, 4.0])),
+            Value::Tensor(vec_tensor(&[0.2, 0.3])),
+            Value::Tensor(vec_tensor(&[0.4, 0.5])),
+            Value::String("o-".into()),
+            Value::String("LineWidth".into()),
+            Value::Num(1.5),
+        ])
+        .unwrap();
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let PlotElement::ErrorBar(error) = fig.plots().next().unwrap() else {
+            panic!("expected errorbar");
+        };
+        assert_eq!(
+            error.orientation,
+            runmat_plot::plots::errorbar::ErrorBarOrientation::Vertical
+        );
+        assert_eq!(error.line_style, runmat_plot::plots::LineStyle::Solid);
+        assert_eq!(error.line_width, 1.5);
+        let marker = error.marker.as_ref().expect("expected marker");
+        assert_eq!(
+            marker.kind,
+            runmat_plot::plots::scatter::MarkerStyle::Circle
+        );
+    }
+
+    #[test]
+    fn errorbar_accepts_name_value_pairs_after_asymmetric_vertical_data() {
+        let _guard = lock_plot_registry();
+        ensure_plot_test_env();
+        reset_hold_state_for_run();
+        let _ = clear_figure(None);
+        errorbar_builtin(vec![
+            Value::Tensor(vec_tensor(&[1.0, 2.0])),
+            Value::Tensor(vec_tensor(&[3.0, 4.0])),
+            Value::Tensor(vec_tensor(&[0.2, 0.3])),
+            Value::Tensor(vec_tensor(&[0.4, 0.5])),
+            Value::String("LineWidth".into()),
+            Value::Num(1.5),
+        ])
+        .unwrap();
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let PlotElement::ErrorBar(error) = fig.plots().next().unwrap() else {
+            panic!("expected errorbar");
+        };
+        assert_eq!(
+            error.orientation,
+            runmat_plot::plots::errorbar::ErrorBarOrientation::Vertical
+        );
+        assert_eq!(error.line_width, 1.5);
+    }
+
+    #[test]
+    fn errorbar_preserves_both_direction_form_with_trailing_style() {
+        let _guard = lock_plot_registry();
+        ensure_plot_test_env();
+        reset_hold_state_for_run();
+        let _ = clear_figure(None);
+        errorbar_builtin(vec![
+            Value::Tensor(vec_tensor(&[1.0, 2.0])),
+            Value::Tensor(vec_tensor(&[3.0, 4.0])),
+            Value::Tensor(vec_tensor(&[0.2, 0.3])),
+            Value::Tensor(vec_tensor(&[0.4, 0.5])),
+            Value::Tensor(vec_tensor(&[0.1, 0.2])),
+            Value::Tensor(vec_tensor(&[0.2, 0.3])),
+            Value::String("o-".into()),
+            Value::String("LineWidth".into()),
+            Value::Num(1.5),
+        ])
+        .unwrap();
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let PlotElement::ErrorBar(error) = fig.plots().next().unwrap() else {
+            panic!("expected errorbar");
+        };
+        assert_eq!(
+            error.orientation,
+            runmat_plot::plots::errorbar::ErrorBarOrientation::Both
+        );
+        assert_eq!(error.x_neg, vec![0.1, 0.2]);
+        assert_eq!(error.x_pos, vec![0.2, 0.3]);
+        assert_eq!(error.line_width, 1.5);
+        let marker = error.marker.as_ref().expect("expected marker");
+        assert_eq!(
+            marker.kind,
+            runmat_plot::plots::scatter::MarkerStyle::Circle
+        );
     }
 
     #[test]

--- a/crates/runmat-runtime/src/builtins/plotting/ops/errorbar.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/errorbar.rs
@@ -410,14 +410,6 @@ fn parse_errorbar_args(args: Vec<Value>) -> crate::BuiltinResult<ErrorBarArgs> {
                 let mut rest = vec![third, fourth];
                 rest.extend(it);
                 Ok((target_axes, x, y, None, None, err.clone(), err, rest))
-            } else if is_y_only_asymmetric_style(&first, &second, &third, &fourth) {
-                let y = first;
-                let y_neg = second;
-                let y_pos = third;
-                let x = infer_errorbar_x_from_y(&y)?;
-                let mut rest = vec![fourth];
-                rest.extend(it);
-                Ok((target_axes, x, y, None, None, y_neg, y_pos, rest))
             } else if is_styleish(&fourth) {
                 let mut rest = vec![fourth];
                 rest.extend(it);
@@ -484,24 +476,6 @@ fn infer_errorbar_x_from_y(y: &Value) -> crate::BuiltinResult<Value> {
         cols: 1,
         dtype: runmat_builtins::NumericDType::F64,
     }))
-}
-
-fn is_y_only_asymmetric_style(
-    first: &Value,
-    second: &Value,
-    third: &Value,
-    fourth: &Value,
-) -> bool {
-    let Some(style) = super::style::value_as_string(fourth) else {
-        return false;
-    };
-    is_numericish(first)
-        && is_numericish(second)
-        && is_numericish(third)
-        && !super::style::looks_like_option_name(&style)
-        && Tensor::try_from(first).is_ok()
-        && Tensor::try_from(second).is_ok()
-        && Tensor::try_from(third).is_ok()
 }
 
 #[cfg(test)]
@@ -678,15 +652,15 @@ mod tests {
     }
 
     #[test]
-    fn errorbar_accepts_y_only_asymmetric_line_spec_before_name_value_pairs() {
+    fn errorbar_preserves_explicit_x_y_err_with_trailing_line_spec() {
         let _guard = lock_plot_registry();
         ensure_plot_test_env();
         reset_hold_state_for_run();
         let _ = clear_figure(None);
         errorbar_builtin(vec![
+            Value::Tensor(vec_tensor(&[1.0, 2.0])),
             Value::Tensor(vec_tensor(&[3.0, 4.0])),
             Value::Tensor(vec_tensor(&[0.2, 0.3])),
-            Value::Tensor(vec_tensor(&[0.4, 0.5])),
             Value::String("o-".into()),
             Value::String("LineWidth".into()),
             Value::Num(1.5),
@@ -703,7 +677,7 @@ mod tests {
         assert_eq!(error.x, vec![1.0, 2.0]);
         assert_eq!(error.y, vec![3.0, 4.0]);
         assert_eq!(error.y_neg, vec![0.2, 0.3]);
-        assert_eq!(error.y_pos, vec![0.4, 0.5]);
+        assert_eq!(error.y_pos, vec![0.2, 0.3]);
         assert_eq!(error.line_width, 1.5);
         let marker = error.marker.as_ref().expect("expected marker");
         assert_eq!(

--- a/crates/runmat-runtime/src/builtins/plotting/ops/errorbar.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/errorbar.rs
@@ -380,34 +380,14 @@ fn parse_errorbar_args(args: Vec<Value>) -> crate::BuiltinResult<ErrorBarArgs> {
         (None, _) => {
             let y = first;
             let err = second;
-            let len = Tensor::try_from(&y)
-                .map_err(|e| plotting_error(BUILTIN_NAME, format!("errorbar: {e}")))?
-                .data
-                .len();
-            let x = Value::Tensor(Tensor {
-                data: (1..=len).map(|i| i as f64).collect(),
-                shape: vec![len],
-                rows: len,
-                cols: 1,
-                dtype: runmat_builtins::NumericDType::F64,
-            });
+            let x = infer_errorbar_x_from_y(&y)?;
             Ok((target_axes, x, y, None, None, err.clone(), err, Vec::new()))
         }
         (Some(third), None) => {
             if is_styleish(&third) {
                 let y = first;
                 let err = second;
-                let len = Tensor::try_from(&y)
-                    .map_err(|e| plotting_error(BUILTIN_NAME, format!("errorbar: {e}")))?
-                    .data
-                    .len();
-                let x = Value::Tensor(Tensor {
-                    data: (1..=len).map(|i| i as f64).collect(),
-                    shape: vec![len],
-                    rows: len,
-                    cols: 1,
-                    dtype: runmat_builtins::NumericDType::F64,
-                });
+                let x = infer_errorbar_x_from_y(&y)?;
                 Ok((target_axes, x, y, None, None, err.clone(), err, vec![third]))
             } else {
                 Ok((
@@ -423,7 +403,22 @@ fn parse_errorbar_args(args: Vec<Value>) -> crate::BuiltinResult<ErrorBarArgs> {
             }
         }
         (Some(third), Some(fourth)) => {
-            if is_styleish(&fourth) {
+            if is_styleish(&third) {
+                let y = first;
+                let err = second;
+                let x = infer_errorbar_x_from_y(&y)?;
+                let mut rest = vec![third, fourth];
+                rest.extend(it);
+                Ok((target_axes, x, y, None, None, err.clone(), err, rest))
+            } else if is_y_only_asymmetric_style(&first, &second, &third, &fourth) {
+                let y = first;
+                let y_neg = second;
+                let y_pos = third;
+                let x = infer_errorbar_x_from_y(&y)?;
+                let mut rest = vec![fourth];
+                rest.extend(it);
+                Ok((target_axes, x, y, None, None, y_neg, y_pos, rest))
+            } else if is_styleish(&fourth) {
                 let mut rest = vec![fourth];
                 rest.extend(it);
                 Ok((
@@ -475,6 +470,38 @@ fn is_numericish(value: &Value) -> bool {
         value,
         Value::Tensor(_) | Value::GpuTensor(_) | Value::Num(_) | Value::Int(_) | Value::Bool(_)
     )
+}
+
+fn infer_errorbar_x_from_y(y: &Value) -> crate::BuiltinResult<Value> {
+    let len = Tensor::try_from(y)
+        .map_err(|e| plotting_error(BUILTIN_NAME, format!("errorbar: {e}")))?
+        .data
+        .len();
+    Ok(Value::Tensor(Tensor {
+        data: (1..=len).map(|i| i as f64).collect(),
+        shape: vec![len],
+        rows: len,
+        cols: 1,
+        dtype: runmat_builtins::NumericDType::F64,
+    }))
+}
+
+fn is_y_only_asymmetric_style(
+    first: &Value,
+    second: &Value,
+    third: &Value,
+    fourth: &Value,
+) -> bool {
+    let Some(style) = super::style::value_as_string(fourth) else {
+        return false;
+    };
+    is_numericish(first)
+        && is_numericish(second)
+        && is_numericish(third)
+        && !super::style::looks_like_option_name(&style)
+        && Tensor::try_from(first).is_ok()
+        && Tensor::try_from(second).is_ok()
+        && Tensor::try_from(third).is_ok()
 }
 
 #[cfg(test)]
@@ -618,6 +645,71 @@ mod tests {
             runmat_plot::plots::errorbar::ErrorBarOrientation::Vertical
         );
         assert_eq!(error.line_width, 1.5);
+    }
+
+    #[test]
+    fn errorbar_accepts_y_only_line_spec_before_name_value_pairs() {
+        let _guard = lock_plot_registry();
+        ensure_plot_test_env();
+        reset_hold_state_for_run();
+        let _ = clear_figure(None);
+        errorbar_builtin(vec![
+            Value::Tensor(vec_tensor(&[3.0, 4.0])),
+            Value::Tensor(vec_tensor(&[0.2, 0.3])),
+            Value::String("o-".into()),
+            Value::String("LineWidth".into()),
+            Value::Num(1.5),
+        ])
+        .unwrap();
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let PlotElement::ErrorBar(error) = fig.plots().next().unwrap() else {
+            panic!("expected errorbar");
+        };
+        assert_eq!(error.x, vec![1.0, 2.0]);
+        assert_eq!(error.y, vec![3.0, 4.0]);
+        assert_eq!(error.y_neg, vec![0.2, 0.3]);
+        assert_eq!(error.y_pos, vec![0.2, 0.3]);
+        assert_eq!(error.line_width, 1.5);
+        let marker = error.marker.as_ref().expect("expected marker");
+        assert_eq!(
+            marker.kind,
+            runmat_plot::plots::scatter::MarkerStyle::Circle
+        );
+    }
+
+    #[test]
+    fn errorbar_accepts_y_only_asymmetric_line_spec_before_name_value_pairs() {
+        let _guard = lock_plot_registry();
+        ensure_plot_test_env();
+        reset_hold_state_for_run();
+        let _ = clear_figure(None);
+        errorbar_builtin(vec![
+            Value::Tensor(vec_tensor(&[3.0, 4.0])),
+            Value::Tensor(vec_tensor(&[0.2, 0.3])),
+            Value::Tensor(vec_tensor(&[0.4, 0.5])),
+            Value::String("o-".into()),
+            Value::String("LineWidth".into()),
+            Value::Num(1.5),
+        ])
+        .unwrap();
+        let fig = clone_figure(current_figure_handle()).unwrap();
+        let PlotElement::ErrorBar(error) = fig.plots().next().unwrap() else {
+            panic!("expected errorbar");
+        };
+        assert_eq!(
+            error.orientation,
+            runmat_plot::plots::errorbar::ErrorBarOrientation::Vertical
+        );
+        assert_eq!(error.x, vec![1.0, 2.0]);
+        assert_eq!(error.y, vec![3.0, 4.0]);
+        assert_eq!(error.y_neg, vec![0.2, 0.3]);
+        assert_eq!(error.y_pos, vec![0.4, 0.5]);
+        assert_eq!(error.line_width, 1.5);
+        let marker = error.marker.as_ref().expect("expected marker");
+        assert_eq!(
+            marker.kind,
+            runmat_plot::plots::scatter::MarkerStyle::Circle
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes `errorbar` argument parsing/dispatch, which can affect multiple call signatures and error handling, but scope is limited to plotting input parsing and is covered by new tests.
> 
> **Overview**
> Fixes `errorbar` argument parsing to correctly handle MATLAB-style call forms where a line spec (e.g. `"o-"`) appears before trailing name/value pairs, including y-only invocations with inferred `x`.
> 
> Refactors parsing by extracting `infer_errorbar_x_from_y`, adding `is_numericish`, and tightening detection of asymmetric X-error arguments (including a clearer error when only one X-error side is provided). Adds several new tests covering line-spec + name/value ordering and both-direction/asymmetric cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7ffadf79a7901ea9db4380d5a0d1e2fb98e4311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error bar plots now support asymmetric horizontal and vertical error components.
  * Line and style specifications can be applied in conjunction with error bar data.
  * Enhanced argument parsing provides more flexible error bar configuration options.

* **Tests**
  * Expanded test coverage for error bar styling and formatting combinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->