### PR TITLE
Implemented sinc builtin

### DIFF
--- a/crates/runmat-accelerate-api/src/lib.rs
+++ b/crates/runmat-accelerate-api/src/lib.rs
@@ -1510,6 +1510,12 @@ pub trait AccelProvider: Send + Sync {
     ) -> AccelProviderFuture<'a, GpuTensorHandle> {
         unsupported_future("unary_sin not supported by provider")
     }
+    fn unary_sinc<'a>(
+        &'a self,
+        _a: &'a GpuTensorHandle,
+    ) -> AccelProviderFuture<'a, GpuTensorHandle> {
+        unsupported_future("unary_sinc not supported by provider")
+    }
     fn unary_gamma<'a>(
         &'a self,
         _a: &'a GpuTensorHandle,

--- a/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/provider_impl.rs
@@ -14373,6 +14373,15 @@ impl AccelProvider for WgpuProvider {
         )
     }
 
+    fn unary_sinc<'a>(
+        &'a self,
+        a: &'a GpuTensorHandle,
+    ) -> AccelProviderFuture<'a, GpuTensorHandle> {
+        Box::pin(
+            async move { self.unary_op_exec(crate::backend::wgpu::types::UnaryOpCode::Sinc, a) },
+        )
+    }
+
     fn unary_gamma<'a>(
         &'a self,
         a: &'a GpuTensorHandle,

--- a/crates/runmat-accelerate/src/backend/wgpu/shaders/elementwise.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/shaders/elementwise.rs
@@ -428,6 +428,18 @@ fn factorial_real(a: f64) -> f64 {
     return acc;
 }
 
+fn sinc_real(a: f64) -> f64 {
+    if (a == 0.0) {
+        return 1.0;
+    }
+    let abs_a = abs(a);
+    if (!is_nan64(a) && !is_inf64(a) && floor(abs_a) == abs_a) {
+        return 0.0;
+    }
+    let scaled = PI * a;
+    return sin(scaled) / scaled;
+}
+
 fn apply(a: f64) -> f64 {
     switch params.op {
         case 0u: { return sin(a); }
@@ -486,6 +498,7 @@ fn apply(a: f64) -> f64 {
             }
             return ceil(log2(aa));
         }
+        case 33u: { return sinc_real(a); }
         default: { return a; }
     }
 }
@@ -665,6 +678,18 @@ fn factorial_real(a: f32) -> f32 {
     return acc;
 }
 
+fn sinc_real(a: f32) -> f32 {
+    if (a == 0.0) {
+        return 1.0;
+    }
+    let abs_a = abs(a);
+    if (!is_nan32(a) && !is_inf32(a) && floor(abs_a) == abs_a) {
+        return 0.0;
+    }
+    let scaled = PI * a;
+    return sin(scaled) / scaled;
+}
+
 fn apply(a: f32) -> f32 {
     switch params.op {
         case 0u: { return sin(a); }
@@ -723,6 +748,7 @@ fn apply(a: f32) -> f32 {
             }
             return ceil(log2(aa));
         }
+        case 33u: { return sinc_real(a); }
         default: { return a; }
     }
 }

--- a/crates/runmat-accelerate/src/backend/wgpu/types.rs
+++ b/crates/runmat-accelerate/src/backend/wgpu/types.rs
@@ -61,6 +61,7 @@ pub enum UnaryOpCode {
     Factorial = 30,
     Single = 31,
     NextPow2 = 32,
+    Sinc = 33,
 }
 
 #[derive(Clone, Copy)]

--- a/crates/runmat-accelerate/src/simple_provider.rs
+++ b/crates/runmat-accelerate/src/simple_provider.rs
@@ -95,6 +95,17 @@ fn generate_window_data(kind: WindowKind, len: usize, periodic: bool) -> Vec<f64
 }
 const FACTORIAL_INT_TOL: f64 = 1.0e-10;
 
+fn sinc_scalar_host(value: f64) -> f64 {
+    if value == 0.0 {
+        return 1.0;
+    }
+    if value.is_finite() && value.fract() == 0.0 {
+        return 0.0;
+    }
+    let scaled = std::f64::consts::PI * value;
+    scaled.sin() / scaled
+}
+
 fn runtime_flow_to_anyhow(_context: &str, err: RuntimeError) -> anyhow::Error {
     anyhow::Error::new(err)
 }
