### PR TITLE
fix wasm async write event loop starvation

### DIFF
--- a/crates/runmat-runtime/src/builtins/introspection/who.rs
+++ b/crates/runmat-runtime/src/builtins/introspection/who.rs
@@ -69,7 +69,7 @@ async fn who_builtin(args: Vec<Value>) -> crate::BuiltinResult<Value> {
 
     let mut entries = match &request.source {
         WhoSource::Workspace => crate::workspace::snapshot().unwrap_or_default(),
-        WhoSource::File(path) => read_mat_file_for_builtin(path, "who")?,
+        WhoSource::File(path) => read_mat_file_for_builtin(path, "who").await?,
     };
 
     if matches!(request.source, WhoSource::File(_)) {

--- a/crates/runmat-runtime/src/builtins/introspection/whos.rs
+++ b/crates/runmat-runtime/src/builtins/introspection/whos.rs
@@ -64,7 +64,7 @@ async fn whos_builtin(args: Vec<Value>) -> crate::BuiltinResult<Value> {
 
     let mut entries = match &request.source {
         WhosSource::Workspace => crate::workspace::snapshot().unwrap_or_default(),
-        WhosSource::File(path) => read_mat_file_for_builtin(path, "whos")?,
+        WhosSource::File(path) => read_mat_file_for_builtin(path, "whos").await?,
     };
 
     if matches!(request.source, WhosSource::File(_)) {

--- a/crates/runmat-runtime/src/builtins/io/filetext/filewrite.rs
+++ b/crates/runmat-runtime/src/builtins/io/filetext/filewrite.rs
@@ -149,7 +149,7 @@ async fn filewrite_builtin(
     let options = parse_options(&rest)?;
     let resolved = resolve_path(&path)?;
     let payload = prepare_payload(&data, options.encoding)?;
-    let written = write_bytes(&resolved, &payload, options.write_mode)?;
+    let written = write_bytes(&resolved, &payload, options.write_mode).await?;
     Ok(Value::Num(written as f64))
 }
 
@@ -509,7 +509,7 @@ fn encode_bytes(bytes: Vec<u8>, encoding: FileEncoding) -> BuiltinResult<Vec<u8>
     Ok(bytes)
 }
 
-fn write_bytes(path: &Path, payload: &[u8], mode: WriteMode) -> BuiltinResult<usize> {
+async fn write_bytes(path: &Path, payload: &[u8], mode: WriteMode) -> BuiltinResult<usize> {
     let mut options = OpenOptions::new();
     options.create(true);
     match mode {
@@ -521,7 +521,7 @@ fn write_bytes(path: &Path, payload: &[u8], mode: WriteMode) -> BuiltinResult<us
         }
     }
 
-    let mut file = options.open(path).map_err(|err| {
+    let mut file = options.open_async(path).await.map_err(|err| {
         build_runtime_error(format!(
             "filewrite: unable to open '{}': {}",
             path.display(),
@@ -543,7 +543,7 @@ fn write_bytes(path: &Path, payload: &[u8], mode: WriteMode) -> BuiltinResult<us
         .build()
     })?;
 
-    file.flush().map_err(|err| {
+    file.flush_async().await.map_err(|err| {
         build_runtime_error(format!(
             "filewrite: unable to flush '{}': {}",
             path.display(),

--- a/crates/runmat-runtime/src/builtins/io/mat/load.rs
+++ b/crates/runmat-runtime/src/builtins/io/mat/load.rs
@@ -167,7 +167,7 @@ pub async fn evaluate(args: &[Value]) -> BuiltinResult<LoadEval> {
         regex_patterns,
     };
     let path = normalise_path(&path_value)?;
-    let entries = read_mat_file(&path)?;
+    let entries = read_mat_file(&path).await?;
 
     let selected = select_variables(&entries, &request)?;
     Ok(LoadEval {
@@ -307,11 +307,11 @@ fn insert_or_replace(selected: &mut Vec<(String, Value)>, name: &str, value: Val
     }
 }
 
-pub(crate) fn read_mat_file_for_builtin(
+pub(crate) async fn read_mat_file_for_builtin(
     path: &Path,
     builtin: &str,
 ) -> crate::BuiltinResult<Vec<(String, Value)>> {
-    match read_mat_file(path) {
+    match read_mat_file(path).await {
         Ok(entries) => Ok(entries),
         Err(err) => {
             let message = err.message().replacen("load:", &format!("{builtin}:"), 1);
@@ -324,8 +324,8 @@ pub(crate) fn read_mat_file_for_builtin(
     }
 }
 
-pub(crate) fn read_mat_file(path: &Path) -> BuiltinResult<Vec<(String, Value)>> {
-    let file = File::open(path).map_err(|err| {
+pub(crate) async fn read_mat_file(path: &Path) -> BuiltinResult<Vec<(String, Value)>> {
+    let file = File::open_async(path).await.map_err(|err| {
         load_error_with_source(
             format!("load: failed to open '{}': {err}", path.display()),
             err,

--- a/crates/runmat-runtime/src/builtins/io/tabular/csvread.rs
+++ b/crates/runmat-runtime/src/builtins/io/tabular/csvread.rs
@@ -90,7 +90,7 @@ async fn csvread_builtin(path: Value, rest: Vec<Value>) -> crate::BuiltinResult<
         .map_err(map_control_flow)?;
     let options = parse_arguments(&rest).await?;
     let resolved = resolve_path(&gathered_path)?;
-    let (rows, max_cols, skipped_rows) = read_csv_rows(&resolved, &options)?;
+    let (rows, max_cols, skipped_rows) = read_csv_rows(&resolved, &options).await?;
     let start_row = if options.range.is_none() {
         options.start_row.saturating_sub(skipped_rows)
     } else {
@@ -214,11 +214,11 @@ fn normalize_path(raw: &str) -> BuiltinResult<PathBuf> {
     Ok(Path::new(&expanded).to_path_buf())
 }
 
-fn read_csv_rows(
+async fn read_csv_rows(
     path: &Path,
     options: &CsvReadOptions,
 ) -> BuiltinResult<(Vec<Vec<f64>>, usize, usize)> {
-    let file = File::open(path).map_err(|err| {
+    let file = File::open_async(path).await.map_err(|err| {
         csvread_error_with_source(
             format!("csvread: unable to open '{}': {err}", path.display()),
             err,

--- a/crates/runmat-runtime/src/builtins/io/tabular/csvwrite.rs
+++ b/crates/runmat-runtime/src/builtins/io/tabular/csvwrite.rs
@@ -114,7 +114,7 @@ async fn csvwrite_builtin(
         tensor::value_into_tensor_for("csvwrite", gathered_data).map_err(csvwrite_error)?;
     ensure_matrix_shape(&tensor)?;
 
-    let bytes = write_csv(&path, &tensor, row_offset, col_offset)?;
+    let bytes = write_csv(&path, &tensor, row_offset, col_offset).await?;
     Ok(Value::Num(bytes as f64))
 }
 
@@ -218,7 +218,7 @@ fn ensure_matrix_shape(tensor: &Tensor) -> BuiltinResult<()> {
     ))
 }
 
-fn write_csv(
+async fn write_csv(
     path: &Path,
     tensor: &Tensor,
     row_offset: usize,
@@ -226,7 +226,7 @@ fn write_csv(
 ) -> BuiltinResult<usize> {
     let mut options = OpenOptions::new();
     options.create(true).write(true).truncate(true);
-    let mut file = options.open(path).map_err(|err| {
+    let mut file = options.open_async(path).await.map_err(|err| {
         csvwrite_error_with_source(
             format!(
                 "csvwrite: unable to open \"{}\" for writing ({err})",
@@ -253,7 +253,7 @@ fn write_csv(
     }
 
     if rows == 0 || cols == 0 {
-        file.flush().map_err(|err| {
+        file.flush_async().await.map_err(|err| {
             csvwrite_error_with_source(format!("csvwrite: failed to flush output ({err})"), err)
         })?;
         return Ok(bytes_written);
@@ -285,7 +285,7 @@ fn write_csv(
         bytes_written += line_ending.len();
     }
 
-    file.flush().map_err(|err| {
+    file.flush_async().await.map_err(|err| {
         csvwrite_error_with_source(format!("csvwrite: failed to flush output ({err})"), err)
     })?;
 

--- a/crates/runmat-runtime/src/builtins/io/tabular/dlmread.rs
+++ b/crates/runmat-runtime/src/builtins/io/tabular/dlmread.rs
@@ -103,7 +103,8 @@ async fn dlmread_builtin(path: Value, rest: Vec<Value>) -> crate::BuiltinResult<
         &options.delimiter,
         parse_start_row,
         parse_start_col,
-    )?;
+    )
+    .await?;
     let subset = if let Some(range) = options.range {
         apply_range(&rows, max_cols, &range, 0.0)
     } else {
@@ -385,13 +386,13 @@ fn normalize_path(raw: &str) -> BuiltinResult<PathBuf> {
     Ok(Path::new(&expanded).to_path_buf())
 }
 
-fn read_dlm_rows(
+async fn read_dlm_rows(
     path: &Path,
     delimiter: &DelimiterSpec,
     parse_start_row: usize,
     parse_start_col: usize,
 ) -> BuiltinResult<(Vec<Vec<f64>>, usize)> {
-    let file = File::open(path).map_err(|err| {
+    let file = File::open_async(path).await.map_err(|err| {
         dlmread_error_with_source(
             format!("dlmread: unable to open '{}': {err}", path.display()),
             err,

--- a/crates/runmat-runtime/src/builtins/io/tabular/dlmwrite.rs
+++ b/crates/runmat-runtime/src/builtins/io/tabular/dlmwrite.rs
@@ -557,7 +557,7 @@ async fn write_dlm(
         open.write(true).truncate(true);
     }
 
-    let mut file = open.open(path).map_err(|err| {
+    let mut file = open.open_async(path).await.map_err(|err| {
         dlmwrite_error_with_source(
             format!(
                 "dlmwrite: unable to open \"{}\" for writing ({err})",
@@ -590,7 +590,7 @@ async fn write_dlm(
     }
 
     if rows == 0 || cols == 0 {
-        file.flush().map_err(|err| {
+        file.flush_async().await.map_err(|err| {
             dlmwrite_error_with_source(format!("dlmwrite: failed to flush output ({err})"), err)
         })?;
         return Ok(bytes);
@@ -619,7 +619,7 @@ async fn write_dlm(
         bytes += newline.len();
     }
 
-    file.flush().map_err(|err| {
+    file.flush_async().await.map_err(|err| {
         dlmwrite_error_with_source(format!("dlmwrite: failed to flush output ({err})"), err)
     })?;
     Ok(bytes)
@@ -672,7 +672,7 @@ async fn file_ends_with_newline(path: &Path) -> io::Result<bool> {
     if len == 0 {
         return Ok(false);
     }
-    let mut file = File::open(path)?;
+    let mut file = File::open_async(path).await?;
     let to_read = len.min(2) as usize;
     file.seek(SeekFrom::End(-(to_read as i64)))?;
     let mut buffer = vec![0u8; to_read];

--- a/crates/runmat-runtime/src/builtins/io/tabular/readmatrix.rs
+++ b/crates/runmat-runtime/src/builtins/io/tabular/readmatrix.rs
@@ -89,7 +89,7 @@ async fn readmatrix_builtin(path: Value, rest: Vec<Value>) -> crate::BuiltinResu
     let options = parse_options(&rest).await?;
     options.validate()?;
     let resolved = resolve_path(&path_value)?;
-    let tensor = read_numeric_matrix(&resolved, &options)?;
+    let tensor = read_numeric_matrix(&resolved, &options).await?;
     finalize_output(tensor, &options)
 }
 
@@ -813,8 +813,8 @@ fn tensor_to_gpu(
     Ok(Value::Tensor(tensor))
 }
 
-fn read_numeric_matrix(path: &Path, options: &ReadMatrixOptions) -> BuiltinResult<Tensor> {
-    let file = File::open(path).map_err(|err| {
+async fn read_numeric_matrix(path: &Path, options: &ReadMatrixOptions) -> BuiltinResult<Tensor> {
+    let file = File::open_async(path).await.map_err(|err| {
         readmatrix_error_with_source(
             format!("readmatrix: unable to read '{}': {err}", path.display()),
             err,

--- a/crates/runmat-runtime/src/builtins/io/tabular/writematrix.rs
+++ b/crates/runmat-runtime/src/builtins/io/tabular/writematrix.rs
@@ -98,7 +98,7 @@ async fn writematrix_builtin(data: Value, rest: Vec<Value>) -> crate::BuiltinRes
         .map_err(map_control_flow)?;
     let matrix = MatrixData::from_value(gathered)?;
 
-    let bytes_written = write_matrix(&path, &matrix, &options)?;
+    let bytes_written = write_matrix(&path, &matrix, &options).await?;
 
     Ok(Value::Num(bytes_written as f64))
 }
@@ -445,7 +445,7 @@ fn ensure_matrix_shape(shape: &[usize], context: &str) -> BuiltinResult<()> {
     }
 }
 
-fn write_matrix(
+async fn write_matrix(
     path: &Path,
     matrix: &MatrixData,
     options: &WriteMatrixOptions,
@@ -464,7 +464,7 @@ fn write_matrix(
         }
     }
 
-    let mut file = open_options.open(path).map_err(|err| {
+    let mut file = open_options.open_async(path).await.map_err(|err| {
         writematrix_error_with_source(
             format!(
                 "writematrix: unable to open \"{}\" for writing ({err})",
@@ -480,7 +480,7 @@ fn write_matrix(
 
     if rows == 0 {
         // Nothing else to do; file was truncated or created above.
-        file.flush().map_err(|err| {
+        file.flush_async().await.map_err(|err| {
             writematrix_error_with_source(
                 format!("writematrix: failed to flush output ({err})"),
                 err,
@@ -520,7 +520,7 @@ fn write_matrix(
         bytes_written += line_ending.len();
     }
 
-    file.flush().map_err(|err| {
+    file.flush_async().await.map_err(|err| {
         writematrix_error_with_source(format!("writematrix: failed to flush output ({err})"), err)
     })?;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many widely used I/O builtins and shared MAT read helpers; behavior should match sync I/O on native targets but WASM/async scheduling differences could surface edge-case timing or error-path bugs.
> 
> **Overview**
> **Host I/O builtins** now open and flush files through **`runmat_filesystem`** async APIs (`File::open_async`, `OpenOptions::open_async`, `flush_async`) instead of blocking sync calls, so WASM runs can yield during filesystem work and avoid starving the async event loop (especially on writes).
> 
> **MAT loading** is updated the same way: `read_mat_file` and `read_mat_file_for_builtin` are **`async`**, use `open_async`, and callers (`load`, `who`, `whos`) **`.await`** them.
> 
> **Tabular and text I/O** (`csvread`/`csvwrite`, `dlmread`/`dlmwrite`, `readmatrix`/`writematrix`, `filewrite`) follow the same pattern—internal read/write helpers are **`async`** and propagate **`await`** from the already-async builtins. In-memory parsing after open is unchanged; only the open/flush path is async.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b03a0880e8cb742c691b5a1a325cca2664658c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Converted file I/O operations to use non-blocking operations across multiple file formats:
    - MAT file loading and introspection
    - CSV file reading and writing
    - Delimited file processing
    - Matrix file operations
    - Text file writing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->