### PR TITLE
Implemented nyquist builtin

### DIFF
--- a/crates/runmat-runtime/LIBRARY.md
+++ b/crates/runmat-runtime/LIBRARY.md
@@ -65,6 +65,13 @@
 |-----------|------------|--------------------------------------------------|-------------------|-----|--------|------------------|----------------------------------------|
 |     ✅    | math/poly  | polyval, polyfit, roots, polyder, polyint        | Poly utilities    | —   | P      | LAPACK (QR)      | polyfit via least squares (\/QR).      |
 
+## Control systems
+
+| Completed | Path    | Name(s)                    | Purpose                         | GPU | Fusion | BLAS/LAPACK/FFTs | Notes                                                   |
+|-----------|---------|----------------------------|---------------------------------|-----|--------|------------------|---------------------------------------------------------|
+|     ✅     | control | tf                         | Transfer-function models        | —   | —      | —                | SISO metadata object; gathers coefficient inputs.       |
+|     ✅     | control | step, impulse, nyquist     | Time and frequency responses    | —   | —      | —                | Host-side response evaluation with GPU residency specs. |
+
 ## Statistics (core)
 
 | Completed | Path           | Name(s)                | Purpose                    | GPU | Fusion | BLAS/LAPACK/FFTs | Notes                                 |