@@ -2862,6 +2873,27 @@ impl AccelProvider for InProcessProvider {
                 .get(&a.buffer_id)
                 .ok_or_else(|| anyhow::anyhow!("buffer not found: {}", a.buffer_id))?;
             let out: Vec<f64> = abuf.iter().map(|&x| x.sin()).collect();
+            drop(guard);
+            let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+            let mut guard2 = registry().lock().unwrap();
+            guard2.insert(id, out);
+            Ok(GpuTensorHandle {
+                shape: a.shape.clone(),
+                device_id: 0,
+                buffer_id: id,
+            })
+        })
+    }
+    fn unary_sinc<'a>(
+        &'a self,
+        a: &'a GpuTensorHandle,
+    ) -> AccelProviderFuture<'a, GpuTensorHandle> {
+        Box::pin(async move {
+            let guard = registry().lock().unwrap();
+            let abuf = guard
+                .get(&a.buffer_id)
+                .ok_or_else(|| anyhow::anyhow!("buffer not found: {}", a.buffer_id))?;
+            let out: Vec<f64> = abuf.iter().copied().map(sinc_scalar_host).collect();
             drop(guard);
             let id = self.next_id.fetch_add(1, Ordering::Relaxed);
             let mut guard2 = registry().lock().unwrap();

--- a/crates/runmat-accelerate/tests/native_auto.rs
+++ b/crates/runmat-accelerate/tests/native_auto.rs
@@ -10,6 +10,7 @@ fn ensure_auto_init() {
     INIT.call_once(|| {
         std::env::set_var("RUNMAT_ACCEL_AUTO_OFFLOAD", "1");
         std::env::set_var("RUNMAT_ACCEL_CALIBRATE", "0");
+        std::env::set_var("RUNMAT_ACCEL_THRESHOLD_UNARY", "1");
         std::env::set_var("RUNMAT_ACCEL_THRESHOLD_ELEMWISE", "1");
         std::env::set_var("RUNMAT_ACCEL_THRESHOLD_REDUCTION", "1");
         register_inprocess_provider();
@@ -43,4 +44,14 @@ async fn gather_occurs_for_sink_builtins() {
         .expect("promote");
     let prepared = prepare_builtin_args("disp", &[gpu]).await.expect("prepare");
     assert!(matches!(prepared.as_slice(), [Value::Tensor(_)]));
+}
+
+#[tokio::test]
+async fn prepare_builtin_promotes_sinc_as_unary() {
+    ensure_auto_init();
+    let tensor = make_tensor(4);
+    let prepared = prepare_builtin_args("sinc", &[Value::Tensor(tensor)])
+        .await
+        .expect("prepare");
+    assert!(matches!(prepared.as_slice(), [Value::GpuTensor(_)]));
 }

--- a/crates/runmat-runtime/src/builtins/builtins-json/sinc.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/sinc.json
@@ -1,0 +1,131 @@
+{
+  "title": "sinc",
+  "category": "math/signal",
+  "keywords": [
+    "sinc",
+    "normalized sinc",
+    "signal processing",
+    "elementwise",
+    "complex"
+  ],
+  "summary": "Normalized sinc, sin(pi*x)/(pi*x), evaluated element-wise.",
+  "references": [
+    "title: \"MATLAB sinc documentation\""
+  ],
+  "gpu_support": {
+    "elementwise": true,
+    "reduction": false,
+    "precisions": [
+      "f32",
+      "f64"
+    ],
+    "broadcasting": "matlab",
+    "notes": "Providers may execute sinc on-device through unary_sinc. The runtime gathers to the host only when a provider lacks that hook or cannot service the input."
+  },
+  "fusion": {
+    "elementwise": true,
+    "reduction": false,
+    "max_inputs": 1,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::math::signal::sinc::tests",
+    "integration": "builtins::math::signal::sinc::tests::sinc_gpu_input_stays_resident_when_provider_supports_sinc"
+  },
+  "description": "`y = sinc(x)` evaluates the normalized sinc function element-wise using MATLAB's definition `sin(pi*x)/(pi*x)`, with `sinc(0)` defined as `1`.",
+  "behaviors": [
+    "Accepts real or complex scalars, vectors, matrices, and N-D tensors.",
+    "Preserves the input shape for vector, matrix, and N-D tensor inputs.",
+    "Returns `1` for exactly zero real inputs.",
+    "Returns exact `0` for finite nonzero integer-valued real inputs, matching MATLAB's `sinpi`-style integer accuracy where practical.",
+    "Logical and integer inputs are promoted to double precision before evaluation.",
+    "Complex inputs use the analytic extension `sin(pi*z)/(pi*z)` and return `1 + 0i` for `z == 0`.",
+    "GPU inputs stay resident when the active provider supports `unary_sinc`; otherwise RunMat gathers automatically and evaluates with the host implementation."
+  ],
+  "examples": [
+    {
+      "description": "Evaluate sinc at zero",
+      "input": "y = sinc(0)",
+      "output": "y = 1"
+    },
+    {
+      "description": "Evaluate sinc at integer inputs",
+      "input": "x = 1:5;\ny = sinc(x)",
+      "output": "y = [0 0 0 0 0]"
+    },
+    {
+      "description": "Evaluate normalized sinc values",
+      "input": "x = [-1 0 1 0.5];\ny = sinc(x)",
+      "output": "y = [0 1 0 0.6366]"
+    },
+    {
+      "description": "Preserve matrix shape",
+      "input": "A = [0 0.5; 1.5 2];\nY = sinc(A)",
+      "output": "Y =\n    1.0000    0.6366\n   -0.2122         0"
+    },
+    {
+      "description": "Evaluate sinc for a complex value",
+      "input": "z = sinc(0.5 + 0.25i)"
+    },
+    {
+      "description": "Use gpuArray input",
+      "input": "g = gpuArray([0 0.5 1]);\ny = sinc(g);\nresult = gather(y)",
+      "output": "result = [1 0.6366 0]"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Which sinc definition does RunMat use?",
+      "answer": "RunMat uses MATLAB's normalized definition, `sin(pi*x)/(pi*x)`, with the removable singularity at zero defined as `1`."
+    },
+    {
+      "question": "Why does `sinc(1:5)` return exact zeros?",
+      "answer": "The implementation detects finite nonzero integer-valued real inputs before evaluating the trigonometric expression. This avoids floating-point residuals from `sin(pi*x)` and matches MATLAB's practical `sinpi` behaviour."
+    },
+    {
+      "question": "Does `sinc` support complex values?",
+      "answer": "Yes. Complex scalars and complex tensors use the analytic extension `sin(pi*z)/(pi*z)` and preserve tensor shape."
+    },
+    {
+      "question": "Will `sinc(gpuArray(...))` stay on the GPU?",
+      "answer": "Yes when the active provider implements `unary_sinc`. Providers without that hook fall back to host evaluation so zero and integer cases still use the exact MATLAB-compatible path."
+    }
+  ],
+  "links": [
+    {
+      "label": "sin",
+      "url": "./sin"
+    },
+    {
+      "label": "fft",
+      "url": "./fft"
+    },
+    {
+      "label": "filter",
+      "url": "./filter"
+    },
+    {
+      "label": "conv",
+      "url": "./conv"
+    },
+    {
+      "label": "gpuArray",
+      "url": "./gpuarray"
+    },
+    {
+      "label": "gather",
+      "url": "./gather"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/math/signal/sinc.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/math/signal/sinc.rs"
+  },
+  "gpu_residency": "`sinc` keeps real GPU tensors resident when the active provider exposes `unary_sinc`. The runtime preserves a host fallback for providers that do not support the hook.",
+  "gpu_behavior": [
+    "Provider-backed execution uses the same normalized sinc semantics, including `sinc(0) == 1` and exact zeros for finite nonzero integer-valued real inputs.",
+    "If the provider declines the operation, RunMat gathers through the active provider and evaluates with the host implementation.",
+    "Fusion emits a guarded normalized sinc expression with explicit zero and integer branches for real elementwise graphs."
+  ]
+}

--- a/crates/runmat-runtime/src/builtins/math/signal/mod.rs
+++ b/crates/runmat-runtime/src/builtins/math/signal/mod.rs
@@ -8,4 +8,5 @@ pub mod deconv;
 pub mod filter;
 pub(crate) mod hamming;
 pub(crate) mod hann;
+pub(crate) mod sinc;
 pub(crate) mod type_resolvers;

--- a/crates/runmat-runtime/src/builtins/math/signal/sinc.rs
+++ b/crates/runmat-runtime/src/builtins/math/signal/sinc.rs
@@ -42,7 +42,7 @@ pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
     two_pass_threshold: None,
     workgroup_size: None,
     accepts_nan_mode: false,
-    notes: "Providers may execute normalized sinc on-device via unary_sinc; otherwise the runtime gathers and applies the MATLAB-compatible host implementation.",
+    notes: "Providers may execute real normalized sinc on-device via unary_sinc; complex-interleaved handles and unsupported hooks gather and apply the MATLAB-compatible host implementation.",
 };
 
 #[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::math::signal::sinc")]
@@ -114,6 +114,9 @@ async fn sinc_builtin(value: Value) -> BuiltinResult<Value> {
 
 async fn sinc_gpu(handle: GpuTensorHandle) -> BuiltinResult<Value> {
     if let Some(provider) = runmat_accelerate_api::provider_for_handle(&handle) {
+        if runmat_accelerate_api::handle_storage(&handle) == GpuTensorStorage::ComplexInterleaved {
+            return sinc_gpu_host_fallback(provider, &handle).await;
+        }
         match provider.unary_sinc(&handle).await {
             Ok(out) => return Ok(gpu_helpers::resident_gpu_value(out)),
             Err(err) if provider_error_is_unsupported(&err) => {
@@ -137,7 +140,6 @@ async fn sinc_gpu_host_fallback(
                 .with_identifier("RunMat:gather:DownloadFailed")
                 .build()
         })?;
-    runmat_accelerate_api::clear_residency(handle);
 
     let runmat_accelerate_api::HostTensorOwned {
         mut data,
@@ -153,10 +155,11 @@ async fn sinc_gpu_host_fallback(
     }
 
     if storage == GpuTensorStorage::ComplexInterleaved {
-        let complex = data
-            .chunks_exact(2)
-            .map(|chunk| (chunk[0], chunk[1]))
-            .collect::<Vec<_>>();
+        let chunks = data.chunks_exact(2);
+        if !chunks.remainder().is_empty() {
+            return Err(builtin_error("sinc: malformed complex buffer, odd length"));
+        }
+        let complex = chunks.map(|chunk| (chunk[0], chunk[1])).collect::<Vec<_>>();
         let tensor =
             ComplexTensor::new(complex, shape).map_err(|e| builtin_error(format!("sinc: {e}")))?;
         return sinc_complex_tensor(tensor);
@@ -258,7 +261,7 @@ mod tests {
             Ok(GpuTensorHandle {
                 shape: host.shape.to_vec(),
                 device_id: self.device_id(),
-                buffer_id: 1,
+                buffer_id: 2,
             })
         }
 
@@ -317,6 +320,54 @@ mod tests {
             _: &'a GpuTensorHandle,
         ) -> AccelProviderFuture<'a, GpuTensorHandle> {
             Box::pin(async move { Err(anyhow::anyhow!("device lost while running unary_sinc")) })
+        }
+    }
+
+    struct ComplexSincProvider;
+
+    impl AccelProvider for ComplexSincProvider {
+        fn upload(&self, host: &HostTensorView) -> anyhow::Result<GpuTensorHandle> {
+            Ok(GpuTensorHandle {
+                shape: host.shape.to_vec(),
+                device_id: self.device_id(),
+                buffer_id: 3,
+            })
+        }
+
+        fn download<'a>(&'a self, handle: &'a GpuTensorHandle) -> AccelDownloadFuture<'a> {
+            Box::pin(async move {
+                if handle.buffer_id == 4 {
+                    return Ok(HostTensorOwned {
+                        data: vec![0.0, 0.0, 0.5],
+                        shape: vec![2, 1],
+                        storage: GpuTensorStorage::ComplexInterleaved,
+                    });
+                }
+                Ok(HostTensorOwned {
+                    data: vec![0.0, 0.0, 0.5, 0.25],
+                    shape: vec![2, 1],
+                    storage: GpuTensorStorage::ComplexInterleaved,
+                })
+            })
+        }
+
+        fn free(&self, _: &GpuTensorHandle) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn device_info(&self) -> String {
+            "complex-sinc-test-provider".to_string()
+        }
+
+        fn device_id(&self) -> u32 {
+            90_003
+        }
+
+        fn unary_sinc<'a>(
+            &'a self,
+            _: &'a GpuTensorHandle,
+        ) -> AccelProviderFuture<'a, GpuTensorHandle> {
+            Box::pin(async move { Err(anyhow::anyhow!("unary_sinc should not be called")) })
         }
     }
 
@@ -494,7 +545,7 @@ mod tests {
         let handle = GpuTensorHandle {
             shape: vec![1, 3],
             device_id: provider.device_id(),
-            buffer_id: 1,
+            buffer_id: 2,
         };
         let result = call(Value::GpuTensor(handle)).expect("sinc gpu fallback");
         match result {
@@ -526,6 +577,47 @@ mod tests {
         assert!(err
             .message()
             .contains("device lost while running unary_sinc"));
+    }
+
+    #[test]
+    fn sinc_gpu_complex_interleaved_bypasses_real_unary_provider_hook() {
+        let _guard = test_support::accel_test_lock();
+        let provider: &'static dyn AccelProvider = Box::leak(Box::new(ComplexSincProvider));
+        let _thread_provider = runmat_accelerate_api::ThreadProviderGuard::set(Some(provider));
+        let handle = GpuTensorHandle {
+            shape: vec![2, 1],
+            device_id: provider.device_id(),
+            buffer_id: 3,
+        };
+        runmat_accelerate_api::set_handle_storage(&handle, GpuTensorStorage::ComplexInterleaved);
+
+        let result = call(Value::GpuTensor(handle)).expect("complex sinc gpu fallback");
+        match result {
+            Value::ComplexTensor(out) => {
+                assert_eq!(out.shape, vec![2, 1]);
+                assert_complex_close(out.data[0], (1.0, 0.0));
+                assert_complex_close(out.data[1], sinc_complex_value(0.5, 0.25));
+            }
+            other => panic!("expected complex tensor fallback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sinc_gpu_complex_interleaved_rejects_odd_buffer_length() {
+        let _guard = test_support::accel_test_lock();
+        let provider: &'static dyn AccelProvider = Box::leak(Box::new(ComplexSincProvider));
+        let _thread_provider = runmat_accelerate_api::ThreadProviderGuard::set(Some(provider));
+        let handle = GpuTensorHandle {
+            shape: vec![2, 1],
+            device_id: provider.device_id(),
+            buffer_id: 4,
+        };
+        runmat_accelerate_api::set_handle_storage(&handle, GpuTensorStorage::ComplexInterleaved);
+
+        let err = call(Value::GpuTensor(handle)).expect_err("odd complex buffer should error");
+        assert!(err
+            .message()
+            .contains("sinc: malformed complex buffer, odd length"));
     }
 
     #[test]

--- a/crates/runmat-runtime/src/builtins/math/signal/sinc.rs
+++ b/crates/runmat-runtime/src/builtins/math/signal/sinc.rs
@@ -1,7 +1,7 @@
 //! MATLAB-compatible normalized `sinc` builtin for RunMat.
 
-use runmat_accelerate_api::GpuTensorHandle;
-use runmat_builtins::{ComplexTensor, Tensor, Value};
+use runmat_accelerate_api::{AccelProvider, GpuTensorHandle, GpuTensorStorage};
+use runmat_builtins::{ComplexTensor, NumericDType, Tensor, Value};
 use runmat_macros::runtime_builtin;
 
 use crate::builtins::common::random_args::complex_tensor_into_value;
@@ -15,6 +15,19 @@ use crate::builtins::math::type_resolvers::numeric_unary_type;
 use crate::{build_runtime_error, BuiltinResult, RuntimeError};
 
 const BUILTIN_NAME: &str = "sinc";
+
+#[derive(Debug)]
+struct ProviderAnyhowError {
+    message: String,
+}
+
+impl std::fmt::Display for ProviderAnyhowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ProviderAnyhowError {}
 
 #[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::math::signal::sinc")]
 pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
@@ -43,7 +56,7 @@ pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
             let input = ctx.inputs.first().ok_or(FusionError::MissingInput(0))?;
             let scaled = format!("(3.141592653589793 * {input})");
             Ok(format!(
-                "select(select(sin({scaled}) / {scaled}, 0.0, abs({input}) < 9.007199254740992e15 && floor(abs({input})) == abs({input})), 1.0, {input} == 0.0)"
+                "select(select(sin({scaled}) / {scaled}, 0.0, isFinite({input}) && floor(abs({input})) == abs({input})), 1.0, {input} == 0.0)"
             ))
         },
     }),
@@ -59,12 +72,28 @@ fn builtin_error(message: impl Into<String>) -> RuntimeError {
         .build()
 }
 
+fn provider_error_is_unsupported(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.to_string() == "unary_sinc not supported by provider")
+}
+
+fn provider_error(err: anyhow::Error) -> RuntimeError {
+    let message = err.to_string();
+    let source = ProviderAnyhowError {
+        message: format!("{err:?}"),
+    };
+    build_runtime_error(format!("sinc: GPU provider unary_sinc failed: {message}"))
+        .with_builtin(BUILTIN_NAME)
+        .with_source(source)
+        .build()
+}
+
 #[runtime_builtin(
     name = "sinc",
     category = "math/signal",
     summary = "Normalized sinc, sin(pi*x)/(pi*x), evaluated element-wise.",
     keywords = "sinc,normalized sinc,signal processing,elementwise",
-    accel = "cpu",
+    accel = "unary",
     type_resolver(numeric_unary_type),
     builtin_path = "crate::builtins::math::signal::sinc"
 )]
@@ -85,11 +114,60 @@ async fn sinc_builtin(value: Value) -> BuiltinResult<Value> {
 
 async fn sinc_gpu(handle: GpuTensorHandle) -> BuiltinResult<Value> {
     if let Some(provider) = runmat_accelerate_api::provider_for_handle(&handle) {
-        if let Ok(out) = provider.unary_sinc(&handle).await {
-            return Ok(gpu_helpers::resident_gpu_value(out));
+        match provider.unary_sinc(&handle).await {
+            Ok(out) => return Ok(gpu_helpers::resident_gpu_value(out)),
+            Err(err) if provider_error_is_unsupported(&err) => {
+                return sinc_gpu_host_fallback(provider, &handle).await;
+            }
+            Err(err) => return Err(provider_error(err)),
         }
     }
     let tensor = gpu_helpers::gather_tensor_async(&handle).await?;
+    Ok(tensor::tensor_into_value(sinc_tensor(tensor)?))
+}
+
+async fn sinc_gpu_host_fallback(
+    provider: &dyn AccelProvider,
+    handle: &GpuTensorHandle,
+) -> BuiltinResult<Value> {
+    let host = crate::dispatcher::download_handle_async(provider, handle)
+        .await
+        .map_err(|err| {
+            build_runtime_error(format!("gather: {err}"))
+                .with_identifier("RunMat:gather:DownloadFailed")
+                .build()
+        })?;
+    runmat_accelerate_api::clear_residency(handle);
+
+    let runmat_accelerate_api::HostTensorOwned {
+        mut data,
+        shape,
+        storage,
+    } = host;
+    let precision =
+        runmat_accelerate_api::handle_precision(handle).unwrap_or_else(|| provider.precision());
+    if matches!(precision, runmat_accelerate_api::ProviderPrecision::F32) {
+        for value in &mut data {
+            *value = (*value as f32) as f64;
+        }
+    }
+
+    if storage == GpuTensorStorage::ComplexInterleaved {
+        let complex = data
+            .chunks_exact(2)
+            .map(|chunk| (chunk[0], chunk[1]))
+            .collect::<Vec<_>>();
+        let tensor =
+            ComplexTensor::new(complex, shape).map_err(|e| builtin_error(format!("sinc: {e}")))?;
+        return sinc_complex_tensor(tensor);
+    }
+
+    let dtype = match precision {
+        runmat_accelerate_api::ProviderPrecision::F32 => NumericDType::F32,
+        runmat_accelerate_api::ProviderPrecision::F64 => NumericDType::F64,
+    };
+    let tensor = Tensor::new_with_dtype(data, shape, dtype)
+        .map_err(|e| builtin_error(format!("sinc: {e}")))?;
     Ok(tensor::tensor_into_value(sinc_tensor(tensor)?))
 }
 
@@ -152,7 +230,13 @@ mod tests {
     use super::*;
     use crate::builtins::common::test_support;
     use futures::executor::block_on;
-    use runmat_builtins::{CharArray, IntValue, ResolveContext, Type};
+    use runmat_accelerate_api::{
+        AccelDownloadFuture, AccelProvider, AccelProviderFuture, GpuTensorStorage, HostTensorOwned,
+        HostTensorView,
+    };
+    use runmat_builtins::{
+        builtin_function_by_name, AccelTag, CharArray, IntValue, ResolveContext, Type,
+    };
 
     fn call(value: Value) -> BuiltinResult<Value> {
         block_on(sinc_builtin(value))
@@ -165,6 +249,75 @@ mod tests {
     fn assert_complex_close(got: (f64, f64), want: (f64, f64)) {
         assert_close(got.0, want.0);
         assert_close(got.1, want.1);
+    }
+
+    struct UnsupportedSincProvider;
+
+    impl AccelProvider for UnsupportedSincProvider {
+        fn upload(&self, host: &HostTensorView) -> anyhow::Result<GpuTensorHandle> {
+            Ok(GpuTensorHandle {
+                shape: host.shape.to_vec(),
+                device_id: self.device_id(),
+                buffer_id: 1,
+            })
+        }
+
+        fn download<'a>(&'a self, _: &'a GpuTensorHandle) -> AccelDownloadFuture<'a> {
+            Box::pin(async move {
+                Ok(HostTensorOwned {
+                    data: vec![0.0, 0.5, 1.0],
+                    shape: vec![1, 3],
+                    storage: GpuTensorStorage::Real,
+                })
+            })
+        }
+
+        fn free(&self, _: &GpuTensorHandle) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn device_info(&self) -> String {
+            "unsupported-sinc-test-provider".to_string()
+        }
+
+        fn device_id(&self) -> u32 {
+            90_001
+        }
+    }
+
+    struct FailingSincProvider;
+
+    impl AccelProvider for FailingSincProvider {
+        fn upload(&self, host: &HostTensorView) -> anyhow::Result<GpuTensorHandle> {
+            Ok(GpuTensorHandle {
+                shape: host.shape.to_vec(),
+                device_id: self.device_id(),
+                buffer_id: 1,
+            })
+        }
+
+        fn download<'a>(&'a self, _: &'a GpuTensorHandle) -> AccelDownloadFuture<'a> {
+            Box::pin(async move { Err(anyhow::anyhow!("download should not be called")) })
+        }
+
+        fn free(&self, _: &GpuTensorHandle) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn device_info(&self) -> String {
+            "failing-sinc-test-provider".to_string()
+        }
+
+        fn device_id(&self) -> u32 {
+            90_002
+        }
+
+        fn unary_sinc<'a>(
+            &'a self,
+            _: &'a GpuTensorHandle,
+        ) -> AccelProviderFuture<'a, GpuTensorHandle> {
+            Box::pin(async move { Err(anyhow::anyhow!("device lost while running unary_sinc")) })
+        }
     }
 
     #[test]
@@ -195,6 +348,18 @@ mod tests {
     }
 
     #[test]
+    fn sinc_registers_unary_acceleration_tag() {
+        let builtin = builtin_function_by_name(BUILTIN_NAME).expect("registered sinc builtin");
+        assert!(
+            builtin
+                .accel_tags
+                .iter()
+                .any(|tag| matches!(tag, AccelTag::Unary)),
+            "sinc must be tagged unary so native auto-promotion uploads host numeric inputs for unary_sinc"
+        );
+    }
+
+    #[test]
     fn sinc_zero_returns_one() {
         let result = call(Value::Num(0.0)).expect("sinc");
         match result {
@@ -205,12 +370,16 @@ mod tests {
 
     #[test]
     fn sinc_nonzero_integer_inputs_are_exact_zero() {
-        let tensor = Tensor::new(vec![1.0, 2.0, 3.0, 4.0, 5.0], vec![1, 5]).unwrap();
+        let tensor = Tensor::new(
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 9_007_199_254_740_992.0],
+            vec![1, 6],
+        )
+        .unwrap();
         let result = call(Value::Tensor(tensor)).expect("sinc");
         match result {
             Value::Tensor(out) => {
-                assert_eq!(out.shape, vec![1, 5]);
-                assert_eq!(out.data, vec![0.0; 5]);
+                assert_eq!(out.shape, vec![1, 6]);
+                assert_eq!(out.data, vec![0.0; 6]);
             }
             other => panic!("expected tensor, got {other:?}"),
         }
@@ -220,6 +389,23 @@ mod tests {
             Value::Num(value) => assert_eq!(value, 0.0),
             other => panic!("expected scalar, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn sinc_fusion_integer_guard_matches_host() {
+        let template = FUSION_SPEC.elementwise.expect("fusion template");
+        let inputs = ["x"];
+        let ctx = FusionExprContext {
+            scalar_ty: ScalarType::F64,
+            inputs: &inputs,
+            constants: &[],
+        };
+        let expr = (template.wgsl_body)(&ctx).expect("fusion expression");
+        assert!(expr.contains("isFinite(x) && floor(abs(x)) == abs(x)"));
+        assert!(
+            !expr.contains("9.007199254740992e15"),
+            "fusion must not cap exact-integer handling below host/unary GPU behavior"
+        );
     }
 
     #[test]
@@ -298,6 +484,48 @@ mod tests {
     fn sinc_rejects_text_inputs() {
         let err = call(Value::CharArray(CharArray::new_row("abc"))).expect_err("sinc text");
         assert!(err.message().contains("sinc: expected numeric input"));
+    }
+
+    #[test]
+    fn sinc_gpu_falls_back_only_for_explicit_unsupported_hook() {
+        let _guard = test_support::accel_test_lock();
+        let provider: &'static dyn AccelProvider = Box::leak(Box::new(UnsupportedSincProvider));
+        let _thread_provider = runmat_accelerate_api::ThreadProviderGuard::set(Some(provider));
+        let handle = GpuTensorHandle {
+            shape: vec![1, 3],
+            device_id: provider.device_id(),
+            buffer_id: 1,
+        };
+        let result = call(Value::GpuTensor(handle)).expect("sinc gpu fallback");
+        match result {
+            Value::Tensor(out) => {
+                assert_eq!(out.shape, vec![1, 3]);
+                let expected = [1.0, 2.0 / std::f64::consts::PI, 0.0];
+                for (got, want) in out.data.iter().zip(expected) {
+                    assert_close(*got, want);
+                }
+            }
+            other => panic!("expected host tensor fallback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sinc_gpu_propagates_provider_execution_errors() {
+        let _guard = test_support::accel_test_lock();
+        let provider: &'static dyn AccelProvider = Box::leak(Box::new(FailingSincProvider));
+        let _thread_provider = runmat_accelerate_api::ThreadProviderGuard::set(Some(provider));
+        let handle = GpuTensorHandle {
+            shape: vec![1, 3],
+            device_id: provider.device_id(),
+            buffer_id: 1,
+        };
+        let err = call(Value::GpuTensor(handle)).expect_err("provider error should surface");
+        assert!(err
+            .message()
+            .contains("sinc: GPU provider unary_sinc failed"));
+        assert!(err
+            .message()
+            .contains("device lost while running unary_sinc"));
     }
 
     #[test]

--- a/crates/runmat-runtime/src/builtins/math/signal/sinc.rs
+++ b/crates/runmat-runtime/src/builtins/math/signal/sinc.rs
@@ -1,0 +1,361 @@
+//! MATLAB-compatible normalized `sinc` builtin for RunMat.
+
+use runmat_accelerate_api::GpuTensorHandle;
+use runmat_builtins::{ComplexTensor, Tensor, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::random_args::complex_tensor_into_value;
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, FusionError,
+    FusionExprContext, FusionKernelTemplate, GpuOpKind, ProviderHook, ReductionNaN,
+    ResidencyPolicy, ScalarType, ShapeRequirements,
+};
+use crate::builtins::common::{gpu_helpers, tensor};
+use crate::builtins::math::type_resolvers::numeric_unary_type;
+use crate::{build_runtime_error, BuiltinResult, RuntimeError};
+
+const BUILTIN_NAME: &str = "sinc";
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::math::signal::sinc")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: BUILTIN_NAME,
+    op_kind: GpuOpKind::Elementwise,
+    supported_precisions: &[ScalarType::F32, ScalarType::F64],
+    broadcast: BroadcastSemantics::Matlab,
+    provider_hooks: &[ProviderHook::Unary { name: "unary_sinc" }],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::NewHandle,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "Providers may execute normalized sinc on-device via unary_sinc; otherwise the runtime gathers and applies the MATLAB-compatible host implementation.",
+};
+
+#[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::math::signal::sinc")]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: BUILTIN_NAME,
+    shape: ShapeRequirements::BroadcastCompatible,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: Some(FusionKernelTemplate {
+        scalar_precisions: &[ScalarType::F32, ScalarType::F64],
+        wgsl_body: |ctx: &FusionExprContext| {
+            let input = ctx.inputs.first().ok_or(FusionError::MissingInput(0))?;
+            let scaled = format!("(3.141592653589793 * {input})");
+            Ok(format!(
+                "select(select(sin({scaled}) / {scaled}, 0.0, abs({input}) < 9.007199254740992e15 && floor(abs({input})) == abs({input})), 1.0, {input} == 0.0)"
+            ))
+        },
+    }),
+    reduction: None,
+    emits_nan: true,
+    notes:
+        "Fusion emits a guarded normalized sinc expression with explicit zero and integer branches.",
+};
+
+fn builtin_error(message: impl Into<String>) -> RuntimeError {
+    build_runtime_error(message)
+        .with_builtin(BUILTIN_NAME)
+        .build()
+}
+
+#[runtime_builtin(
+    name = "sinc",
+    category = "math/signal",
+    summary = "Normalized sinc, sin(pi*x)/(pi*x), evaluated element-wise.",
+    keywords = "sinc,normalized sinc,signal processing,elementwise",
+    accel = "cpu",
+    type_resolver(numeric_unary_type),
+    builtin_path = "crate::builtins::math::signal::sinc"
+)]
+async fn sinc_builtin(value: Value) -> BuiltinResult<Value> {
+    match value {
+        Value::GpuTensor(handle) => sinc_gpu(handle).await,
+        Value::Complex(re, im) => {
+            let (out_re, out_im) = sinc_complex_value(re, im);
+            Ok(Value::Complex(out_re, out_im))
+        }
+        Value::ComplexTensor(tensor) => sinc_complex_tensor(tensor),
+        Value::CharArray(_) | Value::String(_) | Value::StringArray(_) => {
+            Err(builtin_error("sinc: expected numeric input"))
+        }
+        other => sinc_real(other),
+    }
+}
+
+async fn sinc_gpu(handle: GpuTensorHandle) -> BuiltinResult<Value> {
+    if let Some(provider) = runmat_accelerate_api::provider_for_handle(&handle) {
+        if let Ok(out) = provider.unary_sinc(&handle).await {
+            return Ok(gpu_helpers::resident_gpu_value(out));
+        }
+    }
+    let tensor = gpu_helpers::gather_tensor_async(&handle).await?;
+    Ok(tensor::tensor_into_value(sinc_tensor(tensor)?))
+}
+
+fn sinc_real(value: Value) -> BuiltinResult<Value> {
+    let tensor = tensor::value_into_tensor_for(BUILTIN_NAME, value)
+        .map_err(|e| builtin_error(format!("sinc: {e}")))?;
+    Ok(tensor::tensor_into_value(sinc_tensor(tensor)?))
+}
+
+fn sinc_tensor(tensor: Tensor) -> BuiltinResult<Tensor> {
+    let data = tensor
+        .data
+        .iter()
+        .map(|&value| sinc_real_value(value))
+        .collect::<Vec<_>>();
+    Tensor::new(data, tensor.shape.clone()).map_err(|e| builtin_error(format!("sinc: {e}")))
+}
+
+fn sinc_complex_tensor(tensor: ComplexTensor) -> BuiltinResult<Value> {
+    let data = tensor
+        .data
+        .iter()
+        .map(|&(re, im)| sinc_complex_value(re, im))
+        .collect::<Vec<_>>();
+    let tensor = ComplexTensor::new(data, tensor.shape.clone())
+        .map_err(|e| builtin_error(format!("sinc: {e}")))?;
+    Ok(complex_tensor_into_value(tensor))
+}
+
+#[inline]
+fn sinc_real_value(value: f64) -> f64 {
+    if value == 0.0 {
+        return 1.0;
+    }
+    if value.is_finite() && value.fract() == 0.0 {
+        return 0.0;
+    }
+    let scaled = std::f64::consts::PI * value;
+    scaled.sin() / scaled
+}
+
+fn sinc_complex_value(re: f64, im: f64) -> (f64, f64) {
+    if im == 0.0 {
+        return (sinc_real_value(re), 0.0);
+    }
+
+    let scaled_re = std::f64::consts::PI * re;
+    let scaled_im = std::f64::consts::PI * im;
+    let num_re = scaled_re.sin() * scaled_im.cosh();
+    let num_im = scaled_re.cos() * scaled_im.sinh();
+    let denom_norm = scaled_re.mul_add(scaled_re, scaled_im * scaled_im);
+    (
+        (num_re * scaled_re + num_im * scaled_im) / denom_norm,
+        (num_im * scaled_re - num_re * scaled_im) / denom_norm,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtins::common::test_support;
+    use futures::executor::block_on;
+    use runmat_builtins::{CharArray, IntValue, ResolveContext, Type};
+
+    fn call(value: Value) -> BuiltinResult<Value> {
+        block_on(sinc_builtin(value))
+    }
+
+    fn assert_close(got: f64, want: f64) {
+        assert!((got - want).abs() < 1e-12, "got {got}, expected {want}");
+    }
+
+    fn assert_complex_close(got: (f64, f64), want: (f64, f64)) {
+        assert_close(got.0, want.0);
+        assert_close(got.1, want.1);
+    }
+
+    #[test]
+    fn sinc_type_preserves_tensor_shape() {
+        let out = numeric_unary_type(
+            &[Type::Tensor {
+                shape: Some(vec![Some(2), Some(3)]),
+            }],
+            &ResolveContext::new(Vec::new()),
+        );
+        assert_eq!(
+            out,
+            Type::Tensor {
+                shape: Some(vec![Some(2), Some(3)])
+            }
+        );
+    }
+
+    #[test]
+    fn sinc_type_scalar_tensor_returns_num() {
+        let out = numeric_unary_type(
+            &[Type::Tensor {
+                shape: Some(vec![Some(1), Some(1)]),
+            }],
+            &ResolveContext::new(Vec::new()),
+        );
+        assert_eq!(out, Type::Num);
+    }
+
+    #[test]
+    fn sinc_zero_returns_one() {
+        let result = call(Value::Num(0.0)).expect("sinc");
+        match result {
+            Value::Num(value) => assert_eq!(value, 1.0),
+            other => panic!("expected scalar, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sinc_nonzero_integer_inputs_are_exact_zero() {
+        let tensor = Tensor::new(vec![1.0, 2.0, 3.0, 4.0, 5.0], vec![1, 5]).unwrap();
+        let result = call(Value::Tensor(tensor)).expect("sinc");
+        match result {
+            Value::Tensor(out) => {
+                assert_eq!(out.shape, vec![1, 5]);
+                assert_eq!(out.data, vec![0.0; 5]);
+            }
+            other => panic!("expected tensor, got {other:?}"),
+        }
+
+        let result = call(Value::Int(IntValue::I32(-3))).expect("sinc int");
+        match result {
+            Value::Num(value) => assert_eq!(value, 0.0),
+            other => panic!("expected scalar, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sinc_matches_normalized_values() {
+        let tensor = Tensor::new(vec![-1.0, 0.0, 1.0, 0.5], vec![1, 4]).unwrap();
+        let result = call(Value::Tensor(tensor)).expect("sinc");
+        match result {
+            Value::Tensor(out) => {
+                assert_eq!(out.shape, vec![1, 4]);
+                let expected = [0.0, 1.0, 0.0, 2.0 / std::f64::consts::PI];
+                for (got, want) in out.data.iter().zip(expected) {
+                    assert_close(*got, want);
+                }
+            }
+            other => panic!("expected tensor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sinc_preserves_matrix_shape() {
+        let tensor = Tensor::new(vec![0.0, 0.5, 1.5, 2.0], vec![2, 2]).unwrap();
+        let result = call(Value::Tensor(tensor)).expect("sinc");
+        match result {
+            Value::Tensor(out) => assert_eq!(out.shape, vec![2, 2]),
+            other => panic!("expected tensor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sinc_logical_inputs_are_numeric() {
+        let zero = call(Value::Bool(false)).expect("sinc false");
+        let one = call(Value::Bool(true)).expect("sinc true");
+        match (zero, one) {
+            (Value::Num(zero), Value::Num(one)) => {
+                assert_eq!(zero, 1.0);
+                assert_eq!(one, 0.0);
+            }
+            other => panic!("expected scalar results, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sinc_complex_scalar_matches_formula() {
+        let result = call(Value::Complex(0.5, 0.25)).expect("sinc complex");
+        let expected = sinc_complex_value(0.5, 0.25);
+        match result {
+            Value::Complex(re, im) => assert_complex_close((re, im), expected),
+            other => panic!("expected complex scalar, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sinc_complex_real_integer_is_exact_zero() {
+        let result = call(Value::Complex(2.0, 0.0)).expect("sinc complex integer");
+        match result {
+            Value::Complex(re, im) => assert_eq!((re, im), (0.0, 0.0)),
+            other => panic!("expected complex scalar, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sinc_complex_tensor_preserves_shape() {
+        let tensor = ComplexTensor::new(vec![(0.0, 0.0), (0.5, 0.25)], vec![2, 1]).unwrap();
+        let result = call(Value::ComplexTensor(tensor)).expect("sinc complex tensor");
+        match result {
+            Value::ComplexTensor(out) => {
+                assert_eq!(out.shape, vec![2, 1]);
+                assert_complex_close(out.data[0], (1.0, 0.0));
+                assert_complex_close(out.data[1], sinc_complex_value(0.5, 0.25));
+            }
+            other => panic!("expected complex tensor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sinc_rejects_text_inputs() {
+        let err = call(Value::CharArray(CharArray::new_row("abc"))).expect_err("sinc text");
+        assert!(err.message().contains("sinc: expected numeric input"));
+    }
+
+    #[test]
+    fn sinc_gpu_input_stays_resident_when_provider_supports_sinc() {
+        test_support::with_test_provider(|provider| {
+            let tensor = Tensor::new(vec![0.0, 0.5, 1.0], vec![1, 3]).unwrap();
+            let view = runmat_accelerate_api::HostTensorView {
+                data: &tensor.data,
+                shape: &tensor.shape,
+            };
+            let handle = provider.upload(&view).expect("upload");
+            let result = call(Value::GpuTensor(handle)).expect("sinc gpu");
+            assert!(
+                matches!(result, Value::GpuTensor(_)),
+                "provider-backed sinc should keep gpuArray output resident"
+            );
+            let gathered = test_support::gather(result).expect("gather");
+            assert_eq!(gathered.shape, vec![1, 3]);
+            let expected = [1.0, 2.0 / std::f64::consts::PI, 0.0];
+            for (got, want) in gathered.data.iter().zip(expected) {
+                assert_close(*got, want);
+            }
+        });
+    }
+
+    #[test]
+    #[cfg(feature = "wgpu")]
+    fn sinc_wgpu_matches_cpu_elementwise() {
+        if runmat_accelerate::backend::wgpu::provider::register_wgpu_provider(
+            runmat_accelerate::backend::wgpu::provider::WgpuProviderOptions::default(),
+        )
+        .is_err()
+        {
+            return;
+        }
+        if runmat_accelerate_api::provider().is_none() {
+            return;
+        }
+        let tensor = Tensor::new(vec![0.0, 0.5, 1.0, 1.25, 2.0], vec![1, 5]).unwrap();
+        let cpu = sinc_real(Value::Tensor(tensor.clone())).expect("cpu sinc");
+        let view = runmat_accelerate_api::HostTensorView {
+            data: &tensor.data,
+            shape: &tensor.shape,
+        };
+        let handle = runmat_accelerate_api::provider()
+            .expect("wgpu provider")
+            .upload(&view)
+            .expect("upload");
+        let gpu = block_on(sinc_gpu(handle)).expect("gpu sinc");
+        let gathered = test_support::gather(gpu).expect("gather");
+        let expected = test_support::gather(cpu).expect("gather cpu");
+        assert_eq!(gathered.shape, expected.shape);
+        let tol = match runmat_accelerate_api::provider().unwrap().precision() {
+            runmat_accelerate_api::ProviderPrecision::F64 => 1e-12,
+            runmat_accelerate_api::ProviderPrecision::F32 => 1e-5,
+        };
+        for (got, want) in gathered.data.iter().zip(expected.data.iter()) {
+            assert!((got - want).abs() < tol, "|{got} - {want}| >= {tol}");
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new builtin plus a new `AccelProvider` hook/`UnaryOpCode` and WGPU shader path, which can affect GPU execution and requires providers to handle the new API method. Main risk is numerical edge cases and runtime fallback/residency behavior across real vs complex GPU storage.
> 
> **Overview**
> Implements a new MATLAB-compatible normalized `sinc` builtin (`sin(pi*x)/(pi*x)`) with support for real, logical, and complex inputs (including complex tensors) and shape preservation.
> 
> Adds GPU acceleration via a new `AccelProvider::unary_sinc` hook, including WGPU backend support (`UnaryOpCode::Sinc` + shader implementation with zero/integer guards) and an in-process/simple-provider implementation; unsupported providers transparently fall back to a host implementation while preserving correct semantics.
> 
> Introduces builtin metadata (`builtins-json/sinc.json`) and new tests covering host behavior, fusion expression generation, GPU residency/fallback, and auto-promotion for the new unary builtin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b1fb0d5585d2d723e2bca4cc3d57d9c524185b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MATLAB-compatible normalized sinc (sin(πx)/(πx)) as a builtin for real, complex, and logical tensors with shape preservation.
  * GPU execution path added for accelerated elementwise sinc with transparent fallback to host when unavailable.

* **Documentation**
  * Included builtin metadata, examples, semantics, and edge-case notes.

* **Tests**
  * Added comprehensive tests for numeric/complex correctness, GPU vs CPU comparisons, fusion, and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->