### PR TITLE
Add fminbnd builtin and share Brent helper with fzero 

### DIFF
--- a/crates/runmat-runtime/src/builtins/builtins-json/fminbnd.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/fminbnd.json
@@ -1,0 +1,82 @@
+{
+  "title": "fminbnd",
+  "category": "math/optim",
+  "keywords": [
+    "fminbnd",
+    "bounded minimization",
+    "brent",
+    "golden section",
+    "parabolic interpolation",
+    "optimization"
+  ],
+  "summary": "Find a local minimum of a scalar function on a bounded interval using Brent's method.",
+  "references": ["https://www.mathworks.com/help/matlab/ref/fminbnd.html"],
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [],
+    "broadcasting": "none",
+    "notes": "The solver runs on the host. Callback functions may still call GPU-aware builtins."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 4,
+    "constants": "inline"
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::math::optim::fminbnd::tests",
+    "integration": "runmat-vm/tests/closures.rs::fminbnd_accepts_anonymous_function"
+  },
+  "description": "`x = fminbnd(fun, x1, x2)` searches the closed interval `[x1, x2]` for a local minimum of the scalar function `fun` using Brent's method (golden-section search combined with parabolic interpolation). Additional output arities expose the function value at the minimum, an exit flag, and a diagnostic struct.",
+  "behaviors": [
+    "The function handle must return a finite real scalar for every sampled point in the interval.",
+    "If `x1 > x2`, the bounds are inconsistent and `exitflag = -2`.",
+    "If `x1 == x2`, that point is returned with `exitflag = 1`.",
+    "Options are supplied as a struct, usually built with `optimset`. `TolX`, `MaxIter`, `MaxFunEvals`, and `Display` are accepted.",
+    "`Display` may be `'off'`, `'iter'`, `'notify'` (default; only prints when the solver fails to converge), or `'final'`.",
+    "`exitflag` is `1` on convergence within `TolX`, `0` when the iteration or evaluation budget is exhausted.",
+    "The fourth output is a struct with `iterations`, `funcCount`, `algorithm`, and `message` fields."
+  ],
+  "examples": [
+    {
+      "description": "Minimize a quadratic",
+      "input": "x = fminbnd(@(x) (x-2).^2, 0, 5)",
+      "output": "x =\n    2.0000"
+    },
+    {
+      "description": "Capture the function value too",
+      "input": "[x, fval] = fminbnd(@(x) (x-3).^2 + 1, 0, 5)",
+      "output": "x =\n    3.0000\nfval =\n    1.0000"
+    },
+    {
+      "description": "Tighten tolerances",
+      "input": "opts = optimset('TolX', 1e-10, 'Display', 'off');\n[x, fval, exitflag] = fminbnd(@cos, 0, pi, opts)",
+      "output": "x =\n    3.1416\nfval =\n   -1.0000\nexitflag =\n     1"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Does fminbnd support unbounded minimization?",
+      "answer": "No. `fminbnd` requires finite scalar bounds. Use `fminunc` or `fminsearch` for unconstrained problems."
+    },
+    {
+      "question": "Can I retrieve the iteration history?",
+      "answer": "Yes — request the four-output form `[x, fval, exitflag, output] = fminbnd(...)` to receive a struct with `iterations`, `funcCount`, `algorithm`, and `message`."
+    },
+    {
+      "question": "Does fminbnd guarantee a global minimum?",
+      "answer": "No. Brent's method converges to a local minimum on `[x1, x2]`. For multi-modal functions, narrow the interval to bracket the desired minimum."
+    }
+  ],
+  "links": [
+    { "label": "fzero", "url": "./fzero" },
+    { "label": "fsolve", "url": "./fsolve" },
+    { "label": "optimset", "url": "./optimset" }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/math/optim/fminbnd.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/math/optim/fminbnd.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/builtins-json/optimset.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/optimset.json
@@ -2,7 +2,7 @@
   "title": "optimset",
   "category": "math/optim",
   "keywords": ["optimset", "options", "TolX", "TolFun", "MaxIter", "Display"],
-  "summary": "Create or update an optimization options structure for fzero and fsolve.",
+  "summary": "Create or update an optimization options structure for fminbnd, fzero, and fsolve.",
   "references": ["https://www.mathworks.com/help/matlab/ref/optimset.html"],
   "gpu_support": {
     "elementwise": false,
@@ -21,7 +21,7 @@
   "tested": {
     "unit": "builtins::math::optim::optimset::tests"
   },
-  "description": "`opts = optimset(name, value, ...)` creates a struct of optimization options. `opts = optimset(old, name, value, ...)` copies an existing options struct and applies overrides.",
+  "description": "`opts = optimset(name, value, ...)` creates a struct of optimization options. `opts = optimset(old, name, value, ...)` copies an existing options struct and applies overrides. The resulting struct can be passed to optimization builtins such as `fminbnd`, `fzero`, and `fsolve`.",
   "behaviors": [
     "Option names are case-insensitive for the builtins that consume them.",
     "`TolX`, `TolFun`, `MaxIter`, `MaxFunEvals`, and `Display` are canonicalized when constructed with `optimset`.",
@@ -29,12 +29,13 @@
   ],
   "examples": [
     {
-      "description": "Create options for fzero",
-      "input": "opts = optimset('TolX', 1e-10, 'Display', 'off');\nx = fzero(@sin, [3 4], opts)",
+      "description": "Create options for fminbnd",
+      "input": "opts = optimset('TolX', 1e-10, 'Display', 'off');\nx = fminbnd(@cos, 0, pi, opts)",
       "output": "x =\n    3.1416"
     }
   ],
   "links": [
+    { "label": "fminbnd", "url": "./fminbnd" },
     { "label": "fzero", "url": "./fzero" },
     { "label": "fsolve", "url": "./fsolve" }
   ],

--- a/crates/runmat-runtime/src/builtins/math/optim/brent.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/brent.rs
@@ -1,0 +1,362 @@
+//! Brent's method primitives shared across optimization builtins.
+//!
+//! Two related Brent algorithms live here:
+//!
+//! * [`brent_zero`] — root-finding by inverse-quadratic / secant / bisection.
+//!   Powers [`crate::builtins::math::optim::fzero`].
+//! * [`brent_min`] — bounded scalar minimization using golden-section search
+//!   plus parabolic interpolation.  Powers [`crate::builtins::math::optim::fminbnd`].
+//!
+//! Both routines reuse [`call_scalar_function`] from the optim `common` module
+//! so RunMat's function-handle dispatch path (closures, anonymous functions,
+//! named handles) flows through a single helper.
+
+use runmat_builtins::Value;
+
+use crate::builtins::math::optim::common::{call_scalar_function, optim_error};
+use crate::BuiltinResult;
+
+/// Result of a successful (or terminated) bounded scalar minimization.
+#[derive(Debug, Clone)]
+pub(crate) struct BrentMinResult {
+    pub x: f64,
+    pub fval: f64,
+    pub iterations: usize,
+    pub func_count: usize,
+    pub converged: bool,
+}
+
+/// Tuning parameters shared by both Brent variants.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BrentParams {
+    pub tol_x: f64,
+    pub max_iter: usize,
+    pub max_fun_evals: usize,
+}
+
+/// Per-iteration hook used for `Display = 'iter'` output.
+pub(crate) trait BrentMinObserver {
+    fn on_iteration(
+        &mut self,
+        iter: usize,
+        func_count: usize,
+        x: f64,
+        fx: f64,
+        step_kind: BrentStepKind,
+    );
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum BrentStepKind {
+    Initial,
+    GoldenSection,
+    Parabolic,
+}
+
+/// Find a zero of a scalar function on a sign-changing bracket using Brent's method.
+///
+/// `bracket` must satisfy `fa * fb <= 0` (otherwise the contract is violated and
+/// the function returns an error).  The function evaluation counter
+/// (`initial_evals`) tracks calls performed by the caller while constructing the
+/// bracket; the returned tuple's second element is the total invocations.
+pub(crate) async fn brent_zero(
+    name: &str,
+    function: &Value,
+    bracket: BrentZeroBracket,
+    params: BrentParams,
+) -> BuiltinResult<f64> {
+    if bracket.fa == 0.0 || bracket.a == bracket.b {
+        return Ok(bracket.a);
+    }
+    if bracket.fb == 0.0 {
+        return Ok(bracket.b);
+    }
+
+    let mut a = bracket.a;
+    let mut b = bracket.b;
+    let mut c = a;
+    let mut fa = bracket.fa;
+    let mut fb = bracket.fb;
+    let mut fc = fa;
+    let mut d = b - a;
+    let mut e = d;
+    let mut evals = bracket.evals;
+
+    for _ in 0..params.max_iter {
+        if fb.signum() == fc.signum() {
+            c = a;
+            fc = fa;
+            d = b - a;
+            e = d;
+        }
+        if fc.abs() < fb.abs() {
+            let old_b = b;
+            let old_fb = fb;
+            a = b;
+            fa = fb;
+            b = c;
+            fb = fc;
+            c = old_b;
+            fc = old_fb;
+        }
+
+        let tol = 2.0 * f64::EPSILON * b.abs() + 0.5 * params.tol_x;
+        let midpoint = 0.5 * (c - b);
+        if midpoint.abs() <= tol || fb == 0.0 {
+            return Ok(b);
+        }
+        if evals >= params.max_fun_evals {
+            return Err(optim_error(
+                name,
+                format!("{name}: exceeded maximum function evaluations"),
+            ));
+        }
+
+        if e.abs() >= tol && fa.abs() > fb.abs() {
+            let s = fb / fa;
+            let (mut p, mut q) = if a == c {
+                (2.0 * midpoint * s, 1.0 - s)
+            } else {
+                let q = fa / fc;
+                let r = fb / fc;
+                (
+                    s * (2.0 * midpoint * q * (q - r) - (b - a) * (r - 1.0)),
+                    (q - 1.0) * (r - 1.0) * (s - 1.0),
+                )
+            };
+            if p > 0.0 {
+                q = -q;
+            }
+            p = p.abs();
+            if interpolation_step_accepted(p, q, midpoint, tol, e) {
+                e = d;
+                d = p / q;
+            } else {
+                d = midpoint;
+                e = d;
+            }
+        } else {
+            d = midpoint;
+            e = d;
+        }
+
+        a = b;
+        fa = fb;
+        b += if d.abs() > tol {
+            d
+        } else if midpoint >= 0.0 {
+            tol
+        } else {
+            -tol
+        };
+        fb = call_scalar_function(name, function, b).await?;
+        evals += 1;
+    }
+
+    Err(optim_error(
+        name,
+        format!("{name}: exceeded maximum iterations"),
+    ))
+}
+
+/// Bracket consumed by [`brent_zero`].
+#[derive(Clone, Copy)]
+pub(crate) struct BrentZeroBracket {
+    pub a: f64,
+    pub b: f64,
+    pub fa: f64,
+    pub fb: f64,
+    pub evals: usize,
+}
+
+pub(crate) fn interpolation_step_accepted(p: f64, q: f64, midpoint: f64, tol: f64, e: f64) -> bool {
+    let min_a = 3.0 * midpoint * q - (tol * q).abs();
+    let min_b = (e * q).abs();
+    2.0 * p < min_a.min(min_b)
+}
+
+/// Inverse golden ratio used by Brent minimization: `(3 - sqrt(5)) / 2`.
+const CGOLD: f64 = 0.381_966_011_250_105_15;
+
+/// Bounded scalar minimization following Brent's method (Numerical Recipes §10.2).
+///
+/// The function `function` is evaluated through the standard scalar dispatcher.
+/// `a` and `b` must be finite and may be supplied in any order.  The optional
+/// `observer` receives a callback for each accepted iteration (used to drive
+/// `Display = 'iter'`).
+pub(crate) async fn brent_min(
+    name: &str,
+    function: &Value,
+    a: f64,
+    b: f64,
+    params: BrentParams,
+    mut observer: Option<&mut dyn BrentMinObserver>,
+) -> BuiltinResult<BrentMinResult> {
+    if !a.is_finite() || !b.is_finite() {
+        return Err(optim_error(
+            name,
+            format!("{name}: bounds must be finite real scalars"),
+        ));
+    }
+    let (mut a, mut b) = (a.min(b), a.max(b));
+    if (b - a).abs() <= f64::EPSILON * (a.abs() + b.abs()) {
+        let x = 0.5 * (a + b);
+        let fx = call_scalar_function(name, function, x).await?;
+        if let Some(observer) = observer.as_deref_mut() {
+            observer.on_iteration(0, 1, x, fx, BrentStepKind::Initial);
+        }
+        return Ok(BrentMinResult {
+            x,
+            fval: fx,
+            iterations: 0,
+            func_count: 1,
+            converged: true,
+        });
+    }
+
+    let mut x = a + CGOLD * (b - a);
+    let mut w = x;
+    let mut v = x;
+    let mut fx = call_scalar_function(name, function, x).await?;
+    let mut fw = fx;
+    let mut fv = fx;
+    let mut func_count = 1usize;
+    let mut d = 0.0_f64;
+    let mut e = 0.0_f64;
+
+    if let Some(observer) = observer.as_deref_mut() {
+        observer.on_iteration(0, func_count, x, fx, BrentStepKind::Initial);
+    }
+
+    for iter in 1..=params.max_iter {
+        let xm = 0.5 * (a + b);
+        let tol1 = brent_min_tolerance(x, params);
+        let tol2 = 2.0 * tol1;
+        if (x - xm).abs() <= tol2 - 0.5 * (b - a) {
+            return Ok(BrentMinResult {
+                x,
+                fval: fx,
+                iterations: iter - 1,
+                func_count,
+                converged: true,
+            });
+        }
+
+        let mut step_kind = BrentStepKind::GoldenSection;
+        let mut use_parabolic = false;
+        if e.abs() > tol1 {
+            let r = (x - w) * (fx - fv);
+            let mut q = (x - v) * (fx - fw);
+            let mut p = (x - v) * q - (x - w) * r;
+            q = 2.0 * (q - r);
+            if q > 0.0 {
+                p = -p;
+            }
+            q = q.abs();
+            let etemp = e;
+            e = d;
+            if p.abs() < (0.5 * q * etemp).abs() && p > q * (a - x) && p < q * (b - x) {
+                d = p / q;
+                let u = x + d;
+                if (u - a) < tol2 || (b - u) < tol2 {
+                    d = with_sign(tol1, xm - x);
+                }
+                use_parabolic = true;
+                step_kind = BrentStepKind::Parabolic;
+            }
+        }
+        if !use_parabolic {
+            e = if x >= xm { a - x } else { b - x };
+            d = CGOLD * e;
+        }
+
+        let u = if d.abs() >= tol1 {
+            x + d
+        } else {
+            x + with_sign(tol1, d)
+        };
+        if func_count >= params.max_fun_evals {
+            return Ok(BrentMinResult {
+                x,
+                fval: fx,
+                iterations: iter - 1,
+                func_count,
+                converged: false,
+            });
+        }
+        let fu = call_scalar_function(name, function, u).await?;
+        func_count += 1;
+
+        if fu <= fx {
+            if u >= x {
+                a = x;
+            } else {
+                b = x;
+            }
+            v = w;
+            w = x;
+            x = u;
+            fv = fw;
+            fw = fx;
+            fx = fu;
+        } else {
+            if u < x {
+                a = u;
+            } else {
+                b = u;
+            }
+            if fu <= fw || w == x {
+                v = w;
+                fv = fw;
+                w = u;
+                fw = fu;
+            } else if fu <= fv || v == x || v == w {
+                v = u;
+                fv = fu;
+            }
+        }
+
+        if let Some(observer) = observer.as_deref_mut() {
+            observer.on_iteration(iter, func_count, x, fx, step_kind);
+        }
+    }
+
+    Ok(BrentMinResult {
+        x,
+        fval: fx,
+        iterations: params.max_iter,
+        func_count,
+        converged: false,
+    })
+}
+
+fn with_sign(magnitude: f64, sign_source: f64) -> f64 {
+    if sign_source >= 0.0 {
+        magnitude.abs()
+    } else {
+        -magnitude.abs()
+    }
+}
+
+pub(crate) fn brent_min_tolerance(x: f64, params: BrentParams) -> f64 {
+    params.tol_x + 3.0 * x.abs() * f64::EPSILON.sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interpolation_acceptance_uses_signed_q() {
+        assert!(!interpolation_step_accepted(1.0, -2.0, 1.0, 0.1, 10.0));
+        assert!(interpolation_step_accepted(1.0, -2.0, -1.0, 0.1, 10.0));
+    }
+
+    #[test]
+    fn with_sign_matches_fortran_semantics() {
+        assert_eq!(with_sign(1.0, 0.5), 1.0);
+        assert_eq!(with_sign(1.0, -0.5), -1.0);
+        assert_eq!(with_sign(1.0, 0.0), 1.0);
+        assert_eq!(with_sign(-1.0, -1.0), -1.0);
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/optim/brent.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/brent.rs
@@ -55,7 +55,7 @@ pub(crate) enum BrentStepKind {
 
 /// Find a zero of a scalar function on a sign-changing bracket using Brent's method.
 ///
-/// `bracket` must satisfy `fa * fb <= 0` (otherwise the contract is violated and
+/// `bracket` must satisfy `fa * fb < 0` unless either endpoint is already zero
 /// the function returns an error).  The function evaluation counter
 /// (`initial_evals`) tracks calls performed by the caller while constructing the
 /// bracket; the returned tuple's second element is the total invocations.
@@ -65,11 +65,17 @@ pub(crate) async fn brent_zero(
     bracket: BrentZeroBracket,
     params: BrentParams,
 ) -> BuiltinResult<f64> {
-    if bracket.fa == 0.0 || bracket.a == bracket.b {
+    if bracket.fa == 0.0 {
         return Ok(bracket.a);
     }
     if bracket.fb == 0.0 {
         return Ok(bracket.b);
+    }
+    if bracket.fa * bracket.fb >= 0.0 {
+        return Err(optim_error(
+            name,
+            format!("{name}: invalid bracket; endpoint function values must have opposite signs"),
+        ));
     }
 
     let mut a = bracket.a;
@@ -199,8 +205,10 @@ pub(crate) async fn brent_min(
         ));
     }
     let (mut a, mut b) = (a.min(b), a.max(b));
-    if (b - a).abs() <= f64::EPSILON * (a.abs() + b.abs()) {
-        let x = 0.5 * (a + b);
+    let width = b - a;
+    let scale = a.abs().max(b.abs()).max(1.0);
+    if width.abs() <= f64::EPSILON * scale {
+        let x = a + width * 0.5;
         let fx = call_scalar_function(name, function, x).await?;
         if let Some(observer) = observer.as_deref_mut() {
             observer.on_iteration(0, 1, x, fx, BrentStepKind::Initial);
@@ -350,6 +358,28 @@ mod tests {
     fn interpolation_acceptance_uses_signed_q() {
         assert!(!interpolation_step_accepted(1.0, -2.0, 1.0, 0.1, 10.0));
         assert!(interpolation_step_accepted(1.0, -2.0, -1.0, 0.1, 10.0));
+    }
+
+    #[test]
+    fn brent_zero_rejects_nonzero_collapsed_bracket() {
+        let err = futures::executor::block_on(brent_zero(
+            "fzero",
+            &Value::FunctionHandle("sin".into()),
+            BrentZeroBracket {
+                a: 1.0,
+                b: 1.0,
+                fa: 1.0,
+                fb: 1.0,
+                evals: 0,
+            },
+            BrentParams {
+                tol_x: 1.0e-6,
+                max_iter: 10,
+                max_fun_evals: 10,
+            },
+        ))
+        .unwrap_err();
+        assert!(err.message().contains("invalid bracket"));
     }
 
     #[test]

--- a/crates/runmat-runtime/src/builtins/math/optim/fminbnd.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/fminbnd.rs
@@ -151,7 +151,7 @@ impl FminbndOptions {
         };
         let max_fun_evals = match options.and_then(|o| lookup(o, "MaxFunEvals")) {
             Some(value) => option_positive_usize("MaxFunEvals", value)?,
-            None => DEFAULT_MAX_FUN_EVALS.max(max_iter),
+            None => DEFAULT_MAX_FUN_EVALS,
         };
         Ok(Self {
             tol_x,
@@ -660,6 +660,15 @@ mod tests {
             V::Num(x) => assert!((x - 2.0).abs() < 1.0e-6, "x = {x}"),
             other => panic!("unexpected value {other:?}"),
         }
+    }
+
+    #[test]
+    fn max_fun_evals_default_is_independent_of_max_iter() {
+        let mut opts = StructValue::new();
+        opts.insert("MaxIter", Value::Num(1000.0));
+        let parsed = FminbndOptions::from_struct(Some(&opts)).unwrap();
+        assert_eq!(parsed.max_iter, 1000);
+        assert_eq!(parsed.max_fun_evals, DEFAULT_MAX_FUN_EVALS);
     }
 
     #[test]

--- a/crates/runmat-runtime/src/builtins/math/optim/fminbnd.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/fminbnd.rs
@@ -1,0 +1,816 @@
+//! MATLAB-compatible `fminbnd` builtin for bounded scalar minimization.
+//!
+//! `fminbnd` finds a local minimum of a scalar function on a finite interval
+//! using Brent's method (golden-section search combined with parabolic
+//! interpolation).  The implementation supports MATLAB's four output arities:
+//!
+//! * `x = fminbnd(fun, x1, x2)`
+//! * `x = fminbnd(fun, x1, x2, options)`
+//! * `[x, fval] = fminbnd(...)`
+//! * `[x, fval, exitflag] = fminbnd(...)`
+//! * `[x, fval, exitflag, output] = fminbnd(...)`
+//!
+//! The optional options struct (typically created by `optimset`) honours
+//! `TolX`, `MaxIter`, `MaxFunEvals`, and `Display`.
+
+use runmat_builtins::{LogicalArray, StructValue, Tensor, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ShapeRequirements,
+};
+use crate::builtins::math::optim::brent::{
+    brent_min, BrentMinObserver, BrentMinResult, BrentParams, BrentStepKind,
+};
+use crate::builtins::math::optim::common::optim_error;
+use crate::builtins::math::optim::type_resolvers::scalar_root_type;
+use crate::BuiltinResult;
+
+const NAME: &str = "fminbnd";
+const ALGORITHM: &str = "golden section search, parabolic interpolation";
+const DEFAULT_TOL_X: f64 = 1.0e-4;
+const DEFAULT_MAX_ITER: usize = 500;
+const DEFAULT_MAX_FUN_EVALS: usize = 500;
+const DEFAULT_DISPLAY: DisplayMode = DisplayMode::Notify;
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::math::optim::fminbnd")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: "fminbnd",
+    op_kind: GpuOpKind::Custom("bounded-scalar-min"),
+    supported_precisions: &[],
+    broadcast: BroadcastSemantics::None,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::GatherImmediately,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "Host iterative solver. Callback computations may use GPU-aware builtins, but the minimization loop runs on the CPU.",
+};
+
+#[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::math::optim::fminbnd")]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: "fminbnd",
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: false,
+    notes:
+        "Bounded scalar minimization repeatedly invokes user code and terminates fusion planning.",
+};
+
+#[runtime_builtin(
+    name = "fminbnd",
+    category = "math/optim",
+    summary = "Find a local minimum of a scalar function on a bounded interval using Brent's method.",
+    keywords = "fminbnd,bounded minimization,brent,golden section,parabolic interpolation,optimization",
+    accel = "sink",
+    type_resolver(scalar_root_type),
+    builtin_path = "crate::builtins::math::optim::fminbnd"
+)]
+async fn fminbnd_builtin(
+    function: Value,
+    x1: Value,
+    x2: Value,
+    rest: Vec<Value>,
+) -> BuiltinResult<Value> {
+    if rest.len() > 1 {
+        return Err(optim_error(NAME, "fminbnd: too many input arguments"));
+    }
+    let options_struct = parse_options(rest.first())?;
+    let options = FminbndOptions::from_struct(options_struct.as_ref())?;
+    let x1 = scalar_bound("lower bound", x1).await?;
+    let x2 = scalar_bound("upper bound", x2).await?;
+
+    if !x1.is_finite() || !x2.is_finite() {
+        return Err(optim_error(NAME, "fminbnd: bounds must be finite"));
+    }
+    if x1 > x2 {
+        return finalize_inconsistent_bounds(&options);
+    }
+
+    let outcome = run_solver(&function, x1, x2, &options).await?;
+    finalize(outcome, &options)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DisplayMode {
+    Off,
+    Iter,
+    Notify,
+    Final,
+}
+
+impl DisplayMode {
+    fn parse(text: &str) -> BuiltinResult<Self> {
+        match text.to_ascii_lowercase().as_str() {
+            "off" | "none" => Ok(Self::Off),
+            "iter" => Ok(Self::Iter),
+            "notify" => Ok(Self::Notify),
+            "final" => Ok(Self::Final),
+            other => Err(optim_error(
+                NAME,
+                format!(
+                    "fminbnd: option Display must be 'off', 'iter', 'notify', or 'final', got '{other}'"
+                ),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FminbndOptions {
+    tol_x: f64,
+    max_iter: usize,
+    max_fun_evals: usize,
+    display: DisplayMode,
+}
+
+impl FminbndOptions {
+    fn from_struct(options: Option<&StructValue>) -> BuiltinResult<Self> {
+        let display = match options {
+            Some(opts) => match lookup(opts, "Display") {
+                Some(value) => DisplayMode::parse(&option_string("Display", value)?)?,
+                None => DEFAULT_DISPLAY,
+            },
+            None => DEFAULT_DISPLAY,
+        };
+        let tol_x = match options.and_then(|o| lookup(o, "TolX")) {
+            Some(value) => option_f64("TolX", value)?,
+            None => DEFAULT_TOL_X,
+        };
+        if tol_x <= 0.0 {
+            return Err(optim_error(NAME, "fminbnd: option TolX must be positive"));
+        }
+        let max_iter = match options.and_then(|o| lookup(o, "MaxIter")) {
+            Some(value) => option_positive_usize("MaxIter", value)?,
+            None => DEFAULT_MAX_ITER,
+        };
+        let max_fun_evals = match options.and_then(|o| lookup(o, "MaxFunEvals")) {
+            Some(value) => option_positive_usize("MaxFunEvals", value)?,
+            None => DEFAULT_MAX_FUN_EVALS.max(max_iter),
+        };
+        Ok(Self {
+            tol_x,
+            max_iter,
+            max_fun_evals,
+            display,
+        })
+    }
+}
+
+fn parse_options(value: Option<&Value>) -> BuiltinResult<Option<StructValue>> {
+    match value {
+        None => Ok(None),
+        Some(Value::Struct(options)) => Ok(Some(options.clone())),
+        Some(other) => Err(optim_error(
+            NAME,
+            format!("fminbnd: options must be a struct, got {other:?}"),
+        )),
+    }
+}
+
+fn lookup<'a>(options: &'a StructValue, name: &str) -> Option<&'a Value> {
+    options
+        .fields
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, v)| v)
+}
+
+fn option_string(field: &str, value: &Value) -> BuiltinResult<String> {
+    match value {
+        Value::String(s) => Ok(s.clone()),
+        Value::StringArray(sa) if sa.data.len() == 1 => Ok(sa.data[0].clone()),
+        Value::CharArray(chars) if chars.rows == 1 => Ok(chars.data.iter().collect()),
+        other => Err(optim_error(
+            NAME,
+            format!("fminbnd: option {field} must be a string, got {other:?}"),
+        )),
+    }
+}
+
+fn option_f64(field: &str, value: &Value) -> BuiltinResult<f64> {
+    let parsed = match value {
+        Value::Num(n) => *n,
+        Value::Int(i) => i.to_f64(),
+        Value::Bool(b) => {
+            if *b {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        Value::Tensor(Tensor { data, .. }) if data.len() == 1 => data[0],
+        Value::LogicalArray(LogicalArray { data, .. }) if data.len() == 1 => {
+            if data[0] != 0 {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        other => {
+            return Err(optim_error(
+                NAME,
+                format!("fminbnd: option {field} must be a real scalar, got {other:?}"),
+            ))
+        }
+    };
+    if parsed.is_finite() {
+        Ok(parsed)
+    } else {
+        Err(optim_error(
+            NAME,
+            format!("fminbnd: option {field} must be finite"),
+        ))
+    }
+}
+
+fn option_positive_usize(field: &str, value: &Value) -> BuiltinResult<usize> {
+    let parsed = option_f64(field, value)?;
+    if parsed < 1.0 {
+        return Err(optim_error(
+            NAME,
+            format!("fminbnd: option {field} must be a positive integer"),
+        ));
+    }
+    if parsed.fract() != 0.0 {
+        return Err(optim_error(
+            NAME,
+            format!("fminbnd: option {field} must be an integer scalar"),
+        ));
+    }
+    Ok(parsed as usize)
+}
+
+async fn scalar_bound(label: &str, value: Value) -> BuiltinResult<f64> {
+    let value = crate::dispatcher::gather_if_needed_async(&value).await?;
+    let parsed = match value {
+        Value::Num(n) => n,
+        Value::Int(i) => i.to_f64(),
+        Value::Bool(b) => {
+            if b {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        Value::Tensor(t) if t.data.len() == 1 => t.data[0],
+        Value::LogicalArray(LogicalArray { data, .. }) if data.len() == 1 => {
+            if data[0] != 0 {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        other => {
+            return Err(optim_error(
+                NAME,
+                format!("fminbnd: {label} must be a finite real scalar, got {other:?}"),
+            ))
+        }
+    };
+    if parsed.is_finite() {
+        Ok(parsed)
+    } else {
+        Err(optim_error(
+            NAME,
+            format!("fminbnd: {label} must be finite"),
+        ))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Outcome {
+    inner: BrentMinResult,
+}
+
+async fn run_solver(
+    function: &Value,
+    lo: f64,
+    hi: f64,
+    options: &FminbndOptions,
+) -> BuiltinResult<Outcome> {
+    let mut iter_log = IterDisplay::new(options.display);
+    let observer: Option<&mut dyn BrentMinObserver> =
+        if matches!(options.display, DisplayMode::Iter) {
+            Some(&mut iter_log)
+        } else {
+            None
+        };
+    let inner = brent_min(
+        NAME,
+        function,
+        lo,
+        hi,
+        BrentParams {
+            tol_x: options.tol_x,
+            max_iter: options.max_iter,
+            max_fun_evals: options.max_fun_evals,
+        },
+        observer,
+    )
+    .await?;
+    Ok(Outcome { inner })
+}
+
+fn finalize(outcome: Outcome, options: &FminbndOptions) -> BuiltinResult<Value> {
+    let exit_flag = if outcome.inner.converged { 1 } else { 0 };
+    let message = build_message(&outcome.inner);
+
+    emit_summary(&outcome.inner, exit_flag, &message, options);
+
+    let x = Value::Num(outcome.inner.x);
+    let fval = Value::Num(outcome.inner.fval);
+    let exitflag = Value::Num(exit_flag as f64);
+    let output_struct = Value::Struct(build_output_struct(&outcome.inner, &message));
+
+    match crate::output_count::current_output_count() {
+        None => Ok(x),
+        Some(0) => Ok(Value::OutputList(Vec::new())),
+        Some(1) => Ok(crate::output_count::output_list_with_padding(1, vec![x])),
+        Some(2) => Ok(crate::output_count::output_list_with_padding(
+            2,
+            vec![x, fval],
+        )),
+        Some(3) => Ok(crate::output_count::output_list_with_padding(
+            3,
+            vec![x, fval, exitflag],
+        )),
+        Some(n) if n >= 4 => Ok(crate::output_count::output_list_with_padding(
+            n,
+            vec![x, fval, exitflag, output_struct],
+        )),
+        Some(_) => Ok(x),
+    }
+}
+
+fn finalize_inconsistent_bounds(options: &FminbndOptions) -> BuiltinResult<Value> {
+    let message = "Exiting: The bounds are inconsistent because x1 > x2.".to_string();
+    emit_invalid_summary(-2, &message, options);
+
+    let x = empty_double();
+    let fval = empty_double();
+    let exitflag = Value::Num(-2.0);
+    let output_struct = Value::Struct(build_invalid_output_struct(&message));
+
+    match crate::output_count::current_output_count() {
+        None => Ok(x),
+        Some(0) => Ok(Value::OutputList(Vec::new())),
+        Some(1) => Ok(crate::output_count::output_list_with_padding(1, vec![x])),
+        Some(2) => Ok(crate::output_count::output_list_with_padding(
+            2,
+            vec![x, fval],
+        )),
+        Some(3) => Ok(crate::output_count::output_list_with_padding(
+            3,
+            vec![x, fval, exitflag],
+        )),
+        Some(n) if n >= 4 => Ok(crate::output_count::output_list_with_padding(
+            n,
+            vec![x, fval, exitflag, output_struct],
+        )),
+        Some(_) => Ok(empty_double()),
+    }
+}
+
+fn empty_double() -> Value {
+    Value::Tensor(Tensor::zeros(vec![0, 0]))
+}
+
+fn build_output_struct(result: &BrentMinResult, message: &str) -> StructValue {
+    let mut fields = StructValue::new();
+    fields.insert("iterations", Value::Num(result.iterations as f64));
+    fields.insert("funcCount", Value::Num(result.func_count as f64));
+    fields.insert("algorithm", Value::from(ALGORITHM));
+    fields.insert("message", Value::from(message.to_string()));
+    fields
+}
+
+fn build_invalid_output_struct(message: &str) -> StructValue {
+    let mut fields = StructValue::new();
+    fields.insert("iterations", Value::Num(0.0));
+    fields.insert("funcCount", Value::Num(0.0));
+    fields.insert("algorithm", Value::from(ALGORITHM));
+    fields.insert("message", Value::from(message.to_string()));
+    fields
+}
+
+fn build_message(result: &BrentMinResult) -> String {
+    if result.converged {
+        format!(
+            "Optimization terminated: the current x satisfies the termination criteria using OPTIONS.TolX. Iterations: {}, FuncCount: {}.",
+            result.iterations, result.func_count
+        )
+    } else {
+        format!(
+            "Exiting: Maximum number of function evaluations or iterations has been exceeded - increase MaxFunEvals or MaxIter. Iterations: {}, FuncCount: {}.",
+            result.iterations, result.func_count
+        )
+    }
+}
+
+fn emit_summary(result: &BrentMinResult, exit_flag: i32, message: &str, options: &FminbndOptions) {
+    let should_emit = match options.display {
+        DisplayMode::Off => false,
+        DisplayMode::Final | DisplayMode::Iter => true,
+        DisplayMode::Notify => exit_flag != 1,
+    };
+    if !should_emit {
+        return;
+    }
+    let line = format!(
+        "fminbnd: x = {x:.6}, fval = {fval:.6}, exitflag = {exit_flag}. {message}",
+        x = result.x,
+        fval = result.fval,
+    );
+    crate::console::record_console_line(crate::console::ConsoleStream::Stdout, line);
+}
+
+fn emit_invalid_summary(exit_flag: i32, message: &str, options: &FminbndOptions) {
+    let should_emit = match options.display {
+        DisplayMode::Off => false,
+        DisplayMode::Final | DisplayMode::Iter => true,
+        DisplayMode::Notify => exit_flag != 1,
+    };
+    if should_emit {
+        crate::console::record_console_line(
+            crate::console::ConsoleStream::Stdout,
+            format!("fminbnd: exitflag = {exit_flag}. {message}"),
+        );
+    }
+}
+
+struct IterDisplay {
+    mode: DisplayMode,
+    printed_header: bool,
+}
+
+impl IterDisplay {
+    fn new(mode: DisplayMode) -> Self {
+        Self {
+            mode,
+            printed_header: false,
+        }
+    }
+}
+
+impl BrentMinObserver for IterDisplay {
+    fn on_iteration(
+        &mut self,
+        iter: usize,
+        func_count: usize,
+        x: f64,
+        fx: f64,
+        step_kind: BrentStepKind,
+    ) {
+        if !matches!(self.mode, DisplayMode::Iter) {
+            return;
+        }
+        if !self.printed_header {
+            crate::console::record_console_line(
+                crate::console::ConsoleStream::Stdout,
+                " Func-count        x          f(x)          Procedure",
+            );
+            self.printed_header = true;
+        }
+        let procedure = match step_kind {
+            BrentStepKind::Initial => "initial",
+            BrentStepKind::GoldenSection => "golden",
+            BrentStepKind::Parabolic => "parabolic",
+        };
+        let line =
+            format!("    {func_count:>5}    {x:13.6e} {fx:13.6e}    {procedure}    (iter {iter})");
+        crate::console::record_console_line(crate::console::ConsoleStream::Stdout, line);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtins::math::optim::brent::brent_min_tolerance;
+    use futures::executor::block_on;
+    use runmat_builtins::Value as V;
+
+    fn run_default(handle: &str, lo: f64, hi: f64) -> Value {
+        block_on(fminbnd_builtin(
+            V::FunctionHandle(handle.into()),
+            V::Num(lo),
+            V::Num(hi),
+            Vec::new(),
+        ))
+        .expect("fminbnd")
+    }
+
+    fn run_with(handle: &str, lo: f64, hi: f64, extra: Vec<Value>) -> Value {
+        block_on(fminbnd_builtin(
+            V::FunctionHandle(handle.into()),
+            V::Num(lo),
+            V::Num(hi),
+            extra,
+        ))
+        .expect("fminbnd")
+    }
+
+    #[runtime_builtin(
+        name = "__fminbnd_quad_minus_two",
+        type_resolver(crate::builtins::math::optim::type_resolvers::scalar_root_type),
+        builtin_path = "crate::builtins::math::optim::fminbnd::tests"
+    )]
+    async fn quad_minus_two(x: Value) -> crate::BuiltinResult<Value> {
+        let x = scalar_bound("x", x).await?;
+        let diff = x - 2.0;
+        Ok(Value::Num(diff * diff))
+    }
+
+    #[runtime_builtin(
+        name = "__fminbnd_quad_minus_three",
+        type_resolver(crate::builtins::math::optim::type_resolvers::scalar_root_type),
+        builtin_path = "crate::builtins::math::optim::fminbnd::tests"
+    )]
+    async fn quad_minus_three(x: Value) -> crate::BuiltinResult<Value> {
+        let x = scalar_bound("x", x).await?;
+        let diff = x - 3.0;
+        Ok(Value::Num(diff * diff))
+    }
+
+    #[runtime_builtin(
+        name = "__fminbnd_multi_modal",
+        type_resolver(crate::builtins::math::optim::type_resolvers::scalar_root_type),
+        builtin_path = "crate::builtins::math::optim::fminbnd::tests"
+    )]
+    async fn multi_modal(x: Value) -> crate::BuiltinResult<Value> {
+        // 1 + sin(3x) on [0, 2π] — local minima near x ≈ π/2 + 2π/3 (etc.).
+        let x = scalar_bound("x", x).await?;
+        Ok(Value::Num(1.0 + (3.0 * x).sin()))
+    }
+
+    #[test]
+    fn locates_smooth_quadratic_minimum() {
+        let result = run_default("__fminbnd_quad_minus_two", 0.0, 5.0);
+        match result {
+            V::Num(x) => assert!((x - 2.0).abs() < 1.0e-3, "x = {x}"),
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn locates_quadratic_minimum_offset_three() {
+        let result = run_default("__fminbnd_quad_minus_three", 0.0, 5.0);
+        match result {
+            V::Num(x) => assert!((x - 3.0).abs() < 1.0e-3, "x = {x}"),
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn locates_cosine_minimum_at_right_endpoint() {
+        // cos(x) is monotonically decreasing on [0, π]; minimum is at x = π.
+        let result = run_default("cos", 0.0, std::f64::consts::PI);
+        match result {
+            V::Num(x) => assert!((x - std::f64::consts::PI).abs() < 1.0e-3, "x = {x}"),
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn returns_lone_endpoint_when_bounds_collapse() {
+        let result = run_default("__fminbnd_quad_minus_two", 1.5, 1.5);
+        match result {
+            V::Num(x) => assert!((x - 1.5).abs() < 1.0e-12, "x = {x}"),
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reports_inconsistent_reversed_bounds() {
+        let _guard = crate::output_count::push_output_count(Some(4));
+        let result = block_on(fminbnd_builtin(
+            V::FunctionHandle("__fminbnd_quad_minus_two".into()),
+            V::Num(5.0),
+            V::Num(0.0),
+            Vec::new(),
+        ))
+        .expect("fminbnd");
+        match result {
+            V::OutputList(outputs) => {
+                assert_eq!(outputs.len(), 4);
+                assert!(matches!(&outputs[0], V::Tensor(t) if t.data.is_empty()));
+                assert!(matches!(&outputs[1], V::Tensor(t) if t.data.is_empty()));
+                assert!(matches!(&outputs[2], V::Num(flag) if *flag == -2.0));
+                match &outputs[3] {
+                    V::Struct(s) => {
+                        assert!(matches!(s.fields.get("iterations"), Some(V::Num(0.0))));
+                        assert!(matches!(s.fields.get("funcCount"), Some(V::Num(0.0))));
+                        match s.fields.get("message") {
+                            Some(V::String(text)) => assert!(text.contains("bounds")),
+                            other => panic!("unexpected message field {other:?}"),
+                        }
+                    }
+                    other => panic!("unexpected output struct {other:?}"),
+                }
+            }
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tolerance_is_additive_not_scaled_by_x() {
+        let params = BrentParams {
+            tol_x: 1.0e-4,
+            max_iter: 500,
+            max_fun_evals: 500,
+        };
+        let small = brent_min_tolerance(2.0, params);
+        let large = brent_min_tolerance(1.0e9, params);
+        assert!(small > params.tol_x);
+        assert!(
+            large < params.tol_x * 1.0e9,
+            "large-scale tolerance was {large}"
+        );
+    }
+
+    #[test]
+    fn finds_local_minimum_in_multi_modal_function() {
+        // 1 + sin(3x) on [1.5, 3.5] has its local minimum near x = π/2 ≈ 1.571 (sin(3π/2) = -1).
+        let result = run_default("__fminbnd_multi_modal", 1.5, 3.5);
+        match result {
+            V::Num(x) => {
+                let target = std::f64::consts::PI / 2.0;
+                assert!((x - target).abs() < 5.0e-3, "x = {x}, target = {target}");
+            }
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn options_struct_overrides_default_tolerance() {
+        let mut opts = StructValue::new();
+        opts.insert("TolX", Value::Num(1.0e-12));
+        let result = run_with(
+            "__fminbnd_quad_minus_two",
+            0.0,
+            5.0,
+            vec![Value::Struct(opts)],
+        );
+        match result {
+            V::Num(x) => assert!((x - 2.0).abs() < 1.0e-6, "x = {x}"),
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_nonfinite_bounds() {
+        let err = block_on(fminbnd_builtin(
+            V::FunctionHandle("__fminbnd_quad_minus_two".into()),
+            V::Num(f64::NAN),
+            V::Num(5.0),
+            Vec::new(),
+        ))
+        .unwrap_err();
+        assert!(err.message().to_ascii_lowercase().contains("finite"));
+    }
+
+    #[test]
+    fn rejects_invalid_options_type() {
+        let err = block_on(fminbnd_builtin(
+            V::FunctionHandle("__fminbnd_quad_minus_two".into()),
+            V::Num(0.0),
+            V::Num(5.0),
+            vec![Value::Num(1.0)],
+        ))
+        .unwrap_err();
+        assert!(err.message().to_ascii_lowercase().contains("options"));
+    }
+
+    #[test]
+    fn rejects_nonpositive_tol_x() {
+        let mut opts = StructValue::new();
+        opts.insert("TolX", Value::Num(0.0));
+        let err = block_on(fminbnd_builtin(
+            V::FunctionHandle("__fminbnd_quad_minus_two".into()),
+            V::Num(0.0),
+            V::Num(5.0),
+            vec![Value::Struct(opts)],
+        ))
+        .unwrap_err();
+        assert!(err.message().to_lowercase().contains("tolx"));
+    }
+
+    #[test]
+    fn rejects_unknown_display_value() {
+        let mut opts = StructValue::new();
+        opts.insert("Display", Value::from("loud"));
+        let err = block_on(fminbnd_builtin(
+            V::FunctionHandle("__fminbnd_quad_minus_two".into()),
+            V::Num(0.0),
+            V::Num(5.0),
+            vec![Value::Struct(opts)],
+        ))
+        .unwrap_err();
+        assert!(err.message().to_lowercase().contains("display"));
+    }
+
+    #[test]
+    fn multi_output_two_returns_x_and_fval() {
+        let _guard = crate::output_count::push_output_count(Some(2));
+        let result = block_on(fminbnd_builtin(
+            V::FunctionHandle("__fminbnd_quad_minus_two".into()),
+            V::Num(0.0),
+            V::Num(5.0),
+            Vec::new(),
+        ))
+        .expect("fminbnd");
+        match result {
+            V::OutputList(outputs) => {
+                assert_eq!(outputs.len(), 2);
+                match (&outputs[0], &outputs[1]) {
+                    (V::Num(x), V::Num(fval)) => {
+                        assert!((x - 2.0).abs() < 1.0e-3);
+                        assert!(fval.abs() < 1.0e-5);
+                    }
+                    other => panic!("unexpected outputs {other:?}"),
+                }
+            }
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_output_three_includes_exitflag() {
+        let _guard = crate::output_count::push_output_count(Some(3));
+        let result = block_on(fminbnd_builtin(
+            V::FunctionHandle("__fminbnd_quad_minus_two".into()),
+            V::Num(0.0),
+            V::Num(5.0),
+            Vec::new(),
+        ))
+        .expect("fminbnd");
+        match result {
+            V::OutputList(outputs) => {
+                assert_eq!(outputs.len(), 3);
+                match &outputs[2] {
+                    V::Num(flag) => assert!((*flag - 1.0).abs() < 1.0e-12),
+                    other => panic!("unexpected exitflag {other:?}"),
+                }
+            }
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_output_four_includes_output_struct() {
+        let _guard = crate::output_count::push_output_count(Some(4));
+        let result = block_on(fminbnd_builtin(
+            V::FunctionHandle("__fminbnd_quad_minus_two".into()),
+            V::Num(0.0),
+            V::Num(5.0),
+            Vec::new(),
+        ))
+        .expect("fminbnd");
+        match result {
+            V::OutputList(outputs) => {
+                assert_eq!(outputs.len(), 4);
+                match &outputs[3] {
+                    V::Struct(s) => {
+                        assert!(matches!(s.fields.get("iterations"), Some(V::Num(_))));
+                        assert!(matches!(s.fields.get("funcCount"), Some(V::Num(_))));
+                        match s.fields.get("algorithm") {
+                            Some(V::String(text)) => assert!(text.contains("golden")),
+                            other => panic!("unexpected algorithm field {other:?}"),
+                        }
+                        assert!(s.fields.get("message").is_some());
+                    }
+                    other => panic!("unexpected output struct {other:?}"),
+                }
+            }
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reports_zero_exitflag_when_max_iter_exhausted() {
+        let mut opts = StructValue::new();
+        opts.insert("MaxIter", Value::Num(1.0));
+        opts.insert("MaxFunEvals", Value::Num(2.0));
+        opts.insert("Display", Value::from("off"));
+        let _guard = crate::output_count::push_output_count(Some(3));
+        let result = block_on(fminbnd_builtin(
+            V::FunctionHandle("__fminbnd_quad_minus_two".into()),
+            V::Num(0.0),
+            V::Num(5.0),
+            vec![Value::Struct(opts)],
+        ))
+        .expect("fminbnd");
+        match result {
+            V::OutputList(outputs) => match &outputs[2] {
+                V::Num(flag) => assert_eq!(*flag, 0.0),
+                other => panic!("unexpected exitflag {other:?}"),
+            },
+            other => panic!("unexpected value {other:?}"),
+        }
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/optim/fzero.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/fzero.rs
@@ -7,6 +7,7 @@ use crate::builtins::common::spec::{
     BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
     ReductionNaN, ResidencyPolicy, ShapeRequirements,
 };
+use crate::builtins::math::optim::brent::{brent_zero, BrentParams, BrentZeroBracket};
 use crate::builtins::math::optim::common::{
     call_scalar_function, optim_error, option_f64, option_string, option_usize,
 };
@@ -61,7 +62,23 @@ async fn fzero_builtin(function: Value, x: Value, rest: Vec<Value>) -> BuiltinRe
     let options = parse_options(rest.first())?;
     let opts = FzeroOptions::from_struct(options.as_ref())?;
     let bracket = initial_bracket(&function, x, &opts).await?;
-    let root = brent(&function, bracket, &opts).await?;
+    let root = brent_zero(
+        NAME,
+        &function,
+        BrentZeroBracket {
+            a: bracket.a,
+            b: bracket.b,
+            fa: bracket.fa,
+            fb: bracket.fb,
+            evals: bracket.evals,
+        },
+        BrentParams {
+            tol_x: opts.tol_x,
+            max_iter: opts.max_iter,
+            max_fun_evals: opts.max_fun_evals,
+        },
+    )
+    .await?;
     Ok(Value::Num(root))
 }
 
@@ -246,104 +263,6 @@ async fn expand_bracket(
     ))
 }
 
-async fn brent(function: &Value, bracket: Bracket, options: &FzeroOptions) -> BuiltinResult<f64> {
-    if bracket.fa == 0.0 || bracket.a == bracket.b {
-        return Ok(bracket.a);
-    }
-    if bracket.fb == 0.0 {
-        return Ok(bracket.b);
-    }
-
-    let mut a = bracket.a;
-    let mut b = bracket.b;
-    let mut c = a;
-    let mut fa = bracket.fa;
-    let mut fb = bracket.fb;
-    let mut fc = fa;
-    let mut d = b - a;
-    let mut e = d;
-    let mut evals = bracket.evals;
-
-    for _ in 0..options.max_iter {
-        if fb.signum() == fc.signum() {
-            c = a;
-            fc = fa;
-            d = b - a;
-            e = d;
-        }
-        if fc.abs() < fb.abs() {
-            let old_b = b;
-            let old_fb = fb;
-            a = b;
-            fa = fb;
-            b = c;
-            fb = fc;
-            c = old_b;
-            fc = old_fb;
-        }
-
-        let tol = 2.0 * f64::EPSILON * b.abs() + 0.5 * options.tol_x;
-        let midpoint = 0.5 * (c - b);
-        if midpoint.abs() <= tol || fb == 0.0 {
-            return Ok(b);
-        }
-        if evals >= options.max_fun_evals {
-            return Err(optim_error(
-                NAME,
-                "fzero: exceeded maximum function evaluations",
-            ));
-        }
-
-        if e.abs() >= tol && fa.abs() > fb.abs() {
-            let s = fb / fa;
-            let (mut p, mut q) = if a == c {
-                (2.0 * midpoint * s, 1.0 - s)
-            } else {
-                let q = fa / fc;
-                let r = fb / fc;
-                (
-                    s * (2.0 * midpoint * q * (q - r) - (b - a) * (r - 1.0)),
-                    (q - 1.0) * (r - 1.0) * (s - 1.0),
-                )
-            };
-            if p > 0.0 {
-                q = -q;
-            }
-            p = p.abs();
-            if interpolation_step_accepted(p, q, midpoint, tol, e) {
-                e = d;
-                d = p / q;
-            } else {
-                d = midpoint;
-                e = d;
-            }
-        } else {
-            d = midpoint;
-            e = d;
-        }
-
-        a = b;
-        fa = fb;
-        b += if d.abs() > tol {
-            d
-        } else if midpoint >= 0.0 {
-            tol
-        } else {
-            -tol
-        };
-        fb = call_scalar_function(NAME, function, b).await?;
-        evals += 1;
-    }
-
-    Err(optim_error(NAME, "fzero: exceeded maximum iterations"))
-}
-
-fn interpolation_step_accepted(p: f64, q: f64, midpoint: f64, tol: f64, e: f64) -> bool {
-    let min_a = 3.0 * midpoint * q - (tol * q).abs();
-    let min_b = (e * q).abs();
-    2.0 * p < min_a.min(min_b)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -391,11 +310,5 @@ mod tests {
             Value::Num(n) => assert!(n.abs() < 1.0e-6),
             other => panic!("unexpected value {other:?}"),
         }
-    }
-
-    #[test]
-    fn brent_interpolation_acceptance_uses_signed_q() {
-        assert!(!interpolation_step_accepted(1.0, -2.0, 1.0, 0.1, 10.0));
-        assert!(interpolation_step_accepted(1.0, -2.0, -1.0, 0.1, 10.0));
     }
 }

--- a/crates/runmat-runtime/src/builtins/math/optim/mod.rs
+++ b/crates/runmat-runtime/src/builtins/math/optim/mod.rs
@@ -1,6 +1,8 @@
 //! Optimization and nonlinear equation solving builtins.
 
+pub(crate) mod brent;
 pub(crate) mod common;
+pub mod fminbnd;
 pub mod fsolve;
 pub mod fzero;
 pub mod integral;

--- a/crates/runmat-vm/tests/closures.rs
+++ b/crates/runmat-vm/tests/closures.rs
@@ -89,6 +89,43 @@ fn integral_accepts_named_function_handle() {
 }
 
 #[test]
+fn fminbnd_accepts_anonymous_function() {
+    let ast = parse("x = fminbnd(@(x) (x-2).^2, 0, 5);").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert!(vars
+        .iter()
+        .any(|v| matches!(v, runmat_builtins::Value::Num(n) if (*n - 2.0).abs() < 1e-3)));
+}
+
+#[test]
+fn fminbnd_returns_optional_function_value() {
+    let ast = parse("[x, fval] = fminbnd(@(x) (x-3).^2 + 1, 0, 5);").unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    let x_ok = vars
+        .iter()
+        .any(|v| matches!(v, runmat_builtins::Value::Num(n) if (*n - 3.0).abs() < 1e-3));
+    let fval_ok = vars
+        .iter()
+        .any(|v| matches!(v, runmat_builtins::Value::Num(n) if (*n - 1.0).abs() < 1e-5));
+    assert!(x_ok, "expected x ≈ 3 in {vars:?}");
+    assert!(fval_ok, "expected fval ≈ 1 in {vars:?}");
+}
+
+#[test]
+fn fminbnd_accepts_optimset_options() {
+    let ast =
+        parse("opts = optimset('TolX', 1e-10, 'Display', 'off'); x = fminbnd(@cos, 0, pi, opts);")
+            .unwrap();
+    let hir = lower(&ast).unwrap();
+    let vars = execute(&hir).unwrap();
+    assert!(vars.iter().any(
+        |v| matches!(v, runmat_builtins::Value::Num(n) if (*n - std::f64::consts::PI).abs() < 1e-3)
+    ));
+}
+
+#[test]
 fn fsolve_accepts_anonymous_vector_function() {
     let ast =
         parse("F = @(x) [x(1)^2 + x(2)^2 - 4; x(1)*x(2) - 1]; x = fsolve(F, [1; 1]);").unwrap();


### PR DESCRIPTION
Implements MATLAB-compatible fminbnd(fun, x1, x2[, options]) for bounded scalar minimization via Brent's method (golden-section search
+ parabolic interpolation). Supports all four output arities (x, [x, fval], [x, fval, exitflag], [x, fval, exitflag, output]), the optimset options struct (TolX, MaxIter, MaxFunEvals, Display), and MATLAB-compatible exitflags and output diagnostics.

Refactors Brent's method out of fzero into a shared module (math/optim/brent.rs) so fzero and fminbnd share infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new iterative optimization builtin and refactors `fzero`’s core Brent solver into shared code; changes could subtly affect convergence/exit conditions and output behavior for root finding/minimization.
> 
> **Overview**
> **Adds MATLAB-compatible bounded minimization via `fminbnd`.** Introduces a new `fminbnd` builtin backed by Brent’s method, including `optimset`-driven options (`TolX`, `MaxIter`, `MaxFunEvals`, `Display`), MATLAB-style exit flags, multi-output variants (up to `[x, fval, exitflag, output]`), and console iteration/final reporting.
> 
> **Refactors Brent logic into a shared module and updates docs/tests.** Extracts Brent root-finding from `fzero` into `math/optim/brent.rs` (now used by both `fzero` and `fminbnd`), updates `optimset` JSON docs to mention `fminbnd`, and adds unit/integration coverage for `fminbnd` (including anonymous functions and `optimset` options).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1342ce7d256f94c8617071380c039afdd5b18ea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `fminbnd` function for finding the minimum of a univariate function within specified bounds, supporting MATLAB-style output arity and optimization options including tolerance settings and iteration limits.

* **Documentation**
  * Updated `optimset` documentation to include usage information for `fminbnd` options.

* **Tests**
  * Added integration tests for `fminbnd` covering anonymous functions and optimization parameter handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->