### PR TITLE
Add sawtooth and square waveform builtins (RM-462)

### DIFF
--- a/crates/runmat-runtime/src/builtins/builtins-json/sawtooth.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/sawtooth.json
@@ -1,0 +1,100 @@
+{
+  "title": "sawtooth",
+  "category": "math/signal",
+  "keywords": [
+    "sawtooth",
+    "waveform",
+    "signal processing",
+    "triangle",
+    "periodic",
+    "elementwise"
+  ],
+  "summary": "Generate a periodic sawtooth waveform with optional peak position.",
+  "references": [],
+  "gpu_support": {
+    "elementwise": true,
+    "reduction": false,
+    "precisions": [
+      "f64"
+    ],
+    "broadcasting": "elementwise",
+    "notes": "GPU inputs are gathered to the host so the reference implementation can guarantee MATLAB-compatible piecewise-linear evaluation at the period boundary."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 1,
+    "constants": "inline",
+    "notes": "Fusion is intentionally disabled for v1 because the WGSL piecewise expression is non-trivial and brings little benefit relative to the host loop."
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::math::signal::sawtooth::tests",
+    "integration": null
+  },
+  "description": "`y = sawtooth(t)` generates a sawtooth wave with period `2*pi` at the sample times in `t`, ranging in `[-1, 1]`. `y = sawtooth(t, xmax)` controls the peak position with `xmax` in `[0, 1]`: `xmax = 1` (the default) produces a rising sawtooth, `xmax = 0` produces a falling sawtooth, and intermediate values such as `xmax = 0.5` produce a triangle wave whose peak is at the centre of each period.",
+  "behaviors": [
+    "Operates element-wise on scalars, vectors, matrices, and N-D tensors; preserves input shape.",
+    "Reduces input modulo `2*pi` so the waveform is periodic across negative and positive sample times.",
+    "Returns `-1` at the start of each period and approaches `+1` just before the period boundary wraps when `xmax = 1`.",
+    "Returns a piecewise-linear triangle wave when `xmax = 0.5`, peaking at `1` at the centre of each period.",
+    "Returns a pure falling ramp when `xmax = 0` and a pure rising ramp when `xmax = 1`.",
+    "Integer and logical inputs are promoted to double precision before evaluation.",
+    "Non-finite sample times (`NaN`, `+Inf`, `-Inf`) propagate as `NaN` element-wise, matching MATLAB.",
+    "Complex and text inputs are rejected with a builtin-scoped error.",
+    "Rejects `xmax` values outside `[0, 1]` and non-scalar `xmax` arguments."
+  ],
+  "examples": [
+    {
+      "description": "Default rising sawtooth over two periods",
+      "input": "t = 0:pi/2:4*pi;\ny = sawtooth(t)",
+      "output": "y = [-1 -0.5 0 0.5 -1 -0.5 0 0.5 -1]"
+    },
+    {
+      "description": "Triangle wave via xmax = 0.5",
+      "input": "t = linspace(0, 2*pi, 5);\ny = sawtooth(t, 0.5)",
+      "output": "y = [-1 0 1 0 -1]"
+    },
+    {
+      "description": "Pure falling sawtooth via xmax = 0",
+      "input": "y = sawtooth([0 pi 2*pi], 0)",
+      "output": "y = [1 0 1]"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Why does `sawtooth(2*pi)` return `-1` instead of `+1`?",
+      "answer": "RunMat reduces the input modulo `2*pi`, so `2*pi` is folded back to the start of the next period. The default rising sawtooth therefore restarts at `-1` exactly on each period boundary, matching MATLAB."
+    },
+    {
+      "question": "How do I produce a triangle wave?",
+      "answer": "Pass `xmax = 0.5` so the peak sits at the centre of each period and the waveform ramps symmetrically up and back down."
+    },
+    {
+      "question": "Can `sawtooth` accept complex inputs?",
+      "answer": "No. `sawtooth` is defined on real samples and rejects complex inputs with a builtin-scoped error to match MATLAB."
+    }
+  ],
+  "links": [
+    {
+      "label": "square",
+      "url": "./square"
+    },
+    {
+      "label": "sin",
+      "url": "./sin"
+    },
+    {
+      "label": "cos",
+      "url": "./cos"
+    },
+    {
+      "label": "linspace",
+      "url": "./linspace"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/math/signal/sawtooth.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/math/signal/sawtooth.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/builtins-json/square.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/square.json
@@ -1,0 +1,99 @@
+{
+  "title": "square",
+  "category": "math/signal",
+  "keywords": [
+    "square",
+    "waveform",
+    "signal processing",
+    "duty cycle",
+    "periodic",
+    "elementwise"
+  ],
+  "summary": "Generate a periodic square wave with optional duty cycle.",
+  "references": [],
+  "gpu_support": {
+    "elementwise": true,
+    "reduction": false,
+    "precisions": [
+      "f64"
+    ],
+    "broadcasting": "elementwise",
+    "notes": "GPU inputs are gathered to the host so the reference implementation can guarantee MATLAB-compatible half-open duty-cycle semantics at the period boundary."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 1,
+    "constants": "inline",
+    "notes": "Fusion is intentionally disabled for v1 because the duty-cycle comparison is cheap on the host and would not materially benefit from kernel fusion."
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::math::signal::square::tests",
+    "integration": null
+  },
+  "description": "`y = square(t)` generates a square wave with period `2*pi` at the sample times in `t`, with values in `{-1, +1}`. `y = square(t, duty)` accepts an explicit duty cycle as a percentage in `[0, 100]`: the output is `+1` over the first `duty/100 * 2*pi` of every period and `-1` for the remainder. The default duty cycle is 50% so that `square` produces the standard symmetric square wave.",
+  "behaviors": [
+    "Operates element-wise on scalars, vectors, matrices, and N-D tensors; preserves input shape.",
+    "Reduces input modulo `2*pi` so the waveform is periodic across negative and positive sample times.",
+    "Uses half-open interval semantics: `+1` for `phi/(2*pi) < duty/100`, `-1` otherwise.",
+    "`duty = 0` produces a constant `-1` waveform; `duty = 100` produces a constant `+1` waveform.",
+    "Integer and logical inputs are promoted to double precision before evaluation.",
+    "Non-finite sample times (`NaN`, `+Inf`, `-Inf`) propagate as `NaN` element-wise, matching MATLAB.",
+    "Complex and text inputs are rejected with a builtin-scoped error.",
+    "Rejects `duty` values outside `[0, 100]` and non-scalar `duty` arguments."
+  ],
+  "examples": [
+    {
+      "description": "Default 50% duty cycle square wave",
+      "input": "t = 0:pi/4:2*pi;\ny = square(t)",
+      "output": "y = [1 1 1 1 -1 -1 -1 -1 1]"
+    },
+    {
+      "description": "25% duty cycle square wave",
+      "input": "t = 0:pi/4:2*pi;\ny = square(t, 25)",
+      "output": "y = [1 1 -1 -1 -1 -1 -1 -1 1]"
+    },
+    {
+      "description": "Constant outputs at the boundaries",
+      "input": "y = square([0 pi 2*pi], 100)",
+      "output": "y = [1 1 1]"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What happens exactly at the duty-cycle boundary?",
+      "answer": "RunMat uses half-open semantics: the boundary phase belongs to the negative half. With the default 50% duty cycle, `square(pi)` returns `-1`. This matches MATLAB's documented behaviour."
+    },
+    {
+      "question": "How do I produce a constant `+1` or `-1`?",
+      "answer": "Pass `duty = 100` for a constant `+1` waveform and `duty = 0` for a constant `-1` waveform."
+    },
+    {
+      "question": "Can `square` accept complex inputs?",
+      "answer": "No. `square` is defined on real samples and rejects complex inputs with a builtin-scoped error to match MATLAB."
+    }
+  ],
+  "links": [
+    {
+      "label": "sawtooth",
+      "url": "./sawtooth"
+    },
+    {
+      "label": "sin",
+      "url": "./sin"
+    },
+    {
+      "label": "cos",
+      "url": "./cos"
+    },
+    {
+      "label": "linspace",
+      "url": "./linspace"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/math/signal/square.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/math/signal/square.rs"
+  }
+}

--- a/crates/runmat-runtime/src/builtins/math/signal/mod.rs
+++ b/crates/runmat-runtime/src/builtins/math/signal/mod.rs
@@ -8,5 +8,7 @@ pub mod deconv;
 pub mod filter;
 pub(crate) mod hamming;
 pub(crate) mod hann;
+pub(crate) mod sawtooth;
 pub(crate) mod sinc;
+pub(crate) mod square;
 pub(crate) mod type_resolvers;

--- a/crates/runmat-runtime/src/builtins/math/signal/sawtooth.rs
+++ b/crates/runmat-runtime/src/builtins/math/signal/sawtooth.rs
@@ -1,0 +1,369 @@
+//! MATLAB-compatible `sawtooth` builtin for RunMat.
+//!
+//! `y = sawtooth(t)` evaluates a sawtooth waveform with period `2*pi` at the
+//! sample times in `t`. The optional second argument `xmax ∈ [0, 1]` controls
+//! the position of the peak inside each period: `xmax = 1` (default) produces
+//! a rising sawtooth, `xmax = 0` produces a falling sawtooth, and any value
+//! in between (e.g. `xmax = 0.5` for a triangle wave) interpolates between
+//! the two via a piecewise-linear ramp.
+
+use std::f64::consts::PI;
+
+use runmat_accelerate_api::GpuTensorHandle;
+use runmat_builtins::{Tensor, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::tensor::{scalar_f64_from_value_async, tensor_into_value};
+use crate::builtins::common::{gpu_helpers, tensor};
+use crate::builtins::math::type_resolvers::numeric_unary_type;
+use crate::{build_runtime_error, BuiltinResult, RuntimeError};
+
+const BUILTIN_NAME: &str = "sawtooth";
+const TWO_PI: f64 = 2.0 * PI;
+
+fn builtin_error(message: impl Into<String>) -> RuntimeError {
+    build_runtime_error(message)
+        .with_builtin(BUILTIN_NAME)
+        .build()
+}
+
+/// Element-wise scalar sawtooth.
+///
+/// `width = xmax * 2π` is the peak position within the period. For phase
+/// values in `[0, width)` the output rises linearly from `-1` to `+1`. For
+/// phase values in `[width, 2π)` the output falls linearly from `+1` back to
+/// `-1`. The boundary cases `xmax == 0` (pure falling) and `xmax == 1` (pure
+/// rising) reduce naturally because `phi ∈ [0, 2π)` never reaches the open
+/// upper bound of the rising branch.
+#[inline]
+fn sawtooth_scalar(t: f64, xmax: f64) -> f64 {
+    if !t.is_finite() {
+        return f64::NAN;
+    }
+    let phi = t.rem_euclid(TWO_PI);
+    let width = xmax * TWO_PI;
+    if width <= 0.0 {
+        1.0 - phi / PI
+    } else if phi < width {
+        -1.0 + 2.0 * phi / width
+    } else {
+        let falling_width = TWO_PI - width;
+        if falling_width <= 0.0 {
+            -1.0 + 2.0 * phi / width
+        } else {
+            1.0 - 2.0 * (phi - width) / falling_width
+        }
+    }
+}
+
+#[runtime_builtin(
+    name = "sawtooth",
+    category = "math/signal",
+    summary = "Generate a periodic sawtooth waveform with optional peak position.",
+    keywords = "sawtooth,waveform,signal processing,triangle,periodic",
+    type_resolver(numeric_unary_type),
+    builtin_path = "crate::builtins::math::signal::sawtooth"
+)]
+async fn sawtooth_builtin(t: Value, varargin: Vec<Value>) -> BuiltinResult<Value> {
+    let xmax = parse_xmax(&varargin).await?;
+    match t {
+        Value::GpuTensor(handle) => sawtooth_gpu(handle, xmax).await,
+        Value::Complex(_, _) | Value::ComplexTensor(_) => Err(builtin_error(
+            "sawtooth: input must be real; complex values are not supported",
+        )),
+        Value::String(_) | Value::StringArray(_) | Value::CharArray(_) => {
+            Err(builtin_error("sawtooth: expected numeric input"))
+        }
+        other => sawtooth_real(other, xmax),
+    }
+}
+
+async fn parse_xmax(varargin: &[Value]) -> BuiltinResult<f64> {
+    match varargin.len() {
+        0 => Ok(1.0),
+        1 => {
+            let raw = scalar_f64_from_value_async(&varargin[0])
+                .await
+                .map_err(|err| builtin_error(format!("sawtooth: {err}")))?
+                .ok_or_else(|| {
+                    builtin_error("sawtooth: xmax must be a real numeric scalar in [0, 1]")
+                })?;
+            if !raw.is_finite() || !(0.0..=1.0).contains(&raw) {
+                return Err(builtin_error(format!(
+                    "sawtooth: xmax must be a finite scalar in [0, 1], got {raw}"
+                )));
+            }
+            Ok(raw)
+        }
+        _ => Err(builtin_error(format!(
+            "sawtooth: expected 1 or 2 arguments, got {}",
+            varargin.len() + 1
+        ))),
+    }
+}
+
+async fn sawtooth_gpu(handle: GpuTensorHandle, xmax: f64) -> BuiltinResult<Value> {
+    let tensor = gpu_helpers::gather_tensor_async(&handle).await?;
+    sawtooth_tensor(tensor, xmax).map(tensor_into_value)
+}
+
+fn sawtooth_real(value: Value, xmax: f64) -> BuiltinResult<Value> {
+    let tensor = tensor::value_into_tensor_for(BUILTIN_NAME, value).map_err(builtin_error)?;
+    sawtooth_tensor(tensor, xmax).map(tensor_into_value)
+}
+
+fn sawtooth_tensor(tensor: Tensor, xmax: f64) -> BuiltinResult<Tensor> {
+    let data = tensor
+        .data
+        .iter()
+        .map(|&value| sawtooth_scalar(value, xmax))
+        .collect::<Vec<_>>();
+    Tensor::new(data, tensor.shape.clone()).map_err(|err| builtin_error(format!("sawtooth: {err}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::{IntValue, LogicalArray, ResolveContext, Type};
+
+    fn call(t: Value) -> BuiltinResult<Value> {
+        block_on(sawtooth_builtin(t, Vec::new()))
+    }
+
+    fn call_with_xmax(t: Value, xmax: Value) -> BuiltinResult<Value> {
+        block_on(sawtooth_builtin(t, vec![xmax]))
+    }
+
+    fn expect_num(value: Value) -> f64 {
+        match value {
+            Value::Num(v) => v,
+            other => panic!("expected scalar result, got {other:?}"),
+        }
+    }
+
+    fn expect_tensor(value: Value) -> Tensor {
+        match value {
+            Value::Tensor(t) => t,
+            other => panic!("expected tensor result, got {other:?}"),
+        }
+    }
+
+    fn assert_close(got: f64, want: f64) {
+        assert!(
+            (got - want).abs() < 1e-12,
+            "got {got}, expected {want} (diff {})",
+            (got - want).abs()
+        );
+    }
+
+    #[test]
+    fn sawtooth_type_preserves_tensor_shape() {
+        let out = numeric_unary_type(
+            &[Type::Tensor {
+                shape: Some(vec![Some(2), Some(3)]),
+            }],
+            &ResolveContext::new(Vec::new()),
+        );
+        assert_eq!(
+            out,
+            Type::Tensor {
+                shape: Some(vec![Some(2), Some(3)])
+            }
+        );
+    }
+
+    #[test]
+    fn sawtooth_default_is_rising_within_first_period() {
+        assert_close(expect_num(call(Value::Num(0.0)).unwrap()), -1.0);
+        assert_close(expect_num(call(Value::Num(PI / 2.0)).unwrap()), -0.5);
+        assert_close(expect_num(call(Value::Num(PI)).unwrap()), 0.0);
+        assert_close(expect_num(call(Value::Num(3.0 * PI / 2.0)).unwrap()), 0.5);
+    }
+
+    #[test]
+    fn sawtooth_period_boundary_wraps_to_minus_one() {
+        assert_close(expect_num(call(Value::Num(TWO_PI)).unwrap()), -1.0);
+        assert_close(expect_num(call(Value::Num(4.0 * PI)).unwrap()), -1.0);
+        assert_close(expect_num(call(Value::Num(-TWO_PI)).unwrap()), -1.0);
+    }
+
+    #[test]
+    fn sawtooth_negative_time_wraps_into_period() {
+        assert_close(expect_num(call(Value::Num(-PI)).unwrap()), 0.0);
+        assert_close(expect_num(call(Value::Num(-PI / 2.0)).unwrap()), 0.5);
+    }
+
+    #[test]
+    fn sawtooth_vector_two_periods_ranges_from_minus_one_to_just_below_one() {
+        let n: usize = 100;
+        let total = 4.0 * PI;
+        let step = total / (n as f64 - 1.0);
+        let data: Vec<f64> = (0..n).map(|i| i as f64 * step).collect();
+        let tensor = Tensor::new(data.clone(), vec![1, n]).unwrap();
+        let result = expect_tensor(call(Value::Tensor(tensor)).unwrap());
+        assert_eq!(result.shape, vec![1, n]);
+        let min = result.data.iter().cloned().fold(f64::INFINITY, f64::min);
+        let max = result
+            .data
+            .iter()
+            .cloned()
+            .fold(f64::NEG_INFINITY, f64::max);
+        assert!(
+            (-1.0 - 1e-12..=-1.0 + 1e-12).contains(&min),
+            "min should be -1, got {min}"
+        );
+        assert!(
+            max <= 1.0 + 1e-12 && max > 0.95,
+            "max should approach 1 from below, got {max}"
+        );
+        // First and last samples land exactly on period boundaries (t=0 and t=4*pi)
+        // so the rising sawtooth resets to -1 at both ends.
+        assert_close(result.data[0], -1.0);
+        assert_close(*result.data.last().unwrap(), -1.0);
+
+        // Each sample must satisfy the elementwise formula.
+        for (idx, (&t, &y)) in data.iter().zip(result.data.iter()).enumerate() {
+            assert_close(y, sawtooth_scalar(t, 1.0));
+            if !y.is_finite() {
+                panic!("non-finite sample at index {idx}");
+            }
+        }
+
+        // There should be exactly two period boundaries in (0, 4*pi]: the inner
+        // reset near index 50 (sample just after 2*pi) and the closing sample.
+        let reset_count = result
+            .data
+            .iter()
+            .enumerate()
+            .filter(|(idx, &y)| *idx > 0 && y < result.data[idx - 1])
+            .count();
+        assert_eq!(
+            reset_count, 2,
+            "expected two period resets across two periods"
+        );
+    }
+
+    #[test]
+    fn sawtooth_xmax_half_is_triangle_wave_with_peak_at_pi() {
+        let half = Value::Num(0.5);
+        assert_close(
+            expect_num(call_with_xmax(Value::Num(0.0), half.clone()).unwrap()),
+            -1.0,
+        );
+        assert_close(
+            expect_num(call_with_xmax(Value::Num(PI / 2.0), half.clone()).unwrap()),
+            0.0,
+        );
+        assert_close(
+            expect_num(call_with_xmax(Value::Num(PI), half.clone()).unwrap()),
+            1.0,
+        );
+        assert_close(
+            expect_num(call_with_xmax(Value::Num(3.0 * PI / 2.0), half.clone()).unwrap()),
+            0.0,
+        );
+        assert_close(
+            expect_num(call_with_xmax(Value::Num(TWO_PI), half).unwrap()),
+            -1.0,
+        );
+    }
+
+    #[test]
+    fn sawtooth_xmax_zero_is_pure_falling() {
+        let zero = Value::Num(0.0);
+        assert_close(
+            expect_num(call_with_xmax(Value::Num(0.0), zero.clone()).unwrap()),
+            1.0,
+        );
+        assert_close(
+            expect_num(call_with_xmax(Value::Num(PI), zero.clone()).unwrap()),
+            0.0,
+        );
+        assert_close(
+            expect_num(call_with_xmax(Value::Num(TWO_PI), zero).unwrap()),
+            1.0,
+        );
+    }
+
+    #[test]
+    fn sawtooth_xmax_one_is_pure_rising() {
+        let one = Value::Num(1.0);
+        assert_close(
+            expect_num(call_with_xmax(Value::Num(0.0), one.clone()).unwrap()),
+            -1.0,
+        );
+        assert_close(
+            expect_num(call_with_xmax(Value::Num(PI), one.clone()).unwrap()),
+            0.0,
+        );
+        // The default call (no xmax) must agree with the explicit xmax = 1 form.
+        for &t in &[-3.7, -1.0, 0.0, 0.25, PI, 5.5, 9.0] {
+            assert_close(
+                expect_num(call(Value::Num(t)).unwrap()),
+                expect_num(call_with_xmax(Value::Num(t), one.clone()).unwrap()),
+            );
+        }
+    }
+
+    #[test]
+    fn sawtooth_xmax_rejects_out_of_range() {
+        assert!(call_with_xmax(Value::Num(0.0), Value::Num(-0.1)).is_err());
+        assert!(call_with_xmax(Value::Num(0.0), Value::Num(1.1)).is_err());
+        assert!(call_with_xmax(Value::Num(0.0), Value::Num(f64::NAN)).is_err());
+        assert!(call_with_xmax(Value::Num(0.0), Value::Num(f64::INFINITY)).is_err());
+    }
+
+    #[test]
+    fn sawtooth_xmax_rejects_non_scalar() {
+        let tensor = Tensor::new(vec![0.5, 1.0], vec![1, 2]).unwrap();
+        assert!(call_with_xmax(Value::Num(0.0), Value::Tensor(tensor)).is_err());
+    }
+
+    #[test]
+    fn sawtooth_int_and_logical_promote_to_double() {
+        let int_result = expect_num(call(Value::Int(IntValue::I32(0))).unwrap());
+        assert_close(int_result, -1.0);
+
+        let bool_result = expect_num(call(Value::Bool(false)).unwrap());
+        assert_close(bool_result, -1.0);
+
+        let logical = LogicalArray::new(vec![0, 1], vec![1, 2]).unwrap();
+        let result = expect_tensor(call(Value::LogicalArray(logical)).unwrap());
+        assert_eq!(result.shape, vec![1, 2]);
+        assert_close(result.data[0], -1.0);
+        assert_close(result.data[1], sawtooth_scalar(1.0, 1.0));
+    }
+
+    #[test]
+    fn sawtooth_nonfinite_inputs_return_nan() {
+        assert!(expect_num(call(Value::Num(f64::NAN)).unwrap()).is_nan());
+        assert!(expect_num(call(Value::Num(f64::INFINITY)).unwrap()).is_nan());
+        assert!(expect_num(call(Value::Num(f64::NEG_INFINITY)).unwrap()).is_nan());
+    }
+
+    #[test]
+    fn sawtooth_complex_input_errors() {
+        let err = call(Value::Complex(1.0, 2.0)).expect_err("complex sawtooth should error");
+        assert!(err
+            .message()
+            .contains("sawtooth: input must be real; complex values are not supported"));
+    }
+
+    #[test]
+    fn sawtooth_text_input_errors() {
+        let err = call(Value::String("0".into())).expect_err("text sawtooth should error");
+        assert!(err.message().contains("sawtooth: expected numeric input"));
+    }
+
+    #[test]
+    fn sawtooth_preserves_matrix_shape() {
+        let tensor = Tensor::new(vec![0.0, PI / 2.0, PI, 3.0 * PI / 2.0], vec![2, 2]).unwrap();
+        let result = expect_tensor(call(Value::Tensor(tensor)).unwrap());
+        assert_eq!(result.shape, vec![2, 2]);
+        let expected = [-1.0, -0.5, 0.0, 0.5];
+        for (got, want) in result.data.iter().zip(expected) {
+            assert_close(*got, want);
+        }
+    }
+}

--- a/crates/runmat-runtime/src/builtins/math/signal/square.rs
+++ b/crates/runmat-runtime/src/builtins/math/signal/square.rs
@@ -1,0 +1,303 @@
+//! MATLAB-compatible `square` builtin for RunMat.
+//!
+//! `y = square(t)` evaluates a square wave with period `2*pi` at the sample
+//! times in `t`, taking the value `+1` over the first half of each period and
+//! `-1` over the second half. The optional second argument `duty ∈ [0, 100]`
+//! is the duty cycle expressed as a percentage: the output is `+1` over the
+//! first `duty/100 * 2*pi` of every period and `-1` over the remainder.
+
+use std::f64::consts::PI;
+
+use runmat_accelerate_api::GpuTensorHandle;
+use runmat_builtins::{Tensor, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::tensor::{scalar_f64_from_value_async, tensor_into_value};
+use crate::builtins::common::{gpu_helpers, tensor};
+use crate::builtins::math::type_resolvers::numeric_unary_type;
+use crate::{build_runtime_error, BuiltinResult, RuntimeError};
+
+const BUILTIN_NAME: &str = "square";
+const TWO_PI: f64 = 2.0 * PI;
+
+fn builtin_error(message: impl Into<String>) -> RuntimeError {
+    build_runtime_error(message)
+        .with_builtin(BUILTIN_NAME)
+        .build()
+}
+
+/// Element-wise scalar square wave.
+///
+/// Returns `+1` while the reduced phase is strictly less than
+/// `duty/100 * 2π` and `-1` for the remainder of the period. `duty = 0`
+/// therefore degenerates to a constant `-1` and `duty = 100` to a constant
+/// `+1`, matching MATLAB's documented half-open interval convention.
+#[inline]
+fn square_scalar(t: f64, duty: f64) -> f64 {
+    if !t.is_finite() {
+        return f64::NAN;
+    }
+    let phi = t.rem_euclid(TWO_PI);
+    let threshold = duty * TWO_PI / 100.0;
+    if phi < threshold {
+        1.0
+    } else {
+        -1.0
+    }
+}
+
+#[runtime_builtin(
+    name = "square",
+    category = "math/signal",
+    summary = "Generate a periodic square wave with optional duty cycle.",
+    keywords = "square,waveform,signal processing,duty cycle,periodic",
+    type_resolver(numeric_unary_type),
+    builtin_path = "crate::builtins::math::signal::square"
+)]
+async fn square_builtin(t: Value, varargin: Vec<Value>) -> BuiltinResult<Value> {
+    let duty = parse_duty(&varargin).await?;
+    match t {
+        Value::GpuTensor(handle) => square_gpu(handle, duty).await,
+        Value::Complex(_, _) | Value::ComplexTensor(_) => Err(builtin_error(
+            "square: input must be real; complex values are not supported",
+        )),
+        Value::String(_) | Value::StringArray(_) | Value::CharArray(_) => {
+            Err(builtin_error("square: expected numeric input"))
+        }
+        other => square_real(other, duty),
+    }
+}
+
+async fn parse_duty(varargin: &[Value]) -> BuiltinResult<f64> {
+    match varargin.len() {
+        0 => Ok(50.0),
+        1 => {
+            let raw = scalar_f64_from_value_async(&varargin[0])
+                .await
+                .map_err(|err| builtin_error(format!("square: {err}")))?
+                .ok_or_else(|| {
+                    builtin_error("square: duty must be a real numeric scalar in [0, 100]")
+                })?;
+            if !raw.is_finite() || !(0.0..=100.0).contains(&raw) {
+                return Err(builtin_error(format!(
+                    "square: duty must be a finite scalar in [0, 100], got {raw}"
+                )));
+            }
+            Ok(raw)
+        }
+        _ => Err(builtin_error(format!(
+            "square: expected 1 or 2 arguments, got {}",
+            varargin.len() + 1
+        ))),
+    }
+}
+
+async fn square_gpu(handle: GpuTensorHandle, duty: f64) -> BuiltinResult<Value> {
+    let tensor = gpu_helpers::gather_tensor_async(&handle).await?;
+    square_tensor(tensor, duty).map(tensor_into_value)
+}
+
+fn square_real(value: Value, duty: f64) -> BuiltinResult<Value> {
+    let tensor = tensor::value_into_tensor_for(BUILTIN_NAME, value).map_err(builtin_error)?;
+    square_tensor(tensor, duty).map(tensor_into_value)
+}
+
+fn square_tensor(tensor: Tensor, duty: f64) -> BuiltinResult<Tensor> {
+    let data = tensor
+        .data
+        .iter()
+        .map(|&value| square_scalar(value, duty))
+        .collect::<Vec<_>>();
+    Tensor::new(data, tensor.shape.clone()).map_err(|err| builtin_error(format!("square: {err}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::{IntValue, LogicalArray, ResolveContext, Type};
+
+    fn call(t: Value) -> BuiltinResult<Value> {
+        block_on(square_builtin(t, Vec::new()))
+    }
+
+    fn call_with_duty(t: Value, duty: Value) -> BuiltinResult<Value> {
+        block_on(square_builtin(t, vec![duty]))
+    }
+
+    fn expect_num(value: Value) -> f64 {
+        match value {
+            Value::Num(v) => v,
+            other => panic!("expected scalar result, got {other:?}"),
+        }
+    }
+
+    fn expect_tensor(value: Value) -> Tensor {
+        match value {
+            Value::Tensor(t) => t,
+            other => panic!("expected tensor result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn square_type_preserves_tensor_shape() {
+        let out = numeric_unary_type(
+            &[Type::Tensor {
+                shape: Some(vec![Some(2), Some(3)]),
+            }],
+            &ResolveContext::new(Vec::new()),
+        );
+        assert_eq!(
+            out,
+            Type::Tensor {
+                shape: Some(vec![Some(2), Some(3)])
+            }
+        );
+    }
+
+    #[test]
+    fn square_default_is_fifty_percent_duty() {
+        assert_eq!(expect_num(call(Value::Num(0.0)).unwrap()), 1.0);
+        assert_eq!(expect_num(call(Value::Num(PI / 2.0)).unwrap()), 1.0);
+        // The boundary at phi == pi falls into the second half (half-open semantics).
+        assert_eq!(expect_num(call(Value::Num(PI)).unwrap()), -1.0);
+        assert_eq!(expect_num(call(Value::Num(3.0 * PI / 2.0)).unwrap()), -1.0);
+        // A full period wraps back to +1.
+        assert_eq!(expect_num(call(Value::Num(TWO_PI)).unwrap()), 1.0);
+    }
+
+    #[test]
+    fn square_vector_only_contains_plus_or_minus_one() {
+        let n: usize = 64;
+        let step = TWO_PI / (n as f64 - 1.0);
+        let data: Vec<f64> = (0..n).map(|i| i as f64 * step).collect();
+        let tensor = Tensor::new(data.clone(), vec![1, n]).unwrap();
+        let result = expect_tensor(call(Value::Tensor(tensor)).unwrap());
+        assert_eq!(result.shape, vec![1, n]);
+        for (idx, &value) in result.data.iter().enumerate() {
+            assert!(
+                value == 1.0 || value == -1.0,
+                "index {idx}: expected only +-1 values, got {value}"
+            );
+        }
+        // Each sample must agree with the elementwise formula.
+        for (&t, &y) in data.iter().zip(result.data.iter()) {
+            assert_eq!(y, square_scalar(t, 50.0));
+        }
+        // The wave is +1 across the first half period, then -1 across the second
+        // half. The final sample lands on the period boundary (t = 2*pi) and wraps
+        // back to phi = 0 -> +1.
+        assert_eq!(result.data[0], 1.0);
+        let toggle_point = data.iter().position(|&t| t >= PI).unwrap();
+        assert!(result.data[..toggle_point].iter().all(|&v| v == 1.0));
+        assert!(result.data[toggle_point..n - 1].iter().all(|&v| v == -1.0));
+        assert_eq!(*result.data.last().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn square_negative_time_wraps_into_period() {
+        // -pi/2 wraps to 3*pi/2 -> second half -> -1.
+        assert_eq!(expect_num(call(Value::Num(-PI / 2.0)).unwrap()), -1.0);
+        // -3*pi/2 wraps to pi/2 -> first half -> +1.
+        assert_eq!(expect_num(call(Value::Num(-3.0 * PI / 2.0)).unwrap()), 1.0);
+    }
+
+    #[test]
+    fn square_duty_zero_is_constant_minus_one() {
+        for &t in &[0.0, PI / 2.0, PI, 3.0 * PI / 2.0, TWO_PI] {
+            assert_eq!(
+                expect_num(call_with_duty(Value::Num(t), Value::Num(0.0)).unwrap()),
+                -1.0
+            );
+        }
+    }
+
+    #[test]
+    fn square_duty_one_hundred_is_constant_plus_one() {
+        for &t in &[0.0, PI / 2.0, PI, 3.0 * PI / 2.0, TWO_PI - 1e-9] {
+            assert_eq!(
+                expect_num(call_with_duty(Value::Num(t), Value::Num(100.0)).unwrap()),
+                1.0
+            );
+        }
+    }
+
+    #[test]
+    fn square_duty_twenty_five_only_first_quarter_is_positive() {
+        let n: usize = 80;
+        let step = TWO_PI / (n as f64);
+        let data: Vec<f64> = (0..n).map(|i| i as f64 * step).collect();
+        let tensor = Tensor::new(data.clone(), vec![1, n]).unwrap();
+        let result =
+            expect_tensor(call_with_duty(Value::Tensor(tensor), Value::Num(25.0)).unwrap());
+        let threshold = PI / 2.0;
+        for (idx, (&t, &y)) in data.iter().zip(result.data.iter()).enumerate() {
+            let expected = if t < threshold { 1.0 } else { -1.0 };
+            assert_eq!(y, expected, "index {idx}, t={t}");
+        }
+    }
+
+    #[test]
+    fn square_duty_fifty_matches_default_call() {
+        for &t in &[0.0, 0.7, PI - 1e-3, PI, PI + 1e-3, 5.5, -2.0, TWO_PI] {
+            assert_eq!(
+                expect_num(call(Value::Num(t)).unwrap()),
+                expect_num(call_with_duty(Value::Num(t), Value::Num(50.0)).unwrap())
+            );
+        }
+    }
+
+    #[test]
+    fn square_duty_rejects_out_of_range() {
+        assert!(call_with_duty(Value::Num(0.0), Value::Num(-1.0)).is_err());
+        assert!(call_with_duty(Value::Num(0.0), Value::Num(101.0)).is_err());
+        assert!(call_with_duty(Value::Num(0.0), Value::Num(f64::NAN)).is_err());
+        assert!(call_with_duty(Value::Num(0.0), Value::Num(f64::NEG_INFINITY)).is_err());
+    }
+
+    #[test]
+    fn square_duty_rejects_non_scalar() {
+        let tensor = Tensor::new(vec![25.0, 50.0], vec![1, 2]).unwrap();
+        assert!(call_with_duty(Value::Num(0.0), Value::Tensor(tensor)).is_err());
+    }
+
+    #[test]
+    fn square_int_and_logical_promote_to_double() {
+        assert_eq!(expect_num(call(Value::Int(IntValue::I32(0))).unwrap()), 1.0);
+        assert_eq!(expect_num(call(Value::Bool(true)).unwrap()), 1.0);
+
+        let logical = LogicalArray::new(vec![1, 0], vec![1, 2]).unwrap();
+        let result = expect_tensor(call(Value::LogicalArray(logical)).unwrap());
+        assert_eq!(result.shape, vec![1, 2]);
+        assert_eq!(result.data, vec![1.0, 1.0]);
+    }
+
+    #[test]
+    fn square_nonfinite_inputs_return_nan() {
+        assert!(expect_num(call(Value::Num(f64::NAN)).unwrap()).is_nan());
+        assert!(expect_num(call(Value::Num(f64::INFINITY)).unwrap()).is_nan());
+        assert!(expect_num(call(Value::Num(f64::NEG_INFINITY)).unwrap()).is_nan());
+    }
+
+    #[test]
+    fn square_complex_input_errors() {
+        let err = call(Value::Complex(1.0, 2.0)).expect_err("complex square should error");
+        assert!(err
+            .message()
+            .contains("square: input must be real; complex values are not supported"));
+    }
+
+    #[test]
+    fn square_text_input_errors() {
+        let err = call(Value::String("0".into())).expect_err("text square should error");
+        assert!(err.message().contains("square: expected numeric input"));
+    }
+
+    #[test]
+    fn square_preserves_matrix_shape() {
+        let tensor = Tensor::new(vec![0.0, PI / 2.0, PI, 3.0 * PI / 2.0], vec![2, 2]).unwrap();
+        let result = expect_tensor(call(Value::Tensor(tensor)).unwrap());
+        assert_eq!(result.shape, vec![2, 2]);
+        assert_eq!(result.data, vec![1.0, 1.0, -1.0, -1.0]);
+    }
+}

--- a/crates/runmat-turbine/tests/jit.rs
+++ b/crates/runmat-turbine/tests/jit.rs
@@ -1151,12 +1151,15 @@ fn test_jit_mixed_execution_patterns() {
     // Test: Mix of JIT-compiled code and function calls
     let mut engine = TurbineEngine::new().expect("Failed to create engine");
 
-    // Define a function
+    // Define a user-defined helper function. The name intentionally avoids any
+    // existing MATLAB builtin (e.g. `square`, which is a real periodic waveform
+    // builtin) so the dispatch path being tested here cannot be intercepted by
+    // the runtime builtin registry.
     let mut functions = HashMap::new();
     functions.insert(
-        "square".to_string(),
+        "my_square".to_string(),
         runmat_vm::UserFunction {
-            name: "square".to_string(),
+            name: "my_square".to_string(),
             params: vec![runmat_hir::VarId(0)],
             outputs: vec![runmat_hir::VarId(1)],
             body: vec![runmat_hir::HirStmt::Assign(
@@ -1202,9 +1205,9 @@ fn test_jit_mixed_execution_patterns() {
                 Instr::LoadConst(3.0),
                 Instr::Add,
                 Instr::StoreVar(1),
-                // Function call: z = square(y) = 64
+                // Function call: z = my_square(y) = 64
                 Instr::LoadVar(1),
-                Instr::CallFunction("square".to_string(), 1),
+                Instr::CallFunction("my_square".to_string(), 1),
                 Instr::StoreVar(2),
                 // JIT-able: result = z + 10 = 74
                 Instr::LoadVar(2),
@@ -1225,7 +1228,7 @@ fn test_jit_mixed_execution_patterns() {
     // Verify results
     assert_eq!(vars[0], Value::Num(5.0), "x should be 5");
     assert_eq!(vars[1], Value::Num(8.0), "y should be 8");
-    assert_eq!(vars[2], Value::Num(64.0), "z should be square(8) = 64");
+    assert_eq!(vars[2], Value::Num(64.0), "z should be my_square(8) = 64");
     assert_eq!(vars[3], Value::Num(74.0), "result should be 64 + 10 = 74");
 }
 


### PR DESCRIPTION
Implements MATLAB-compatible sawtooth(t[, xmax]) and square(t[, duty]) periodic waveform generators in math/signal/. Both accept scalar and array inputs with elementwise broadcasting, reduce input modulo 2*pi, and use the standard MATLAB piecewise-linear / duty-cycle formulas. NaN/Inf inputs propagate to NaN as in MATLAB.

Renames a user-defined helper in test_jit_mixed_execution_patterns from "square" to "my_square" to avoid colliding with the new builtin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new runtime builtins and updates builtin dispatch surface area; while self-contained, incorrect edge-case semantics (period boundaries, arg validation, GPU gather path) could cause user-visible numerical differences.
> 
> **Overview**
> **Adds new signal-processing builtins**: implements MATLAB-compatible `sawtooth(t[, xmax])` and `square(t[, duty])` as elementwise operations over tensors, including modulo-`2*pi` periodicity, strict scalar validation for the optional parameter, and NaN/Inf propagation.
> 
> **Integration & docs**: registers the modules in `math/signal/mod.rs`, adds builtin metadata JSON docs for both functions, and updates a Turbine JIT mixed-execution test to rename a user-defined `square` helper to `my_square` to avoid colliding with the new builtin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b82f319f63d93a3c78044f45386f7dfbfaa71d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->