--- a/crates/runmat-runtime/src/builtins/builtins-json/nyquist.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/nyquist.json
@@ -11,8 +11,10 @@
   ],
   "summary": "Compute or plot the Nyquist frequency response of a SISO transfer-function model.",
   "references": [
-    "title: \"MATLAB nyquist documentation\"",
-    "url: \"https://www.mathworks.com/help/control/ref/dynamicsystem.nyquist.html\""
+    {
+      "title": "MATLAB nyquist documentation",
+      "url": "https://www.mathworks.com/help/control/ref/dynamicsystem.nyquist.html"
+    }
   ],
   "gpu_support": {
     "elementwise": false,

--- a/crates/runmat-runtime/src/builtins/builtins-json/nyquist.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/nyquist.json
@@ -1,0 +1,113 @@
+{
+  "title": "nyquist",
+  "category": "control",
+  "keywords": [
+    "nyquist",
+    "nyquist plot",
+    "frequency response",
+    "control system",
+    "transfer function",
+    "tf"
+  ],
+  "summary": "Compute or plot the Nyquist frequency response of a SISO transfer-function model.",
+  "references": [
+    "title: \"MATLAB nyquist documentation\"",
+    "url: \"https://www.mathworks.com/help/control/ref/dynamicsystem.nyquist.html\""
+  ],
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [],
+    "broadcasting": "none",
+    "notes": "`nyquist` evaluates host-side control-system metadata and returns host-resident response vectors. It registers a GPU residency policy so gpuArray coefficient inputs are gathered before metadata evaluation."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 0,
+    "constants": "inline",
+    "notes": "`nyquist` materialises frequency-response vectors and terminates numeric fusion chains."
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::control::nyquist::tests",
+    "integration": "crates/runmat-vm/tests/control.rs"
+  },
+  "description": "`nyquist(sys)` plots a Nyquist diagram for a supported SISO `tf` object. `[re, im, w] = nyquist(sys)` returns the real part, imaginary part, and frequency vector. `nyquist(sys, w)` evaluates the response at an explicit vector of frequencies in radians per time unit.",
+  "behaviors": [
+    "Supports SISO `tf` objects created by `tf(num, den)` or `tf(num, den, Ts)`.",
+    "Continuous-time models are evaluated as `H(j*w)`.",
+    "Discrete-time models are evaluated on the unit circle as `H(exp(j*w*Ts))`.",
+    "When `w` is omitted, continuous-time models use a deterministic logarithmic frequency grid based on transfer-function poles and zeros.",
+    "When `w` is omitted, discrete-time models use a deterministic grid from zero to the Nyquist frequency `pi/Ts`.",
+    "`[re, im] = nyquist(sys, w)` returns real and imaginary response column vectors.",
+    "`[re, im, wout] = nyquist(sys, w)` returns three same-length column vectors.",
+    "No-output calls plot the positive-frequency curve and mirror the negative-frequency curve for real-coefficient systems.",
+    "Input/output delays and non-`tf` model classes raise clear diagnostics in this implementation."
+  ],
+  "examples": [
+    {
+      "description": "Compute response data at explicit frequencies",
+      "input": "H = tf(1, [1 1]);\nw = [0 1 2];\n[re, im, wout] = nyquist(H, w);\nfprintf(\"%.1f %.1f %.1f %.1f\\n\", re(1), re(2), im(2), wout(3));",
+      "output": "1.0 0.5 -0.5 2.0"
+    },
+    {
+      "description": "Plot a Nyquist diagram",
+      "input": "H = tf(1, [1 2 1]);\nnyquist(H);\nfprintf(\"ok\\n\");",
+      "output": "ok"
+    },
+    {
+      "description": "Discrete-time frequency response",
+      "input": "H = tf(1, [1 -0.5], 0.1);\n[re, im] = nyquist(H, 0:0.5:5);\nfprintf(\"%.1f %.1f\\n\", re(1), im(1));",
+      "output": "2.0 0.0"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Does `nyquist` support MIMO systems?",
+      "answer": "Not yet. The current implementation supports SISO transfer-function objects."
+    },
+    {
+      "question": "Does `nyquist` support state-space models?",
+      "answer": "Not yet. `ss`, `zpk`, `frd`, model arrays, and identified-system families are outside this first implementation."
+    },
+    {
+      "question": "Does `nyquist` run on the GPU?",
+      "answer": "The frequency-response calculation runs on the host from model metadata. The builtin is registered with GPU/fusion metadata as a residency sink so GPU-backed coefficient inputs are gathered predictably before evaluation."
+    }
+  ],
+  "links": [
+    {
+      "label": "tf",
+      "url": "./tf"
+    },
+    {
+      "label": "plot",
+      "url": "./plot"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/control/nyquist.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/control/nyquist.rs"
+  },
+  "syntax": {
+    "example": {
+      "description": "Supported forms",
+      "input": "nyquist(sys)\nnyquist(sys, w)\nre = nyquist(sys, w)\n[re, im] = nyquist(sys, w)\n[re, im, wout] = nyquist(sys)\n[re, im, wout] = nyquist(sys, w)",
+      "output": "Response data is returned when outputs are requested; otherwise a Nyquist plot is rendered."
+    },
+    "points": [
+      "`sys` must currently be a SISO `tf` object.",
+      "`w` must be a real vector of finite non-negative frequencies.",
+      "`re`, `im`, and `wout` are returned as `N x 1` column vectors."
+    ]
+  },
+  "validation": {
+    "summary": "`nyquist` validates object class, coefficient type and shape, delay properties, sample time, denominator singularities, and frequency-vector inputs before evaluating the transfer-function response. Tests cover continuous and discrete responses, multi-output shapes, plotting smoke, complex coefficients, VM dispatch, and representative diagnostics.",
+    "implementation": {
+      "label": "`crates/runmat-runtime/src/builtins/control/nyquist.rs`",
+      "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/control/nyquist.rs"
+    }
+  },
+  "gpu_residency": "`nyquist` returns host-resident response vectors. It does not preserve gpuArray residency."
+}

--- a/crates/runmat-runtime/src/builtins/control/mod.rs
+++ b/crates/runmat-runtime/src/builtins/control/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod db;
 pub mod impulse;
+pub mod nyquist;
 pub mod step;
 pub mod tf;
 pub(crate) mod type_resolvers;

--- a/crates/runmat-runtime/src/builtins/control/mod.rs
+++ b/crates/runmat-runtime/src/builtins/control/mod.rs
@@ -1,8 +1,18 @@
 //! Control System Toolbox builtins.
 
+use crate::RuntimeError;
+
 pub mod db;
 pub mod impulse;
 pub mod nyquist;
 pub mod step;
 pub mod tf;
 pub(crate) mod type_resolvers;
+
+fn is_nonfatal_plot_setup_error(err: &RuntimeError) -> bool {
+    let lower = err.to_string().to_ascii_lowercase();
+    lower.contains("plotting is unavailable")
+        || lower.contains("non-main thread")
+        || lower.contains("interactive plotting failed")
+        || lower.contains("eventloop can't be recreated")
+}

--- a/crates/runmat-runtime/src/builtins/control/nyquist.rs
+++ b/crates/runmat-runtime/src/builtins/control/nyquist.rs
@@ -1,0 +1,677 @@
+//! MATLAB-compatible `nyquist` frequency-response builtin for supported control models.
+
+use nalgebra::DMatrix;
+use num_complex::Complex64;
+use runmat_builtins::{ObjectInstance, Tensor, Value};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ShapeRequirements,
+};
+use crate::builtins::control::type_resolvers::nyquist_type;
+use crate::{build_runtime_error, BuiltinResult, RuntimeError};
+
+const BUILTIN_NAME: &str = "nyquist";
+const TF_CLASS: &str = "tf";
+const EPS: f64 = 1.0e-12;
+const DEFAULT_FREQUENCY_POINTS: usize = 200;
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::control::nyquist")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: "nyquist",
+    op_kind: GpuOpKind::Custom("control-nyquist-frequency-response"),
+    supported_precisions: &[],
+    broadcast: BroadcastSemantics::None,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::GatherImmediately,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "Nyquist frequency-response evaluation runs on the host from transfer-function metadata. GPU-resident coefficient inputs are gathered by tf before model construction.",
+};
+
+#[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::control::nyquist")]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: "nyquist",
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: false,
+    notes: "nyquist materialises host response vectors and terminates numeric fusion chains.",
+};
+
+fn nyquist_error(message: impl Into<String>) -> RuntimeError {
+    build_runtime_error(message)
+        .with_builtin(BUILTIN_NAME)
+        .build()
+}
+
+#[runtime_builtin(
+    name = "nyquist",
+    category = "control",
+    summary = "Compute or plot the Nyquist frequency response of a SISO transfer-function model.",
+    keywords = "nyquist,frequency response,control system,transfer function,tf",
+    sink = true,
+    suppress_auto_output = true,
+    type_resolver(nyquist_type),
+    builtin_path = "crate::builtins::control::nyquist"
+)]
+async fn nyquist_builtin(system: Value, rest: Vec<Value>) -> BuiltinResult<Value> {
+    if rest.len() > 1 {
+        return Err(nyquist_error(
+            "nyquist: expected nyquist(sys) or nyquist(sys, w)",
+        ));
+    }
+
+    let system = TfSystem::parse(system).await?;
+    let frequencies = FrequencySpec::parse(&system, rest.first()).await?;
+    let response = evaluate_nyquist(&system, frequencies)?;
+
+    if let Some(out_count) = crate::output_count::current_output_count() {
+        if out_count == 0 {
+            render_nyquist_plot(&response).await?;
+            return Ok(Value::OutputList(Vec::new()));
+        }
+        if out_count == 1 {
+            return Ok(Value::OutputList(vec![response.re_value()?]));
+        }
+        if out_count == 2 {
+            return Ok(Value::OutputList(vec![
+                response.re_value()?,
+                response.im_value()?,
+            ]));
+        }
+        return Ok(crate::output_count::output_list_with_padding(
+            out_count,
+            response.outputs()?,
+        ));
+    }
+
+    if crate::output_context::requested_output_count() == Some(0) {
+        render_nyquist_plot(&response).await?;
+        return Ok(Value::OutputList(Vec::new()));
+    }
+
+    response.re_value()
+}
+
+#[derive(Clone, Debug)]
+struct TfSystem {
+    numerator: Vec<Complex64>,
+    denominator: Vec<Complex64>,
+    sample_time: f64,
+    is_real: bool,
+}
+
+impl TfSystem {
+    async fn parse(value: Value) -> BuiltinResult<Self> {
+        let gathered = crate::dispatcher::gather_if_needed_async(&value).await?;
+        let Value::Object(object) = gathered else {
+            return Err(nyquist_error(format!(
+                "nyquist: expected a dynamic system model, got {gathered:?}"
+            )));
+        };
+        if object.class_name != TF_CLASS {
+            return Err(nyquist_error(format!(
+                "nyquist: unsupported model class '{}'; only SISO tf objects are currently supported",
+                object.class_name
+            )));
+        }
+
+        let numerator = coefficients(property(&object, "Numerator")?, "Numerator")?;
+        let denominator = coefficients(property(&object, "Denominator")?, "Denominator")?;
+        let sample_time = scalar_property(property(&object, "Ts")?, "Ts")?;
+        let input_delay = scalar_property(property(&object, "InputDelay")?, "InputDelay")?;
+        let output_delay = scalar_property(property(&object, "OutputDelay")?, "OutputDelay")?;
+
+        if !sample_time.is_finite() || sample_time < 0.0 {
+            return Err(nyquist_error(format!(
+                "nyquist: Ts must be a finite non-negative scalar, got {sample_time}"
+            )));
+        }
+        if !input_delay.is_finite() || input_delay < 0.0 {
+            return Err(nyquist_error(format!(
+                "nyquist: InputDelay must be a finite non-negative scalar, got {input_delay}"
+            )));
+        }
+        if !output_delay.is_finite() || output_delay < 0.0 {
+            return Err(nyquist_error(format!(
+                "nyquist: OutputDelay must be a finite non-negative scalar, got {output_delay}"
+            )));
+        }
+        if input_delay.abs() > EPS || output_delay.abs() > EPS {
+            return Err(nyquist_error(
+                "nyquist: transfer functions with input or output delays are not supported yet",
+            ));
+        }
+
+        let numerator = trim_leading_zeros(numerator);
+        let denominator = trim_leading_zeros(denominator);
+        if denominator.is_empty() {
+            return Err(nyquist_error(
+                "nyquist: denominator coefficients cannot be empty",
+            ));
+        }
+        if denominator[0].norm() <= EPS {
+            return Err(nyquist_error(
+                "nyquist: leading denominator coefficient must be non-zero",
+            ));
+        }
+
+        let is_real = numerator
+            .iter()
+            .chain(&denominator)
+            .all(|value| value.im.abs() <= EPS);
+        Ok(Self {
+            numerator,
+            denominator,
+            sample_time,
+            is_real,
+        })
+    }
+
+    fn is_discrete(&self) -> bool {
+        self.sample_time > 0.0
+    }
+}
+
+fn property<'a>(object: &'a ObjectInstance, name: &str) -> BuiltinResult<&'a Value> {
+    object
+        .properties
+        .get(name)
+        .ok_or_else(|| nyquist_error(format!("nyquist: tf object is missing {name} property")))
+}
+
+fn coefficients(value: &Value, label: &str) -> BuiltinResult<Vec<Complex64>> {
+    match value {
+        Value::Tensor(tensor) => {
+            ensure_vector(label, &tensor.shape)?;
+            finite_complex_values(
+                label,
+                tensor
+                    .data
+                    .iter()
+                    .map(|&value| Complex64::new(value, 0.0))
+                    .collect(),
+            )
+        }
+        Value::ComplexTensor(tensor) => {
+            ensure_vector(label, &tensor.shape)?;
+            finite_complex_values(
+                label,
+                tensor
+                    .data
+                    .iter()
+                    .map(|&(re, im)| Complex64::new(re, im))
+                    .collect(),
+            )
+        }
+        Value::Num(n) => finite_complex_values(label, vec![Complex64::new(*n, 0.0)]),
+        Value::Int(i) => finite_complex_values(label, vec![Complex64::new(i.to_f64(), 0.0)]),
+        Value::Bool(b) => {
+            finite_complex_values(label, vec![Complex64::new(if *b { 1.0 } else { 0.0 }, 0.0)])
+        }
+        Value::Complex(re, im) => finite_complex_values(label, vec![Complex64::new(*re, *im)]),
+        other => Err(nyquist_error(format!(
+            "nyquist: {label} must be a numeric coefficient vector, got {other:?}"
+        ))),
+    }
+}
+
+fn finite_complex_values(label: &str, values: Vec<Complex64>) -> BuiltinResult<Vec<Complex64>> {
+    if values
+        .iter()
+        .any(|value| !value.re.is_finite() || !value.im.is_finite())
+    {
+        return Err(nyquist_error(format!(
+            "nyquist: {label} coefficients must be finite"
+        )));
+    }
+    Ok(values)
+}
+
+fn ensure_vector(label: &str, shape: &[usize]) -> BuiltinResult<()> {
+    let non_unit = shape.iter().copied().filter(|&dim| dim > 1).count();
+    if non_unit <= 1 {
+        Ok(())
+    } else {
+        Err(nyquist_error(format!(
+            "nyquist: {label} coefficients must be a vector"
+        )))
+    }
+}
+
+fn scalar_property(value: &Value, label: &str) -> BuiltinResult<f64> {
+    match value {
+        Value::Num(n) => Ok(*n),
+        Value::Int(i) => Ok(i.to_f64()),
+        Value::Bool(b) => Ok(if *b { 1.0 } else { 0.0 }),
+        Value::Tensor(tensor) if tensor.data.len() == 1 => Ok(tensor.data[0]),
+        other => Err(nyquist_error(format!(
+            "nyquist: {label} must be a real scalar, got {other:?}"
+        ))),
+    }
+}
+
+#[derive(Clone, Debug)]
+enum FrequencySpec {
+    Values(Vec<f64>),
+}
+
+impl FrequencySpec {
+    async fn parse(system: &TfSystem, value: Option<&Value>) -> BuiltinResult<Self> {
+        let Some(value) = value else {
+            return Ok(Self::Values(default_frequency_vector(system)));
+        };
+        let gathered = crate::dispatcher::gather_if_needed_async(value).await?;
+        let tensor = frequency_tensor_from_value(gathered)?;
+        ensure_vector("frequency", &tensor.shape)?;
+        validate_frequency_vector(&tensor.data)?;
+        Ok(Self::Values(tensor.data))
+    }
+}
+
+fn frequency_tensor_from_value(value: Value) -> BuiltinResult<Tensor> {
+    match value {
+        Value::Tensor(tensor) => Ok(tensor),
+        Value::Num(n) => {
+            Tensor::new(vec![n], vec![1, 1]).map_err(|err| nyquist_error(format!("nyquist: {err}")))
+        }
+        Value::Int(i) => Tensor::new(vec![i.to_f64()], vec![1, 1])
+            .map_err(|err| nyquist_error(format!("nyquist: {err}"))),
+        Value::Bool(b) => Tensor::new(vec![if b { 1.0 } else { 0.0 }], vec![1, 1])
+            .map_err(|err| nyquist_error(format!("nyquist: {err}"))),
+        other => Err(nyquist_error(format!(
+            "nyquist: frequency input must be a real numeric vector, got {other:?}"
+        ))),
+    }
+}
+
+fn validate_frequency_vector(values: &[f64]) -> BuiltinResult<()> {
+    if values.is_empty() {
+        return Err(nyquist_error("nyquist: frequency vector cannot be empty"));
+    }
+    if values
+        .iter()
+        .any(|value| !value.is_finite() || *value < 0.0)
+    {
+        return Err(nyquist_error(
+            "nyquist: frequency values must be finite and non-negative",
+        ));
+    }
+    Ok(())
+}
+
+fn default_frequency_vector(system: &TfSystem) -> Vec<f64> {
+    if system.is_discrete() {
+        return linspace(
+            0.0,
+            std::f64::consts::PI / system.sample_time,
+            DEFAULT_FREQUENCY_POINTS,
+        );
+    }
+
+    let mut breakpoints = Vec::new();
+    for coeffs in [&system.numerator, &system.denominator] {
+        if let Ok(roots) = polynomial_roots(coeffs) {
+            breakpoints.extend(
+                roots
+                    .into_iter()
+                    .map(|root| root.norm())
+                    .filter(|value| value.is_finite() && *value > EPS),
+            );
+        }
+    }
+
+    if breakpoints.is_empty() {
+        return logspace(-2.0, 2.0, DEFAULT_FREQUENCY_POINTS);
+    }
+
+    let min_w = breakpoints.iter().copied().fold(f64::INFINITY, f64::min);
+    let max_w = breakpoints.iter().copied().fold(0.0, f64::max);
+    let start = (min_w / 100.0).max(1.0e-4);
+    let stop = (max_w * 100.0).max(start * 10.0);
+    logspace(start.log10(), stop.log10(), DEFAULT_FREQUENCY_POINTS)
+}
+
+#[derive(Clone, Debug)]
+struct NyquistResponse {
+    re: Vec<f64>,
+    im: Vec<f64>,
+    w: Vec<f64>,
+    mirror_negative_frequency: bool,
+}
+
+impl NyquistResponse {
+    fn re_value(&self) -> BuiltinResult<Value> {
+        column_tensor(self.re.clone())
+    }
+
+    fn im_value(&self) -> BuiltinResult<Value> {
+        column_tensor(self.im.clone())
+    }
+
+    fn w_value(&self) -> BuiltinResult<Value> {
+        column_tensor(self.w.clone())
+    }
+
+    fn outputs(&self) -> BuiltinResult<Vec<Value>> {
+        Ok(vec![self.re_value()?, self.im_value()?, self.w_value()?])
+    }
+}
+
+fn evaluate_nyquist(
+    system: &TfSystem,
+    frequencies: FrequencySpec,
+) -> BuiltinResult<NyquistResponse> {
+    let FrequencySpec::Values(w) = frequencies;
+    let mut re = Vec::with_capacity(w.len());
+    let mut im = Vec::with_capacity(w.len());
+    for &frequency in &w {
+        let point = if system.is_discrete() {
+            let phase = frequency * system.sample_time;
+            Complex64::new(phase.cos(), phase.sin())
+        } else {
+            Complex64::new(0.0, frequency)
+        };
+        let value = transfer_response(system, point)?;
+        re.push(zero_small(value.re));
+        im.push(zero_small(value.im));
+    }
+    Ok(NyquistResponse {
+        re,
+        im,
+        w,
+        mirror_negative_frequency: system.is_real,
+    })
+}
+
+fn transfer_response(system: &TfSystem, point: Complex64) -> BuiltinResult<Complex64> {
+    let numerator = polynomial_eval(&system.numerator, point);
+    let denominator = polynomial_eval(&system.denominator, point);
+    if denominator.norm() <= EPS {
+        return Err(nyquist_error(
+            "nyquist: frequency response is singular at one or more requested frequencies",
+        ));
+    }
+    Ok(numerator / denominator)
+}
+
+fn polynomial_eval(coeffs: &[Complex64], point: Complex64) -> Complex64 {
+    let mut acc = Complex64::new(0.0, 0.0);
+    for &coeff in coeffs {
+        acc = acc * point + coeff;
+    }
+    acc
+}
+
+fn polynomial_roots(coeffs: &[Complex64]) -> BuiltinResult<Vec<Complex64>> {
+    let trimmed = trim_leading_zeros(coeffs.to_vec());
+    if trimmed.len() <= 1 {
+        return Ok(Vec::new());
+    }
+    if trimmed.len() == 2 {
+        return Ok(vec![-trimmed[1] / trimmed[0]]);
+    }
+
+    let degree = trimmed.len() - 1;
+    let leading = trimmed[0];
+    let mut companion = DMatrix::<Complex64>::zeros(degree, degree);
+    for row in 1..degree {
+        companion[(row, row - 1)] = Complex64::new(1.0, 0.0);
+    }
+    for (idx, coeff) in trimmed.iter().enumerate().skip(1) {
+        companion[(0, idx - 1)] = -*coeff / leading;
+    }
+    let eigenvalues = companion
+        .eigenvalues()
+        .ok_or_else(|| nyquist_error("nyquist: failed to compute transfer-function roots"))?;
+    Ok(eigenvalues.iter().copied().collect())
+}
+
+fn trim_leading_zeros(values: Vec<Complex64>) -> Vec<Complex64> {
+    let first = values.iter().position(|value| value.norm() > EPS);
+    match first {
+        Some(idx) => values[idx..].to_vec(),
+        None => Vec::new(),
+    }
+}
+
+async fn render_nyquist_plot(response: &NyquistResponse) -> BuiltinResult<()> {
+    let mut args = vec![response.re_value()?, response.im_value()?];
+    if response.mirror_negative_frequency {
+        let negative_im = response.im.iter().map(|value| -*value).collect::<Vec<_>>();
+        args.push(response.re_value()?);
+        args.push(column_tensor(negative_im)?);
+    }
+
+    if let Some((&re0, &im0)) = response.re.first().zip(response.im.first()) {
+        args.push(column_tensor(vec![re0])?);
+        args.push(column_tensor(vec![im0])?);
+        args.push(Value::from("x"));
+        if response.mirror_negative_frequency {
+            args.push(column_tensor(vec![re0])?);
+            args.push(column_tensor(vec![-im0])?);
+            args.push(Value::from("o"));
+        }
+    }
+
+    if let Err(err) = crate::call_builtin_async("plot", &args).await {
+        if is_nonfatal_plot_setup_error(&err) {
+            return Ok(());
+        }
+        return Err(err);
+    }
+    let _ = crate::call_builtin_async("title", &[Value::from("Nyquist Diagram")]).await;
+    let _ = crate::call_builtin_async("xlabel", &[Value::from("Real Axis")]).await;
+    let _ = crate::call_builtin_async("ylabel", &[Value::from("Imaginary Axis")]).await;
+    let _ = crate::call_builtin_async("grid", &[Value::from("on")]).await;
+    Ok(())
+}
+
+fn is_nonfatal_plot_setup_error(err: &RuntimeError) -> bool {
+    let lower = err.to_string().to_ascii_lowercase();
+    lower.contains("plotting is unavailable")
+        || lower.contains("unknown builtin")
+        || lower.contains("non-main thread")
+        || lower.contains("interactive plotting failed")
+        || lower.contains("eventloop can't be recreated")
+}
+
+fn column_tensor(data: Vec<f64>) -> BuiltinResult<Value> {
+    let rows = data.len();
+    let tensor =
+        Tensor::new(data, vec![rows, 1]).map_err(|err| nyquist_error(format!("nyquist: {err}")))?;
+    Ok(Value::Tensor(tensor))
+}
+
+fn linspace(start: f64, stop: f64, count: usize) -> Vec<f64> {
+    if count <= 1 {
+        return vec![start];
+    }
+    let step = (stop - start) / ((count - 1) as f64);
+    (0..count).map(|idx| start + idx as f64 * step).collect()
+}
+
+fn logspace(start_exp: f64, stop_exp: f64, count: usize) -> Vec<f64> {
+    linspace(start_exp, stop_exp, count)
+        .into_iter()
+        .map(|value| 10.0_f64.powf(value))
+        .collect()
+}
+
+fn zero_small(value: f64) -> f64 {
+    if value.abs() <= EPS {
+        0.0
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use runmat_builtins::{CharArray, ComplexTensor};
+
+    fn tf_object(num: Vec<f64>, den: Vec<f64>, ts: f64) -> Value {
+        let mut object = ObjectInstance::new("tf".to_string());
+        object.properties.insert(
+            "Numerator".to_string(),
+            Value::Tensor(Tensor::new(num.clone(), vec![1, num.len()]).unwrap()),
+        );
+        object.properties.insert(
+            "Denominator".to_string(),
+            Value::Tensor(Tensor::new(den.clone(), vec![1, den.len()]).unwrap()),
+        );
+        object.properties.insert(
+            "Variable".to_string(),
+            Value::CharArray(CharArray::new_row(if ts > 0.0 { "z" } else { "s" })),
+        );
+        object.properties.insert("Ts".to_string(), Value::Num(ts));
+        object
+            .properties
+            .insert("InputDelay".to_string(), Value::Num(0.0));
+        object
+            .properties
+            .insert("OutputDelay".to_string(), Value::Num(0.0));
+        Value::Object(object)
+    }
+
+    fn run_nyquist(system: Value, rest: Vec<Value>) -> BuiltinResult<Value> {
+        block_on(nyquist_builtin(system, rest))
+    }
+
+    fn tensor_data(value: Value) -> Vec<f64> {
+        match value {
+            Value::Tensor(tensor) => tensor.data,
+            other => panic!("expected tensor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nyquist_first_order_continuous_explicit_frequency() {
+        let sys = tf_object(vec![1.0], vec![1.0, 1.0], 0.0);
+        let w = Value::Tensor(Tensor::new(vec![0.0, 1.0, 2.0], vec![1, 3]).unwrap());
+        let _guard = crate::output_count::push_output_count(Some(3));
+        let result = run_nyquist(sys, vec![w]).expect("nyquist");
+        let Value::OutputList(outputs) = result else {
+            panic!("expected output list");
+        };
+        let re = tensor_data(outputs[0].clone());
+        let im = tensor_data(outputs[1].clone());
+        let w_out = tensor_data(outputs[2].clone());
+        let expected_re = [1.0, 0.5, 0.2];
+        let expected_im = [0.0, -0.5, -0.4];
+        for ((actual_re, actual_im), (expected_re, expected_im)) in re
+            .iter()
+            .zip(&im)
+            .zip(expected_re.into_iter().zip(expected_im))
+        {
+            assert!((actual_re - expected_re).abs() < 1.0e-12);
+            assert!((actual_im - expected_im).abs() < 1.0e-12);
+        }
+        assert_eq!(w_out, vec![0.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn nyquist_two_outputs_returns_real_and_imaginary_columns() {
+        let sys = tf_object(vec![1.0], vec![1.0, 2.0, 1.0], 0.0);
+        let w = Value::Tensor(Tensor::new(vec![0.0, 1.0], vec![2, 1]).unwrap());
+        let _guard = crate::output_count::push_output_count(Some(2));
+        let result = run_nyquist(sys, vec![w]).expect("nyquist");
+        let Value::OutputList(outputs) = result else {
+            panic!("expected output list");
+        };
+        assert_eq!(outputs.len(), 2);
+        match &outputs[0] {
+            Value::Tensor(tensor) => assert_eq!(tensor.shape, vec![2, 1]),
+            other => panic!("expected real tensor, got {other:?}"),
+        }
+        let re = tensor_data(outputs[0].clone());
+        let im = tensor_data(outputs[1].clone());
+        assert!((re[0] - 1.0).abs() < 1.0e-12);
+        assert!(im[0].abs() < 1.0e-12);
+        assert!(re[1].abs() < 1.0e-12);
+        assert!((im[1] + 0.5).abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn nyquist_discrete_uses_unit_circle_frequency_mapping() {
+        let sys = tf_object(vec![1.0], vec![1.0, -0.5], 0.1);
+        let w = Value::Tensor(Tensor::new(vec![0.0], vec![1, 1]).unwrap());
+        let _guard = crate::output_count::push_output_count(Some(2));
+        let result = run_nyquist(sys, vec![w]).expect("nyquist");
+        let Value::OutputList(outputs) = result else {
+            panic!("expected output list");
+        };
+        let re = tensor_data(outputs[0].clone());
+        let im = tensor_data(outputs[1].clone());
+        assert!((re[0] - 2.0).abs() < 1.0e-12);
+        assert!(im[0].abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn nyquist_statement_form_plots_without_error() {
+        let sys = tf_object(vec![1.0], vec![1.0, 2.0, 1.0], 0.0);
+        let _guard = crate::output_count::push_output_count(Some(0));
+        let result = run_nyquist(sys, Vec::new()).expect("nyquist");
+        assert!(matches!(result, Value::OutputList(outputs) if outputs.is_empty()));
+    }
+
+    #[test]
+    fn nyquist_rejects_invalid_frequency_vector() {
+        let sys = tf_object(vec![1.0], vec![1.0, 1.0], 0.0);
+        let w = Value::Tensor(Tensor::new(vec![0.0, f64::INFINITY], vec![1, 2]).unwrap());
+        let err = run_nyquist(sys, vec![w]).expect_err("should fail");
+        assert!(err.message().contains("frequency values must be finite"));
+    }
+
+    #[test]
+    fn nyquist_rejects_unsupported_model_type() {
+        let object = ObjectInstance::new("ss".to_string());
+        let err = run_nyquist(Value::Object(object), Vec::new()).expect_err("should fail");
+        assert!(err.message().contains("unsupported model class"));
+    }
+
+    #[test]
+    fn nyquist_complex_coefficients_are_supported() {
+        let mut object = ObjectInstance::new("tf".to_string());
+        object.properties.insert(
+            "Numerator".to_string(),
+            Value::ComplexTensor(
+                ComplexTensor::new(vec![(1.0, 1.0)], vec![1, 1]).expect("numerator"),
+            ),
+        );
+        object.properties.insert(
+            "Denominator".to_string(),
+            Value::Tensor(Tensor::new(vec![1.0, 1.0], vec![1, 2]).unwrap()),
+        );
+        object.properties.insert(
+            "Variable".to_string(),
+            Value::CharArray(CharArray::new_row("s")),
+        );
+        object.properties.insert("Ts".to_string(), Value::Num(0.0));
+        object
+            .properties
+            .insert("InputDelay".to_string(), Value::Num(0.0));
+        object
+            .properties
+            .insert("OutputDelay".to_string(), Value::Num(0.0));
+
+        let w = Value::Tensor(Tensor::new(vec![0.0], vec![1, 1]).unwrap());
+        let _guard = crate::output_count::push_output_count(Some(2));
+        let result = run_nyquist(Value::Object(object), vec![w]).expect("nyquist");
+        let Value::OutputList(outputs) = result else {
+            panic!("expected output list");
+        };
+        let re = tensor_data(outputs[0].clone());
+        let im = tensor_data(outputs[1].clone());
+        assert!((re[0] - 1.0).abs() < 1.0e-12);
+        assert!((im[0] - 1.0).abs() < 1.0e-12);
+    }
+}

--- a/crates/runmat-runtime/src/builtins/control/nyquist.rs
+++ b/crates/runmat-runtime/src/builtins/control/nyquist.rs
@@ -461,7 +461,7 @@ async fn render_nyquist_plot(response: &NyquistResponse) -> BuiltinResult<()> {
     }
 
     if let Err(err) = crate::call_builtin_async("plot", &args).await {
-        if is_nonfatal_plot_setup_error(&err) {
+        if super::is_nonfatal_plot_setup_error(&err) {
             return Ok(());
         }
         return Err(err);
@@ -471,14 +471,6 @@ async fn render_nyquist_plot(response: &NyquistResponse) -> BuiltinResult<()> {
     let _ = crate::call_builtin_async("ylabel", &[Value::from("Imaginary Axis")]).await;
     let _ = crate::call_builtin_async("grid", &[Value::from("on")]).await;
     Ok(())
-}
-
-fn is_nonfatal_plot_setup_error(err: &RuntimeError) -> bool {
-    let lower = err.to_string().to_ascii_lowercase();
-    lower.contains("plotting is unavailable")
-        || lower.contains("non-main thread")
-        || lower.contains("interactive plotting failed")
-        || lower.contains("eventloop can't be recreated")
 }
 
 fn column_tensor(data: Vec<f64>) -> BuiltinResult<Value> {

--- a/crates/runmat-runtime/src/builtins/control/nyquist.rs
+++ b/crates/runmat-runtime/src/builtins/control/nyquist.rs
@@ -308,7 +308,7 @@ fn validate_frequency_vector(values: &[f64]) -> BuiltinResult<()> {
 
 fn default_frequency_vector(system: &TfSystem) -> Vec<f64> {
     if system.is_discrete() {
-        return linspace(
+        return open_linspace(
             0.0,
             std::f64::consts::PI / system.sample_time,
             DEFAULT_FREQUENCY_POINTS,
@@ -476,7 +476,6 @@ async fn render_nyquist_plot(response: &NyquistResponse) -> BuiltinResult<()> {
 fn is_nonfatal_plot_setup_error(err: &RuntimeError) -> bool {
     let lower = err.to_string().to_ascii_lowercase();
     lower.contains("plotting is unavailable")
-        || lower.contains("unknown builtin")
         || lower.contains("non-main thread")
         || lower.contains("interactive plotting failed")
         || lower.contains("eventloop can't be recreated")
@@ -495,6 +494,16 @@ fn linspace(start: f64, stop: f64, count: usize) -> Vec<f64> {
     }
     let step = (stop - start) / ((count - 1) as f64);
     (0..count).map(|idx| start + idx as f64 * step).collect()
+}
+
+fn open_linspace(start: f64, stop: f64, count: usize) -> Vec<f64> {
+    if count == 0 {
+        return Vec::new();
+    }
+    let step = (stop - start) / ((count + 1) as f64);
+    (0..count)
+        .map(|idx| start + (idx + 1) as f64 * step)
+        .collect()
 }
 
 fn logspace(start_exp: f64, stop_exp: f64, count: usize) -> Vec<f64> {
@@ -613,6 +622,26 @@ mod tests {
         let im = tensor_data(outputs[1].clone());
         assert!((re[0] - 2.0).abs() < 1.0e-12);
         assert!(im[0].abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn nyquist_discrete_default_grid_excludes_singular_unit_circle_endpoints() {
+        let system = TfSystem {
+            numerator: vec![Complex64::new(1.0, 0.0)],
+            denominator: vec![Complex64::new(1.0, 0.0), Complex64::new(-1.0, 0.0)],
+            sample_time: 0.1,
+            is_real: true,
+        };
+        let w = default_frequency_vector(&system);
+        assert_eq!(w.len(), DEFAULT_FREQUENCY_POINTS);
+        assert!(w[0] > 0.0);
+        assert!(w[w.len() - 1] < std::f64::consts::PI / system.sample_time);
+
+        let _guard = crate::output_count::push_output_count(Some(3));
+        run_nyquist(tf_object(vec![1.0], vec![1.0, -1.0], 0.1), Vec::new())
+            .expect("pole at z=1 should not be evaluated at w=0");
+        run_nyquist(tf_object(vec![1.0], vec![1.0, 1.0], 0.1), Vec::new())
+            .expect("pole at z=-1 should not be evaluated at the Nyquist frequency");
     }
 
     #[test]

--- a/crates/runmat-runtime/src/builtins/control/step.rs
+++ b/crates/runmat-runtime/src/builtins/control/step.rs
@@ -512,7 +512,7 @@ async fn plot_response(eval: &StepEval) -> BuiltinResult<()> {
     let t = eval.t_value()?;
     let y = eval.y_value()?;
     if let Err(err) = crate::call_builtin_async("plot", &[t, y]).await {
-        if is_nonfatal_plot_setup_error(&err) {
+        if super::is_nonfatal_plot_setup_error(&err) {
             return Ok(());
         }
         return Err(err);
@@ -521,14 +521,6 @@ async fn plot_response(eval: &StepEval) -> BuiltinResult<()> {
     let _ = crate::call_builtin_async("xlabel", &[Value::from("Time")]).await;
     let _ = crate::call_builtin_async("ylabel", &[Value::from("Amplitude")]).await;
     Ok(())
-}
-
-fn is_nonfatal_plot_setup_error(err: &RuntimeError) -> bool {
-    let lower = err.to_string().to_ascii_lowercase();
-    lower.contains("plotting is unavailable")
-        || lower.contains("non-main thread")
-        || lower.contains("interactive plotting failed")
-        || lower.contains("eventloop can't be recreated")
 }
 
 fn automatic_final_time(model: &TransferFunction) -> f64 {

--- a/crates/runmat-runtime/src/builtins/control/type_resolvers.rs
+++ b/crates/runmat-runtime/src/builtins/control/type_resolvers.rs
@@ -35,3 +35,7 @@ pub fn tf_type(_args: &[Type], _context: &ResolveContext) -> Type {
 pub fn impulse_type(_args: &[Type], _context: &ResolveContext) -> Type {
     Type::Unknown
 }
+
+pub fn nyquist_type(_args: &[Type], _context: &ResolveContext) -> Type {
+    Type::tensor()
+}

--- a/crates/runmat-vm/tests/control.rs
+++ b/crates/runmat-vm/tests/control.rs
@@ -133,3 +133,43 @@ fn impulse_discrete_response_through_vm_dispatch() {
         .iter()
         .any(|value| matches!(value, Value::Num(n) if (*n - 0.5).abs() < 1.0e-12)));
 }
+
+#[test]
+fn nyquist_returns_frequency_response_through_vm_dispatch() {
+    let program = r#"
+        H = tf(1, [1 1]);
+        [re, im, w] = nyquist(H, [0 1 2]);
+        re1 = re(1);
+        re2 = re(2);
+        im2 = im(2);
+        w3 = w(3);
+    "#;
+    let hir = lower(&parse(program).unwrap()).unwrap();
+    let vars = execute(&hir).unwrap();
+
+    assert!(vars
+        .iter()
+        .any(|value| { matches!(value, Value::Tensor(tensor) if tensor.shape == vec![3, 1]) }));
+    assert!(vars
+        .iter()
+        .any(|value| matches!(value, Value::Num(n) if (*n - 1.0).abs() < 1.0e-12)));
+    assert!(vars
+        .iter()
+        .any(|value| matches!(value, Value::Num(n) if (*n - 0.5).abs() < 1.0e-12)));
+    assert!(vars
+        .iter()
+        .any(|value| matches!(value, Value::Num(n) if (*n + 0.5).abs() < 1.0e-12)));
+    assert!(vars
+        .iter()
+        .any(|value| matches!(value, Value::Num(n) if (*n - 2.0).abs() < 1.0e-12)));
+}
+
+#[test]
+fn nyquist_statement_form_plots_without_error() {
+    let program = r#"
+        H = tf(1, [1 2 1]);
+        nyquist(H);
+    "#;
+    let hir = lower(&parse(program).unwrap()).unwrap();
+    execute(&hir).unwrap();
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> New isolated control builtin with broad validation and tests; only shared change is moving plot setup error handling to `control/mod.rs` for `step` and `nyquist`.
> 
> **Overview**
> Adds a **`nyquist`** control builtin for SISO **`tf`** models: optional frequency vector **`w`**, up to three column outputs (**`re`**, **`im`**, **`wout`**), or a Nyquist plot when used as a statement. Continuous systems use **`H(jω)`** with a default log-spaced grid from pole/zero breakpoints; discrete systems map **`w`** to the unit circle and default to an open grid up to **`π/Ts`**, avoiding singular endpoints at **`w=0`** and Nyquist.
> 
> Registers GPU/fusion metadata as a host residency sink, adds **`nyquist.json`** docs, **`nyquist_type`**, and unit plus VM integration tests. **`LIBRARY.md`** lists **`nyquist`** alongside **`step`** / **`impulse`**. Plot failures from unavailable UI/thread issues are handled via shared **`is_nonfatal_plot_setup_error`** in the control module ( **`step`** now uses it too).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf88741da2b566787bdc4bf3557dfe026afe434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a nyquist function to the control toolbox for SISO transfer-function models. Computes frequency-response data (real/imag and optional frequency columns), applies sensible default frequency grids for continuous and discrete systems, and can produce Nyquist plots when used in statement form.

* **Documentation**
  * Added a Control Systems section documenting nyquist alongside existing tf/step/impulse guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->