### PR TITLE
Implement MATLAB suptitle plotting builtin

### DIFF
--- a/crates/runmat-runtime/src/builtins/builtins-json/suptitle.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/suptitle.json
@@ -1,0 +1,84 @@
+{
+  "title": "suptitle",
+  "category": "plotting",
+  "keywords": [
+    "suptitle",
+    "sgtitle",
+    "super title",
+    "subplot title",
+    "figure title",
+    "matlab suptitle"
+  ],
+  "summary": "Set a title centered above the entire figure, especially for older MATLAB subplot code.",
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::plotting::suptitle::tests"
+  },
+  "description": "`suptitle` sets or updates the same figure-level title as `sgtitle`. It exists for compatibility with MATLAB code in the wild that uses the older helper name for subplot layouts. In RunMat, it targets the current figure by default or an explicit figure handle when one is passed, returns a text handle, and participates in `get` and `set` through the shared plotting property system.",
+  "behaviors": [
+    "`suptitle(txt)` updates the current figure and returns the super-title text handle.",
+    "`suptitle(fig, txt, ...)` targets an explicit figure handle when the handle exists.",
+    "String scalars, char arrays, string arrays, and cell arrays can all be used to create multiline super titles.",
+    "Text styling properties such as `FontSize`, `FontWeight`, `FontAngle`, `Color`, `Interpreter`, and `Visible` use the shared plotting text-property system.",
+    "`suptitle` and `sgtitle` update the same figure-level title object."
+  ],
+  "examples": [
+    {
+      "description": "Add a super title above a subplot figure",
+      "input": "subplot(2, 1, 1);\nplot(1:10, rand(1, 10));\nsubplot(2, 1, 2);\nplot(1:10, rand(1, 10));\nsuptitle('Experiment Summary');"
+    },
+    {
+      "description": "Style the figure-level title and inspect the returned handle",
+      "input": "subplot(1, 2, 1);\nimagesc(peaks(20));\nsubplot(1, 2, 2);\nimagesc(peaks(20));\nh = suptitle('Field Comparison', 'FontSize', 18, 'FontWeight', 'bold');\nget(h, 'Type')",
+      "output": "ans =\n    'text'"
+    },
+    {
+      "description": "Target an explicit figure handle",
+      "input": "fig = figure(42);\nsubplot(1, 2, 1);\nplot(0:0.1:1, sin(0:0.1:1));\nsubplot(1, 2, 2);\nplot(0:0.1:1, cos(0:0.1:1));\nsuptitle(fig, 'Sine and Cosine');"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How is suptitle different from sgtitle?",
+      "answer": "In RunMat, `suptitle` and `sgtitle` update the same figure-level super title. `suptitle` is provided as a compatibility spelling for MATLAB code that uses the older helper name."
+    },
+    {
+      "question": "How is suptitle different from title?",
+      "answer": "`title` attaches text to the current axes, so each subplot can have its own panel title. `suptitle` attaches text to the figure as a whole and is drawn once above all panels."
+    },
+    {
+      "question": "Can I update the super title after creating it?",
+      "answer": "Yes. `suptitle` returns a text handle, so you can inspect or update it with `get` and `set`.\n\n```matlab\nh = suptitle('Initial Title');\nset(h, 'String', 'Updated Title', 'FontWeight', 'bold');\n```"
+    }
+  ],
+  "links": [
+    {
+      "label": "sgtitle",
+      "url": "./sgtitle"
+    },
+    {
+      "label": "subplot",
+      "url": "./subplot"
+    },
+    {
+      "label": "title",
+      "url": "./title"
+    },
+    {
+      "label": "get",
+      "url": "./get"
+    },
+    {
+      "label": "set",
+      "url": "./set"
+    },
+    {
+      "label": "Complete plotting guide",
+      "url": "/blog/matlab-plotting-guide"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/plotting/ops/suptitle.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/plotting/ops/suptitle.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/plotting/mod.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/mod.rs
@@ -108,6 +108,8 @@ pub(crate) mod stairs;
 pub(crate) mod stem;
 #[path = "ops/subplot.rs"]
 pub(crate) mod subplot;
+#[path = "ops/suptitle.rs"]
+pub(crate) mod suptitle;
 #[path = "ops/surf.rs"]
 pub(crate) mod surf;
 #[path = "ops/surfc.rs"]

--- a/crates/runmat-runtime/src/builtins/plotting/ops/sgtitle.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/sgtitle.rs
@@ -20,20 +20,27 @@ use crate::builtins::plotting::{
     builtin_path = "crate::builtins::plotting::sgtitle"
 )]
 pub fn sgtitle_builtin(args: Vec<Value>) -> crate::BuiltinResult<f64> {
-    let (target, rest) = split_figure_target("sgtitle", &args)?;
+    sgtitle_impl("sgtitle", args)
+}
+
+pub(super) fn sgtitle_impl(builtin: &'static str, args: Vec<Value>) -> crate::BuiltinResult<f64> {
+    let (target, rest) = split_figure_target(builtin, &args)?;
     if rest.is_empty() {
-        return Err(plotting_error("sgtitle", "sgtitle: expected text input"));
+        return Err(plotting_error(
+            builtin,
+            format!("{builtin}: expected text input"),
+        ));
     }
     let text = super::op_common::value_as_text_string(&rest[0])
         .or_else(|| format_num_as_title_text(&rest[0]))
         .ok_or_else(|| {
             plotting_error(
-                "sgtitle",
-                "sgtitle: expected text as char array, string, string array, or cell array of strings",
+                builtin,
+                format!("{builtin}: expected text as char array, string, string array, or cell array of strings"),
             )
         })?;
-    let style = parse_text_style_pairs("sgtitle", &rest[1..])?;
-    set_sg_title_for_figure(target, &text, style).map_err(|err| map_figure_error("sgtitle", err))
+    let style = parse_text_style_pairs(builtin, &rest[1..])?;
+    set_sg_title_for_figure(target, &text, style).map_err(|err| map_figure_error(builtin, err))
 }
 
 fn split_figure_target<'a>(

--- a/crates/runmat-runtime/src/builtins/plotting/ops/suptitle.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/suptitle.rs
@@ -1,0 +1,131 @@
+use runmat_builtins::Value;
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::plotting::type_resolvers::handle_scalar_type;
+
+#[runtime_builtin(
+    name = "suptitle",
+    category = "plotting",
+    summary = "Set a title centered above the entire figure.",
+    keywords = "suptitle,sgtitle,subplot,title,plotting",
+    suppress_auto_output = true,
+    type_resolver(handle_scalar_type),
+    builtin_path = "crate::builtins::plotting::suptitle"
+)]
+pub fn suptitle_builtin(args: Vec<Value>) -> crate::BuiltinResult<f64> {
+    super::sgtitle::sgtitle_impl("suptitle", args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtins::plotting::get::get_builtin;
+    use crate::builtins::plotting::set::set_builtin;
+    use crate::builtins::plotting::state::{decode_plot_object_handle, PlotObjectKind};
+    use crate::builtins::plotting::tests::{ensure_plot_test_env, lock_plot_registry};
+    use crate::builtins::plotting::{
+        clear_figure, clone_figure, current_figure_handle, figure::figure_builtin,
+        reset_hold_state_for_run,
+    };
+
+    fn setup() -> crate::builtins::plotting::state::PlotTestLockGuard {
+        let guard = lock_plot_registry();
+        ensure_plot_test_env();
+        reset_hold_state_for_run();
+        let _ = clear_figure(None);
+        guard
+    }
+
+    #[test]
+    fn suptitle_returns_handle_and_updates_current_figure() {
+        let _guard = setup();
+        let handle = suptitle_builtin(vec![Value::String("Overview".into())]).unwrap();
+        let (figure, axes, kind) = decode_plot_object_handle(handle).unwrap();
+        assert_eq!(figure, current_figure_handle());
+        assert_eq!(axes, 0);
+        assert_eq!(kind, PlotObjectKind::SuperTitle);
+
+        let fig = clone_figure(figure).unwrap();
+        assert_eq!(fig.sg_title.as_deref(), Some("Overview"));
+    }
+
+    #[test]
+    fn suptitle_accepts_explicit_figure_target() {
+        let _guard = setup();
+        let fig = figure_builtin(vec![Value::Num(421.0)]).unwrap();
+        suptitle_builtin(vec![Value::Num(fig), Value::String("Target Figure".into())]).unwrap();
+
+        let figure = clone_figure(crate::builtins::plotting::FigureHandle::from(421)).unwrap();
+        assert_eq!(figure.sg_title.as_deref(), Some("Target Figure"));
+    }
+
+    #[test]
+    fn suptitle_applies_text_style_pairs() {
+        let _guard = setup();
+        let fig = figure_builtin(vec![Value::Num(422.0)]).unwrap();
+        suptitle_builtin(vec![
+            Value::Num(fig),
+            Value::String("Styled".into()),
+            Value::String("FontSize".into()),
+            Value::Num(20.0),
+            Value::String("FontWeight".into()),
+            Value::String("bold".into()),
+            Value::String("Color".into()),
+            Value::String("red".into()),
+            Value::String("Interpreter".into()),
+            Value::String("none".into()),
+            Value::String("Visible".into()),
+            Value::Bool(false),
+        ])
+        .unwrap();
+
+        let figure = clone_figure(crate::builtins::plotting::FigureHandle::from(422)).unwrap();
+        assert_eq!(figure.sg_title.as_deref(), Some("Styled"));
+        assert_eq!(figure.sg_title_style.font_size, Some(20.0));
+        assert_eq!(figure.sg_title_style.font_weight.as_deref(), Some("bold"));
+        assert!(figure.sg_title_style.color.is_some());
+        assert_eq!(figure.sg_title_style.interpreter.as_deref(), Some("none"));
+        assert!(!figure.sg_title_style.visible);
+    }
+
+    #[test]
+    fn suptitle_handle_supports_get_and_set() {
+        let _guard = setup();
+        let handle = suptitle_builtin(vec![Value::String("Initial".into())]).unwrap();
+
+        let ty = get_builtin(vec![Value::Num(handle), Value::String("Type".into())]).unwrap();
+        assert_eq!(ty, Value::String("text".into()));
+
+        set_builtin(vec![
+            Value::Num(handle),
+            Value::String("String".into()),
+            Value::String("Updated".into()),
+            Value::String("FontWeight".into()),
+            Value::String("bold".into()),
+        ])
+        .unwrap();
+
+        let string = get_builtin(vec![Value::Num(handle), Value::String("String".into())]).unwrap();
+        assert_eq!(string, Value::String("Updated".into()));
+        let weight =
+            get_builtin(vec![Value::Num(handle), Value::String("FontWeight".into())]).unwrap();
+        assert_eq!(weight, Value::String("bold".into()));
+    }
+
+    #[test]
+    fn suptitle_reports_errors_with_suptitle_context() {
+        let _guard = setup();
+        let err = suptitle_builtin(vec![]).unwrap_err();
+        assert!(err.message.contains("suptitle"));
+        assert!(!err.message.contains("sgtitle"));
+
+        let err = suptitle_builtin(vec![
+            Value::String("Top".into()),
+            Value::String("Bogus".into()),
+            Value::Num(1.0),
+        ])
+        .unwrap_err();
+        assert!(err.message.contains("suptitle"));
+        assert!(!err.message.contains("sgtitle"));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new plotting builtin that reuses existing `sgtitle` logic plus minor refactoring of error messages; low risk aside from potential compatibility expectations in plotting handle/argument parsing.
> 
> **Overview**
> Adds a new `suptitle` plotting builtin as a MATLAB-compatibility alias for `sgtitle`, including unit tests that cover handle return values, explicit figure targeting, style property pairs, and `get`/`set` integration.
> 
> Refactors `sgtitle` to expose `sgtitle_impl(builtin, args)` so both builtins share the same implementation while reporting errors under the calling builtin name, and registers `suptitle` in `plotting/mod.rs` plus a new `suptitle.json` builtin metadata entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e380ad2720dd1d041bef1649c9e7cf9049ca0b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `suptitle` plotting function to set centered super-titles above figures, with support for optional text styling (font size, weight, color, interpreter, visibility) and explicit figure targeting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->