### PR TITLE
Adding prompts to agent page, matlab-online video updates, homepage links 

### DIFF
--- a/website/app/matlab-ai-agent/page.tsx
+++ b/website/app/matlab-ai-agent/page.tsx
@@ -32,6 +32,36 @@ const heroVideoSrc = "https://web.runmatstatic.com/video/3D-wave-surface-runmat.
 const heroPosterSrc = "https://web.runmatstatic.com/video/posters/3D-wave-surface-runmat.webp";
 const agentDiffImageSrc = "https://web.runmatstatic.com/runmat-agent-diff-rain.webp";
 
+const dampedOscillatorCode = `% Damped oscillator: single run
+m = 1.0;
+k = 25.0;
+c = 0.8;
+
+t = linspace(0, 6, 400);
+omega0 = sqrt(k / m);
+zeta = c / (2 * sqrt(k * m));
+omegaD = omega0 * sqrt(1 - zeta^2);
+
+x = exp(-zeta * omega0 * t) .* cos(omegaD * t);
+
+plot(t, x);
+xlabel('Time (s)');
+ylabel('Displacement (m)');
+title('Damped oscillator');
+grid on;`;
+
+const brokenFilteringCode = `% This script has a dimension mismatch for the agent to debug.
+t = linspace(0, 2*pi, 200);
+signal = sin(t);
+window = [0.25 0.5 0.75];
+
+filtered = signal .* window;
+
+plot(t, filtered);
+xlabel('Time (s)');
+ylabel('Filtered signal');
+title('Broken filtering script');`;
+
 // These prompts launch through the existing workspace payload flow rather than
 // direct query params so the sandbox can hydrate both starter code and prompt text.
 const tryPrompts: { id: string; title: string; prompt: string }[] = [
@@ -92,23 +122,7 @@ const startCards: StartCard[] = [
     source: "agent-page-start-matlab",
     cta: "try-from-matlab",
     exampleId: "existing-script",
-    code: `% Damped oscillator: single run
-m = 1.0;
-k = 25.0;
-c = 0.8;
-
-t = linspace(0, 6, 400);
-omega0 = sqrt(k / m);
-zeta = c / (2 * sqrt(k * m));
-omegaD = omega0 * sqrt(1 - zeta^2);
-
-x = exp(-zeta * omega0 * t) .* cos(omegaD * t);
-
-plot(t, x);
-xlabel('Time (s)');
-ylabel('Displacement (m)');
-title('Damped oscillator');
-grid on;`,
+    code: dampedOscillatorCode,
     agentPrompt:
       "Explain this script, then turn it into a parameter sweep over damping values and overlay the results.",
   },
@@ -138,17 +152,7 @@ grid on;`,
     source: "agent-page-start-broken",
     cta: "try-from-broken",
     exampleId: "broken-script",
-    code: `% This script has a dimension mismatch for the agent to debug
-t = linspace(0, 2*pi, 200);
-signal = sin(t);
-window = [0.25 0.5 0.75];
-
-filtered = signal .* window;
-
-plot(t, filtered);
-xlabel('Time (s)');
-ylabel('Filtered signal');
-title('Broken filtering script');`,
+    code: brokenFilteringCode,
     agentPrompt:
       "Run this script, use the error and workspace state to debug it, then propose a minimal fix.",
   },
@@ -742,7 +746,7 @@ export default function AgentPage() {
                     exampleId={card.exampleId}
                     size="sm"
                     data-ph-capture-attribute-cta={card.cta}
-                    className="mt-4 !h-auto w-fit !border-0 !bg-transparent !p-0 !text-[hsl(var(--brand))] !shadow-none hover:!bg-transparent hover:!text-[hsl(var(--brand))]/80 [&>svg:first-child]:hidden"
+                    className="mt-4 h-auto! w-fit border-0! bg-transparent! p-0! text-[hsl(var(--brand))]! shadow-none! hover:bg-transparent! hover:text-[hsl(var(--brand))]/80! [&>svg:first-child]:hidden"
                   >
                     Try it <ArrowRight className="h-3.5 w-3.5" />
                   </TryInBrowserButton>

--- a/website/app/matlab-ai-agent/page.tsx
+++ b/website/app/matlab-ai-agent/page.tsx
@@ -32,9 +32,8 @@ const heroVideoSrc = "https://web.runmatstatic.com/video/3D-wave-surface-runmat.
 const heroPosterSrc = "https://web.runmatstatic.com/video/posters/3D-wave-surface-runmat.webp";
 const agentDiffImageSrc = "https://web.runmatstatic.com/runmat-agent-diff-rain.webp";
 
-// Open question per plan: /sandbox does not yet handle a `?prompt=` query.
-// Cards link to plain /sandbox and display the prompt so users can copy it.
-// When the query handler ships, switch href to `/sandbox?prompt=encodeURIComponent(prompt)`.
+// These prompts launch through the existing workspace payload flow rather than
+// direct query params so the sandbox can hydrate both starter code and prompt text.
 const tryPrompts: { id: string; title: string; prompt: string }[] = [
   {
     id: "sweep",
@@ -71,6 +70,116 @@ const tryPrompts: { id: string; title: string; prompt: string }[] = [
     title: "Tune a PID controller",
     prompt:
       "Design a PID controller for a 1 kg mass on a spring. Plot the step response and find gains that settle in under 0.5 seconds without overshoot.",
+  },
+];
+
+type StartCard = {
+  title: string;
+  body: string;
+  icon: React.ComponentType<{ className?: string }>;
+  source: string;
+  cta: string;
+  exampleId: string;
+  code: string;
+  agentPrompt: string;
+};
+
+const startCards: StartCard[] = [
+  {
+    title: "An existing MATLAB script",
+    body: "Open a script you already use. Ask the agent to explain it, debug a run, add a plot, or turn a single run into a parameter sweep.",
+    icon: FileCode2,
+    source: "agent-page-start-matlab",
+    cta: "try-from-matlab",
+    exampleId: "existing-script",
+    code: `% Damped oscillator: single run
+m = 1.0;
+k = 25.0;
+c = 0.8;
+
+t = linspace(0, 6, 400);
+omega0 = sqrt(k / m);
+zeta = c / (2 * sqrt(k * m));
+omegaD = omega0 * sqrt(1 - zeta^2);
+
+x = exp(-zeta * omega0 * t) .* cos(omegaD * t);
+
+plot(t, x);
+xlabel('Time (s)');
+ylabel('Displacement (m)');
+title('Damped oscillator');
+grid on;`,
+    agentPrompt:
+      "Explain this script, then turn it into a parameter sweep over damping values and overlay the results.",
+  },
+  {
+    title: "Raw data",
+    body: "Add a CSV or table. Ask the agent to clean it, plot it, fit a model, or compare residuals.",
+    icon: LineChart,
+    source: "agent-page-start-csv",
+    cta: "try-from-csv",
+    exampleId: "raw-data",
+    code: `% Lab measurements copied from a table
+time = [0 1 2 3 4 5 6 7 8 9 10];
+response = [2.1 2.8 3.6 4.3 5.1 6.4 7.2 8.1 9.0 10.6 11.1];
+
+plot(time, response, 'o');
+xlabel('Time (s)');
+ylabel('Response');
+title('Raw lab measurements');
+grid on;`,
+    agentPrompt:
+      "Treat these measurements like imported lab data. Clean obvious issues, fit linear and exponential models, plot residuals, and tell me which fit is better.",
+  },
+  {
+    title: "A script that's broken",
+    body: "Run it in the workspace and ask the agent to debug it. It can use the error, variables, and output to propose a fix.",
+    icon: Bug,
+    source: "agent-page-start-broken",
+    cta: "try-from-broken",
+    exampleId: "broken-script",
+    code: `% This script has a dimension mismatch for the agent to debug
+t = linspace(0, 2*pi, 200);
+signal = sin(t);
+window = [0.25 0.5 0.75];
+
+filtered = signal .* window;
+
+plot(t, filtered);
+xlabel('Time (s)');
+ylabel('Filtered signal');
+title('Broken filtering script');`,
+    agentPrompt:
+      "Run this script, use the error and workspace state to debug it, then propose a minimal fix.",
+  },
+  {
+    title: "An engineering problem",
+    body: "Describe the system, constraints, and result you need. The agent can help write the first script.",
+    icon: Lightbulb,
+    source: "agent-page-start-idea",
+    cta: "try-from-idea",
+    exampleId: "engineering-problem",
+    code: `% Thermal resistance scaffold for a three-layer wall
+thickness = [0.10 0.05 0.012];
+conductivity = [0.72 0.04 0.16];
+insideTemp = 20;
+outsideTemp = -5;
+area = 1.0;
+
+resistance = thickness ./ (conductivity * area);
+totalResistance = sum(resistance);
+heatFlux = (insideTemp - outsideTemp) / totalResistance;
+
+positions = cumsum([0 thickness]);
+interfaceTemps = insideTemp - heatFlux * cumsum([0 resistance]);
+
+plot(positions, interfaceTemps, '-o');
+xlabel('Position through wall (m)');
+ylabel('Temperature (C)');
+title('Temperature gradient through layered wall');
+grid on;`,
+    agentPrompt:
+      "Complete this engineering model, run it, plot the result, and explain the tradeoff.",
   },
 ];
 
@@ -394,17 +503,17 @@ export default function AgentPage() {
                 </Button>
               </div>
             </div>
-            <div className="rounded-xl border border-border bg-card p-2 elevated-panel">
+            <div className="overflow-hidden rounded-xl">
               <Link
                 href="/sandbox"
-                className="block rounded-lg overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                className="block overflow-hidden rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 data-ph-capture-attribute-destination="sandbox"
                 data-ph-capture-attribute-source="agent-page-hero-video"
                 data-ph-capture-attribute-cta="try-runmat-agent"
                 aria-label="Open the RunMat sandbox"
               >
                 <LazyVideo
-                  className="w-full h-auto rounded-lg"
+                  className="w-full h-auto"
                   muted
                   loop
                   playsInline
@@ -615,78 +724,31 @@ export default function AgentPage() {
             </h2>
           </div>
           <div className="mx-auto max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="rounded-lg border border-border bg-card p-6 flex flex-col">
-              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
-                <FileCode2 className="h-5 w-5" />
-              </span>
-              <h3 className="text-lg font-semibold text-foreground">An existing MATLAB script</h3>
-              <p className="text-[0.938rem] text-foreground mt-1 flex-1">
-                Open a script you already use. Ask the agent to explain it, debug a run, add a plot, or turn a single run into a parameter sweep.
-              </p>
-              <Link
-                href="/sandbox"
-                className="text-sm text-[hsl(var(--brand))] hover:text-[hsl(var(--brand))]/80 mt-4 inline-flex items-center gap-1"
-                data-ph-capture-attribute-destination="sandbox"
-                data-ph-capture-attribute-source="agent-page-start-matlab"
-                data-ph-capture-attribute-cta="try-from-matlab"
-              >
-                Try it <ArrowRight className="h-3.5 w-3.5" />
-              </Link>
-            </div>
-            <div className="rounded-lg border border-border bg-card p-6 flex flex-col">
-              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
-                <LineChart className="h-5 w-5" />
-              </span>
-              <h3 className="text-lg font-semibold text-foreground">Raw data</h3>
-              <p className="text-[0.938rem] text-foreground mt-1 flex-1">
-                Add a CSV or table. Ask the agent to clean it, plot it, fit a model, or compare residuals.
-              </p>
-              <Link
-                href="/sandbox"
-                className="text-sm text-[hsl(var(--brand))] hover:text-[hsl(var(--brand))]/80 mt-4 inline-flex items-center gap-1"
-                data-ph-capture-attribute-destination="sandbox"
-                data-ph-capture-attribute-source="agent-page-start-csv"
-                data-ph-capture-attribute-cta="try-from-csv"
-              >
-                Try it <ArrowRight className="h-3.5 w-3.5" />
-              </Link>
-            </div>
-            <div className="rounded-lg border border-border bg-card p-6 flex flex-col">
-              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
-                <Bug className="h-5 w-5" />
-              </span>
-              <h3 className="text-lg font-semibold text-foreground">A script that&apos;s broken</h3>
-              <p className="text-[0.938rem] text-foreground mt-1 flex-1">
-                Run it in the workspace and ask the agent to debug it. It can use the error, variables, and output to propose a fix.
-              </p>
-              <Link
-                href="/sandbox"
-                className="text-sm text-[hsl(var(--brand))] hover:text-[hsl(var(--brand))]/80 mt-4 inline-flex items-center gap-1"
-                data-ph-capture-attribute-destination="sandbox"
-                data-ph-capture-attribute-source="agent-page-start-broken"
-                data-ph-capture-attribute-cta="try-from-broken"
-              >
-                Try it <ArrowRight className="h-3.5 w-3.5" />
-              </Link>
-            </div>
-            <div className="rounded-lg border border-border bg-card p-6 flex flex-col">
-              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
-                <Lightbulb className="h-5 w-5" />
-              </span>
-              <h3 className="text-lg font-semibold text-foreground">An engineering problem</h3>
-              <p className="text-[0.938rem] text-foreground mt-1 flex-1">
-                Describe the system, constraints, and result you need. The agent can help write the first script.
-              </p>
-              <Link
-                href="/sandbox"
-                className="text-sm text-[hsl(var(--brand))] hover:text-[hsl(var(--brand))]/80 mt-4 inline-flex items-center gap-1"
-                data-ph-capture-attribute-destination="sandbox"
-                data-ph-capture-attribute-source="agent-page-start-idea"
-                data-ph-capture-attribute-cta="try-from-idea"
-              >
-                Try it <ArrowRight className="h-3.5 w-3.5" />
-              </Link>
-            </div>
+            {startCards.map((card) => {
+              const Icon = card.icon;
+              return (
+                <div key={card.exampleId} className="rounded-lg border border-border bg-card p-6 flex flex-col">
+                  <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
+                    <Icon className="h-5 w-5" />
+                  </span>
+                  <h3 className="text-lg font-semibold text-foreground">{card.title}</h3>
+                  <p className="text-[0.938rem] text-foreground mt-1 flex-1">
+                    {card.body}
+                  </p>
+                  <TryInBrowserButton
+                    code={card.code}
+                    agentPrompt={card.agentPrompt}
+                    source={card.source}
+                    exampleId={card.exampleId}
+                    size="sm"
+                    data-ph-capture-attribute-cta={card.cta}
+                    className="mt-4 !h-auto w-fit !border-0 !bg-transparent !p-0 !text-[hsl(var(--brand))] !shadow-none hover:!bg-transparent hover:!text-[hsl(var(--brand))]/80 [&>svg:first-child]:hidden"
+                  >
+                    Try it <ArrowRight className="h-3.5 w-3.5" />
+                  </TryInBrowserButton>
+                </div>
+              );
+            })}
           </div>
         </div>
       </section>

--- a/website/app/matlab-online/page.tsx
+++ b/website/app/matlab-online/page.tsx
@@ -37,12 +37,62 @@ import {
 const pageTitle = "Run MATLAB-Syntax Math Online - GPU Browser Sandbox";
 const pageDescription =
   "Run MATLAB-syntax math in your browser with local execution, GPU acceleration when available, and a runtime-aware agent. No account or license required.";
+const pageDates = {
+  publishedAt: new Date("2026-02-03T00:00:00Z"),
+  lastModified: new Date("2026-05-27T00:00:00Z"),
+} as const;
 
 const heroVideoSrc = "https://web.runmatstatic.com/video/runmat-wave-simulation-homepage.mp4";
 const heroPosterSrc = "https://web.runmatstatic.com/video/posters/runmat-wave-simulation-homepage.webp";
+const heroVideoMetadata = {
+  uploadedAt: new Date("2026-05-26T00:00:00Z"),
+} as const;
 
 const agentVideoSrc = "https://web.runmatstatic.com/video/3D-wave-surface-runmat.mp4";
 const agentPosterSrc = "https://web.runmatstatic.com/video/posters/3D-wave-surface-runmat.webp";
+
+const howItWorksVideoSrc = "https://web.runmatstatic.com/video/clamp-agent-runmat.mp4";
+const howItWorksPosterSrc = "https://web.runmatstatic.com/video/posters/clamp-agent-runmat.webp";
+
+const dampedOscillatorCode = `% Damped oscillator: single run
+m = 1.0;
+k = 25.0;
+c = 0.8;
+
+t = linspace(0, 6, 400);
+omega0 = sqrt(k / m);
+zeta = c / (2 * sqrt(k * m));
+omegaD = omega0 * sqrt(1 - zeta^2);
+
+x = exp(-zeta * omega0 * t) .* cos(omegaD * t);
+
+plot(t, x);
+xlabel('Time (s)');
+ylabel('Displacement (m)');
+title('Damped oscillator');
+grid on;`;
+
+const brokenFilteringCode = `% This script has a dimension mismatch for the agent to debug.
+t = linspace(0, 2*pi, 200);
+signal = sin(t);
+window = [0.25 0.5 0.75];
+
+filtered = signal .* window;
+
+plot(t, filtered);
+xlabel('Time (s)');
+ylabel('Filtered signal');
+title('Broken filtering script');`;
+
+const matlabOnlineLimits = {
+  hoursPerMonth: "20 hours per month",
+  continuousLimit: "15-minute continuous compute",
+  idleLimit: "15-minute idle-time",
+  licenseNote: "Basic access is free; full access depends on a linked license",
+  productAccessNote:
+    "Basic MATLAB Online includes a limited set of commonly used products. Full product access depends on your license",
+  lastVerified: "May 2026",
+} as const;
 
 const onlinePrompts: { id: string; title: string; prompt: string; code: string }[] = [
   {
@@ -69,43 +119,17 @@ title('Interfering wave surface');
     id: "oscillator-sweep",
     title: "Sweep an oscillator",
     prompt: "Turn this damped oscillator into a parameter sweep and overlay the results.",
-    code: `% Damped oscillator: single run
-m = 1.0;
-k = 25.0;
-c = 0.8;
-
-t = linspace(0, 6, 400);
-omega0 = sqrt(k / m);
-zeta = c / (2 * sqrt(k * m));
-omegaD = omega0 * sqrt(1 - zeta^2);
-
-x = exp(-zeta * omega0 * t) .* cos(omegaD * t);
-
-plot(t, x);
-xlabel('Time (s)');
-ylabel('Displacement (m)');
-title('Damped oscillator');
-grid on;
-`,
+    code: dampedOscillatorCode,
   },
   {
     id: "dimension-debug",
     title: "Debug a shape error",
     prompt: "Debug a matrix dimension mismatch, explain the fix, and return corrected code.",
-    code: `% This script has a dimension mismatch for the agent to debug.
-t = linspace(0, 2*pi, 200);
-signal = sin(t);
-window = [0.25 0.5 0.75];
-
-filtered = signal .* window;
-
-plot(t, filtered);
-xlabel('Time (s)');
-ylabel('Filtered signal');
-title('Broken filtering script');
-`,
+    code: brokenFilteringCode,
   },
 ];
+
+const toJsonLdDate = (date: Date) => date.toISOString();
 
 export const metadata: Metadata = {
   title: pageTitle,
@@ -304,8 +328,8 @@ const jsonLd = {
       name: pageTitle,
       description: pageDescription,
       inLanguage: "en",
-      datePublished: "2026-02-03T00:00:00Z",
-      dateModified: "2026-05-27T00:00:00Z",
+      datePublished: toJsonLdDate(pageDates.publishedAt),
+      dateModified: toJsonLdDate(pageDates.lastModified),
       isPartOf: { "@id": "https://runmat.com/#website" },
       breadcrumb: { "@id": "https://runmat.com/matlab-online#breadcrumb" },
       author: { "@id": "https://runmat.com/#organization" },
@@ -325,7 +349,7 @@ const jsonLd = {
         "RunMat runs a GPU-accelerated wave simulation with MATLAB-syntax code directly in the browser.",
       thumbnailUrl: heroPosterSrc,
       contentUrl: heroVideoSrc,
-      uploadDate: "2026-05-26T00:00:00Z",
+      uploadDate: toJsonLdDate(heroVideoMetadata.uploadedAt),
     },
     {
       "@type": "BreadcrumbList",
@@ -515,8 +539,9 @@ export default function MatlabOnlinePage() {
                   <div>
                     <h3 className="text-lg font-semibold text-foreground">Why people look beyond MATLAB Online</h3>
                     <p className="text-[0.938rem] text-foreground mt-2">
-                      MATLAB Online runs through MathWorks-hosted compute in the browser. Basic access includes 20 hours
-                      per month with 15-minute continuous compute and idle-time limits; full access depends on a linked license.
+                      MATLAB Online runs through MathWorks-hosted compute in the browser. {matlabOnlineLimits.licenseNote}.
+                      Basic access includes {matlabOnlineLimits.hoursPerMonth} with {matlabOnlineLimits.continuousLimit} and{" "}
+                      {matlabOnlineLimits.idleLimit} limits. As of {matlabOnlineLimits.lastVerified}.
                       That is convenient for some work, but engineers and students still hit friction:
                     </p>
                   </div>
@@ -531,7 +556,8 @@ export default function MatlabOnlinePage() {
                   <div className="rounded-lg border border-amber-500/30 bg-card px-5 py-4">
                     <p className="text-sm font-semibold text-foreground">Idle timeouts &amp; hour caps</p>
                     <p className="text-sm text-foreground mt-1">
-                      Basic sessions have 15-minute continuous compute and idle-time limits. Basic use is capped at 20 hours/month.
+                      Basic access includes {matlabOnlineLimits.hoursPerMonth} with {matlabOnlineLimits.continuousLimit} and{" "}
+                      {matlabOnlineLimits.idleLimit} limits. As of {matlabOnlineLimits.lastVerified}.
                     </p>
                   </div>
                   <div className="rounded-lg border border-amber-500/30 bg-card px-5 py-4">
@@ -549,7 +575,7 @@ export default function MatlabOnlinePage() {
                   <div className="rounded-lg border border-amber-500/30 bg-card px-5 py-4">
                     <p className="text-sm font-semibold text-foreground">Toolbox access depends on license</p>
                     <p className="text-sm text-foreground mt-1">
-                      Basic MATLAB Online includes a limited set of commonly used products. Full product access depends on your license.
+                      {matlabOnlineLimits.productAccessNote}. As of {matlabOnlineLimits.lastVerified}.
                     </p>
                   </div>
                   <div className="rounded-lg border border-amber-500/30 bg-card px-5 py-4">
@@ -795,10 +821,10 @@ export default function MatlabOnlinePage() {
                 loop
                 playsInline
                 preload="metadata"
-                poster="https://web.runmatstatic.com/video/posters/runmat-wave-simulation-homepage.webp"
+                poster={howItWorksPosterSrc}
                 aria-label="RunMat wave simulation demo"
               >
-                <source src="https://web.runmatstatic.com/video/runmat-wave-simulation-homepage.mp4" type="video/mp4" />
+                <source src={howItWorksVideoSrc} type="video/mp4" />
               </video>
             </div>
           </div>
@@ -883,7 +909,8 @@ export default function MatlabOnlinePage() {
             <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl text-foreground">RunMat vs. MATLAB Online</h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
               RunMat runs MATLAB-syntax code in your browser or desktop app with a built-in agent and local GPU acceleration
-              when available. MATLAB Online runs through MathWorks-hosted compute, with basic usage limits and license-linked full access.
+              when available. MATLAB Online runs through MathWorks-hosted compute. {matlabOnlineLimits.licenseNote}.
+              Basic access includes {matlabOnlineLimits.hoursPerMonth}. As of {matlabOnlineLimits.lastVerified}.
             </p>
           </div>
           <div className="mx-auto grid max-w-5xl gap-6 md:grid-cols-2">
@@ -962,7 +989,7 @@ export default function MatlabOnlinePage() {
                 <ul className="space-y-2 text-sm">
                   <li className="flex items-start gap-3 text-foreground">
                     <span className="mt-0.5 inline-flex items-center justify-center text-base text-foreground">–</span>
-                    Basic access is free; full access depends on a linked license
+                    {matlabOnlineLimits.licenseNote}. As of {matlabOnlineLimits.lastVerified}.
                   </li>
                   <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
                     <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
@@ -974,7 +1001,8 @@ export default function MatlabOnlinePage() {
                   </li>
                   <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
                     <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
-                    Basic access capped at 20 hours/month with 15-min compute and idle limits
+                    Basic access includes {matlabOnlineLimits.hoursPerMonth} with {matlabOnlineLimits.continuousLimit} and{" "}
+                    {matlabOnlineLimits.idleLimit} limits. As of {matlabOnlineLimits.lastVerified}.
                   </li>
                   <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
                     <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>

--- a/website/app/matlab-online/page.tsx
+++ b/website/app/matlab-online/page.tsx
@@ -2,15 +2,13 @@ import type { Metadata } from "next";
 import React from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { DetectedDownloadLabel } from "@/components/DetectedDownloadLabel";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SandboxCta } from "@/components/SandboxCta";
 import { FAQAccordion, type FAQItem } from "@/components/FAQAccordion";
+import { TryInBrowserButton } from "@/components/TryInBrowserButton";
 import LazyVideo from "@/components/LazyVideo";
 import dynamic from "next/dynamic";
-
-const MatlabInlineCodeBlock = dynamic(() => import("@/components/MatlabInlineCodeBlock"), {
-  loading: () => <div className="w-full h-[60px] rounded-md bg-muted/40 animate-pulse" />,
-});
 
 const BenchmarkShowcaseBlock = dynamic(
   () => import("@/components/benchmarks/BenchmarkShowcaseBlock"),
@@ -33,12 +31,85 @@ import {
   Wand2,
   FlaskConical,
   FileDiff,
+  Sparkles,
 } from "lucide-react";
 
+const pageTitle = "Run MATLAB-Syntax Math Online - GPU Browser Sandbox";
+const pageDescription =
+  "Run MATLAB-syntax math in your browser with local execution, GPU acceleration when available, and a runtime-aware agent. No account or license required.";
+
+const heroVideoSrc = "https://web.runmatstatic.com/video/runmat-wave-simulation-homepage.mp4";
+const heroPosterSrc = "https://web.runmatstatic.com/video/posters/runmat-wave-simulation-homepage.webp";
+
+const agentVideoSrc = "https://web.runmatstatic.com/video/3D-wave-surface-runmat.mp4";
+const agentPosterSrc = "https://web.runmatstatic.com/video/posters/3D-wave-surface-runmat.webp";
+
+const onlinePrompts: { id: string; title: string; prompt: string; code: string }[] = [
+  {
+    id: "wave-surface",
+    title: "Animate a wave surface",
+    prompt: "Visualize two interfering waves on a square membrane and animate the surface.",
+    code: `% Visualize two interfering waves on a square membrane and animate the surface.
+n = 80;
+x = linspace(-2, 2, n);
+y = linspace(-2, 2, n);
+[X, Y] = meshgrid(x, y);
+
+r1 = sqrt((X + 0.7).^2 + Y.^2);
+r2 = sqrt((X - 0.7).^2 + Y.^2);
+t = 0;
+Z = sin(8 * r1 - 4 * t) + sin(8 * r2 - 4 * t);
+
+surf(X, Y, Z);
+shading interp;
+title('Interfering wave surface');
+`,
+  },
+  {
+    id: "oscillator-sweep",
+    title: "Sweep an oscillator",
+    prompt: "Turn this damped oscillator into a parameter sweep and overlay the results.",
+    code: `% Damped oscillator: single run
+m = 1.0;
+k = 25.0;
+c = 0.8;
+
+t = linspace(0, 6, 400);
+omega0 = sqrt(k / m);
+zeta = c / (2 * sqrt(k * m));
+omegaD = omega0 * sqrt(1 - zeta^2);
+
+x = exp(-zeta * omega0 * t) .* cos(omegaD * t);
+
+plot(t, x);
+xlabel('Time (s)');
+ylabel('Displacement (m)');
+title('Damped oscillator');
+grid on;
+`,
+  },
+  {
+    id: "dimension-debug",
+    title: "Debug a shape error",
+    prompt: "Debug a matrix dimension mismatch, explain the fix, and return corrected code.",
+    code: `% This script has a dimension mismatch for the agent to debug.
+t = linspace(0, 2*pi, 200);
+signal = sin(t);
+window = [0.25 0.5 0.75];
+
+filtered = signal .* window;
+
+plot(t, filtered);
+xlabel('Time (s)');
+ylabel('Filtered signal');
+title('Broken filtering script');
+`,
+  },
+];
+
 export const metadata: Metadata = {
-  title: "Run MATLAB Code Online - Instant GPU Sandbox",
-  description:
-    "Run MATLAB-syntax code in your browser with a built-in coding agent and automatic GPU acceleration. Open-source runtime. No license required.",
+  title: pageTitle,
+  description: pageDescription,
   alternates: { canonical: "https://runmat.com/matlab-online" },
   keywords: [
     "matlab online", "matlab online free", "run matlab online",
@@ -50,18 +121,31 @@ export const metadata: Metadata = {
     "matlab agentic toolkit", "matlab mcp",
   ],
   openGraph: {
-    title: "Run MATLAB Code Online - Instant GPU Sandbox",
-    description:
-      "Run MATLAB-syntax code in your browser with a built-in coding agent and automatic GPU acceleration. Open-source runtime. No license required.",
+    title: pageTitle,
+    description: pageDescription,
     url: "/matlab-online",
     siteName: "RunMat",
     type: "website",
+    images: [
+      {
+        url: heroPosterSrc,
+        width: 3840,
+        height: 2160,
+        alt: "RunMat wave simulation running in the browser",
+      },
+    ],
+    videos: [
+      {
+        url: heroVideoSrc,
+        type: "video/mp4",
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Run MATLAB Code Online - Instant GPU Sandbox",
-    description:
-      "Run MATLAB-syntax code in your browser with a built-in coding agent and automatic GPU acceleration. Open-source runtime. No license required.",
+    title: pageTitle,
+    description: pageDescription,
+    images: [heroPosterSrc],
   },
   robots: {
     index: true,
@@ -75,12 +159,6 @@ export const metadata: Metadata = {
     },
   },
 };
-
-const heroVideoSrc = "https://web.runmatstatic.com/video/clamp-agent-runmat.mp4";
-const heroPosterSrc = "https://web.runmatstatic.com/video/posters/clamp-agent-runmat.webp";
-
-const agentVideoSrc = "https://web.runmatstatic.com/video/runmat-agent-demo-speaker.mp4";
-const agentPosterSrc = "https://web.runmatstatic.com/video/posters/runmat-agent-demo-speaker.webp";
 
 const faqItems: FAQItem[] = [
   {
@@ -223,12 +301,11 @@ const jsonLd = {
       "@type": "WebPage",
       "@id": "https://runmat.com/matlab-online#webpage",
       url: "https://runmat.com/matlab-online",
-      name: "Run MATLAB Code Online - Instant GPU Sandbox",
-      description:
-        "Run MATLAB-syntax code in your browser with a built-in coding agent and automatic GPU acceleration. Open-source runtime. No license required.",
+      name: pageTitle,
+      description: pageDescription,
       inLanguage: "en",
       datePublished: "2026-02-03T00:00:00Z",
-      dateModified: "2026-04-21T00:00:00Z",
+      dateModified: "2026-05-27T00:00:00Z",
       isPartOf: { "@id": "https://runmat.com/#website" },
       breadcrumb: { "@id": "https://runmat.com/matlab-online#breadcrumb" },
       author: { "@id": "https://runmat.com/#organization" },
@@ -243,13 +320,12 @@ const jsonLd = {
     {
       "@type": "VideoObject",
       "@id": "https://runmat.com/matlab-online#hero-video",
-      name: "RunMat agent extending a clamped plate vibration simulation",
+      name: "RunMat wave simulation in the browser",
       description:
-        "RunMat's built-in agent adds a second strike to a clamped-plate vibration simulation and renders the combined interference pattern in the browser.",
+        "RunMat runs a GPU-accelerated wave simulation with MATLAB-syntax code directly in the browser.",
       thumbnailUrl: heroPosterSrc,
       contentUrl: heroVideoSrc,
-      uploadDate: "2026-05-14T00:00:00Z",
-      duration: "PT47S",
+      uploadDate: "2026-05-26T00:00:00Z",
     },
     {
       "@type": "BreadcrumbList",
@@ -268,8 +344,7 @@ const jsonLd = {
       "@type": "SoftwareApplication",
       "@id": "https://runmat.com/matlab-online#software",
       name: "RunMat",
-      description:
-        "RunMat is a high-performance, open-source runtime for math with a built-in coding agent that runs MATLAB-syntax code in the browser with GPU acceleration and no license required.",
+      description: pageDescription,
       applicationCategory: "ScientificApplication",
       applicationSubCategory: "EngineeringApplication",
       operatingSystem: ["Browser", "Windows", "macOS", "Linux"],
@@ -325,7 +400,7 @@ const jsonLd = {
           "@type": "HowToStep",
           position: 3,
           name: "Run on GPU and iterate",
-          text: "Execute on the GPU-accelerated runtime. Inspect plots and variables, then iterate.",
+          text: "Execute on the RunMat runtime with GPU acceleration when available. Inspect plots and variables, then iterate.",
         },
       ],
     },
@@ -358,11 +433,11 @@ export default function MatlabOnlinePage() {
                 MATLAB online alternative
               </div>
               <h1 className="font-bold text-left leading-tight tracking-tight text-3xl sm:text-4xl md:text-5xl">
-                Run MATLAB code in the browser blazing fast
+                Run MATLAB-syntax math in your browser
               </h1>
               <p className="max-w-[42rem] leading-relaxed text-foreground text-[0.938rem]">
-                RunMat executes MATLAB-syntax code in your browser with auto GPU acceleration. No account or licence
-                needed.
+                RunMat executes MATLAB-syntax code locally in your browser with GPU acceleration when available.
+                No account, no license server, no install.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
                 <Button
@@ -376,7 +451,7 @@ export default function MatlabOnlinePage() {
                     data-ph-capture-attribute-source="matlab-online-hero"
                     data-ph-capture-attribute-cta="try-runmat-browser"
                   >
-                    Try RunMat in your browser
+                    Open Browser Sandbox
                   </Link>
                 </Button>
                 <Button
@@ -385,9 +460,23 @@ export default function MatlabOnlinePage() {
                   asChild
                   className="h-12 px-8 text-base rounded-none bg-card border-border text-foreground"
                 >
-                  <Link href="/docs/desktop-browser-guide">View getting started</Link>
+                  <Link
+                    href="/download/latest"
+                    data-ph-capture-attribute-destination="download-latest"
+                    data-ph-capture-attribute-source="matlab-online-hero"
+                    data-ph-capture-attribute-cta="download-runmat"
+                  >
+                    <DetectedDownloadLabel />
+                  </Link>
                 </Button>
               </div>
+              <p className="text-sm text-muted-foreground">
+                Need another installer?{" "}
+                <Link href="/download" className="underline hover:text-foreground">
+                  View all download options
+                </Link>
+                .
+              </p>
             </div>
             <div className="rounded-xl border border-border bg-card p-2">
               <Link
@@ -405,7 +494,7 @@ export default function MatlabOnlinePage() {
                   playsInline
                   initialPosterVariant="poster"
                   poster={heroPosterSrc}
-                  aria-label="RunMat agent extending a clamped plate vibration simulation"
+                  aria-label="RunMat wave simulation running in the browser"
                 >
                   <source src={heroVideoSrc} type="video/mp4" />
                 </LazyVideo>
@@ -424,9 +513,11 @@ export default function MatlabOnlinePage() {
                 <div className="flex items-start gap-3">
                   <AlertTriangle className="mt-1 h-5 w-5 text-amber-600 dark:text-amber-400" />
                   <div>
-                    <h3 className="text-lg font-semibold text-foreground">MATLAB Online has friction</h3>
+                    <h3 className="text-lg font-semibold text-foreground">Why people look beyond MATLAB Online</h3>
                     <p className="text-[0.938rem] text-foreground mt-2">
-                      MATLAB Online runs your code on MathWorks&apos; servers, requires an account, and caps free usage at 20 hours/month with 15-minute idle timeouts. Engineers and students hit these limits regularly:
+                      MATLAB Online runs through MathWorks-hosted compute in the browser. Basic access includes 20 hours
+                      per month with 15-minute continuous compute and idle-time limits; full access depends on a linked license.
+                      That is convenient for some work, but engineers and students still hit friction:
                     </p>
                   </div>
                 </div>
@@ -440,7 +531,7 @@ export default function MatlabOnlinePage() {
                   <div className="rounded-lg border border-amber-500/30 bg-card px-5 py-4">
                     <p className="text-sm font-semibold text-foreground">Idle timeouts &amp; hour caps</p>
                     <p className="text-sm text-foreground mt-1">
-                      Sessions timeout after 15 minutes of inactivity. Free tier is capped at 20 hours/month.
+                      Basic sessions have 15-minute continuous compute and idle-time limits. Basic use is capped at 20 hours/month.
                     </p>
                   </div>
                   <div className="rounded-lg border border-amber-500/30 bg-card px-5 py-4">
@@ -452,19 +543,19 @@ export default function MatlabOnlinePage() {
                   <div className="rounded-lg border border-amber-500/30 bg-card px-5 py-4">
                     <p className="text-sm font-semibold text-foreground">No local GPU access</p>
                     <p className="text-sm text-foreground mt-1">
-                      Code runs on MathWorks&apos; servers, so you cannot use your own GPU for acceleration.
+                      Computation runs on MathWorks-hosted resources, so your laptop or workstation GPU is not the execution target.
                     </p>
                   </div>
                   <div className="rounded-lg border border-amber-500/30 bg-card px-5 py-4">
-                    <p className="text-sm font-semibold text-foreground">Specialty toolboxes cost extra</p>
+                    <p className="text-sm font-semibold text-foreground">Toolbox access depends on license</p>
                     <p className="text-sm text-foreground mt-1">
-                      Specialty toolboxes (Image Processing, Signal Processing, Optimization, etc.) are paid add-ons on top of base MATLAB.
+                      Basic MATLAB Online includes a limited set of commonly used products. Full product access depends on your license.
                     </p>
                   </div>
                   <div className="rounded-lg border border-amber-500/30 bg-card px-5 py-4">
                     <p className="text-sm font-semibold text-foreground">No built-in agent</p>
                     <p className="text-sm text-foreground mt-1">
-                      MathWorks&apos; <Link href="https://github.com/matlab/matlab-agentic-toolkit" target="_blank" rel="noopener nofollow" className="underline hover:text-foreground/80">Agentic Toolkit</Link> is a separate product for local MATLAB installs (Claude Code, Copilot, Codex, Gemini, or Amp). Its MCP returns command-window text — no plot or workspace introspection.
+                      MathWorks&apos; <Link href="https://github.com/matlab/matlab-agentic-toolkit" target="_blank" rel="noopener nofollow" className="underline hover:text-foreground/80">Agentic Toolkit</Link> connects supported AI coding agents to local MATLAB installs through MCP. RunMat puts the agent inside the same browser runtime as your workspace and plots.
                     </p>
                   </div>
                 </div>
@@ -482,9 +573,8 @@ export default function MatlabOnlinePage() {
               Meet RunMat: no license required
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
-              RunMat is an open-source runtime that understands MATLAB syntax and runs it directly in your browser.
-              Your code executes on your own device via WebAssembly, with GPU acceleration in browsers that support
-              WebGPU.
+              RunMat is an open-source runtime for MATLAB-syntax math. In the browser, your code runs on your own
+              device through WebAssembly, with GPU acceleration in browsers that support WebGPU.
             </p>
           </div>
           <div className="mx-auto mt-12 max-w-5xl">
@@ -551,7 +641,7 @@ export default function MatlabOnlinePage() {
                   data-ph-capture-attribute-source="matlab-online-features"
                   data-ph-capture-attribute-cta="try-runmat-browser"
                 >
-                  Try RunMat in your browser
+                  Open Browser Sandbox
                 </Link>
               </Button>
             </div>
@@ -567,7 +657,8 @@ export default function MatlabOnlinePage() {
               An engineering team, working alongside you
             </h2>
             <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
-              The agent runs your scenarios, reviews the code, and searches the project for what you need. You explore problems that used to take a team.
+              RunMat&apos;s agent writes MATLAB-syntax code, runs it in the same runtime, inspects workspace and plot state,
+              and returns each change as a reviewable diff.
             </p>
           </div>
           <div className="mx-auto max-w-3xl mb-8">
@@ -585,7 +676,7 @@ export default function MatlabOnlinePage() {
                   loop
                   playsInline
                   poster={agentPosterSrc}
-                  aria-label="RunMat agent exploring a speaker interference pattern in 3D — opens the sandbox"
+                  aria-label="RunMat 3D wave surface simulation - opens the sandbox"
                 >
                   <source src={agentVideoSrc} type="video/mp4" />
                 </LazyVideo>
@@ -622,6 +713,43 @@ export default function MatlabOnlinePage() {
         </div>
       </section>
 
+      {/* Runnable prompts */}
+      <section className="w-full py-16 md:py-24">
+        <div className="container mx-auto px-4 md:px-6 lg:px-8">
+          <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-6 text-center mb-12">
+            <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl text-foreground">
+              Try a prompt in the browser
+            </h2>
+            <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
+              Open a runnable sandbox session with starter code and an agent prompt already loaded.
+            </p>
+          </div>
+          <div className="mx-auto grid max-w-5xl grid-cols-1 gap-5 md:grid-cols-3">
+            {onlinePrompts.map(prompt => (
+              <div key={prompt.id} className="rounded-lg border border-border bg-card p-6 flex flex-col">
+                <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-foreground/10 text-foreground mb-3">
+                  <Sparkles className="h-5 w-5" />
+                </span>
+                <h3 className="text-lg font-semibold text-foreground">{prompt.title}</h3>
+                <p className="mt-2 flex-1 font-mono text-[0.875rem] leading-relaxed text-foreground">
+                  {prompt.prompt}
+                </p>
+                <TryInBrowserButton
+                  code={prompt.code}
+                  agentPrompt={prompt.prompt}
+                  source={`matlab-online-prompt-${prompt.id}`}
+                  exampleId={prompt.id}
+                  size="sm"
+                  className="mt-5 w-fit"
+                >
+                  Run prompt
+                </TryInBrowserButton>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
       {/* How it works */}
       <section className="w-full py-16 md:py-24 lg:py-32">
         <div className="container mx-auto px-4 md:px-6 lg:px-8">
@@ -654,8 +782,8 @@ export default function MatlabOnlinePage() {
                   3
                 </span>
                 <div>
-                  <h3 className="text-lg font-semibold text-foreground">Run on GPU and iterate</h3>
-                  <p className="text-[0.938rem] text-foreground mt-1">Execute on the same GPU-accelerated runtime. Inspect plots and variables, then iterate until the math is right.</p>
+                  <h3 className="text-lg font-semibold text-foreground">Run and iterate</h3>
+                  <p className="text-[0.938rem] text-foreground mt-1">Execute on the RunMat runtime with GPU acceleration when available. Inspect plots and variables, then iterate until the math is right.</p>
                 </div>
               </div>
             </div>
@@ -667,10 +795,10 @@ export default function MatlabOnlinePage() {
                 loop
                 playsInline
                 preload="metadata"
-                poster="https://web.runmatstatic.com/video/posters/runmat-wave-simulation.webp"
+                poster="https://web.runmatstatic.com/video/posters/runmat-wave-simulation-homepage.webp"
                 aria-label="RunMat wave simulation demo"
               >
-                <source src="https://web.runmatstatic.com/video/runmat-wave-simulation.mp4" type="video/mp4" />
+                <source src="https://web.runmatstatic.com/video/runmat-wave-simulation-homepage.mp4" type="video/mp4" />
               </video>
             </div>
           </div>
@@ -753,7 +881,10 @@ export default function MatlabOnlinePage() {
         <div className="container mx-auto px-4 md:px-6 lg:px-8">
           <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-8 text-center mb-12">
             <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-5xl text-foreground">RunMat vs. MATLAB Online</h2>
-            <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">RunMat runs in your browser with a built-in agent and GPU acceleration, no account needed. MATLAB Online runs on MathWorks&apos; servers behind a paid license and caps free usage.</p>
+            <p className="max-w-[42rem] leading-relaxed text-[0.938rem] text-foreground">
+              RunMat runs MATLAB-syntax code in your browser or desktop app with a built-in agent and local GPU acceleration
+              when available. MATLAB Online runs through MathWorks-hosted compute, with basic usage limits and license-linked full access.
+            </p>
           </div>
           <div className="mx-auto grid max-w-5xl gap-6 md:grid-cols-2">
             <Card className="border border-border bg-card shadow-sm">
@@ -829,9 +960,9 @@ export default function MatlabOnlinePage() {
                   <p className="text-[0.938rem] text-foreground">MathWorks&apos; cloud-hosted MATLAB IDE</p>
                 </div>
                 <ul className="space-y-2 text-sm">
-                  <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
-                    Requires paid MATLAB license
+                  <li className="flex items-start gap-3 text-foreground">
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-foreground">–</span>
+                    Basic access is free; full access depends on a linked license
                   </li>
                   <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
                     <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
@@ -843,15 +974,15 @@ export default function MatlabOnlinePage() {
                   </li>
                   <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
                     <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
-                    Free tier capped at 20 hours/month, 15-min idle timeout
+                    Basic access capped at 20 hours/month with 15-min compute and idle limits
                   </li>
                   <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
                     <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
                     Cloud-based execution
                   </li>
-                  <li className="flex items-start gap-3 text-green-600 dark:text-green-400">
-                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-green-600 dark:text-green-400">✓</span>
-                    GPU support available
+                  <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
+                    <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>
+                    No local GPU access; computation runs on MathWorks-hosted resources
                   </li>
                   <li className="flex items-start gap-3 text-red-600 dark:text-red-400">
                     <span className="mt-0.5 inline-flex items-center justify-center text-base text-red-600 dark:text-red-400">✕</span>

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 
 import Hero, { mediaToneClasses } from "@/components/Hero";
 import LazyVideo from "@/components/LazyVideo";
+import { TryInBrowserLink } from "@/components/TryInBrowserButton";
 import { Button } from "@/components/ui/button";
 import { DetectedDownloadLabel } from "@/components/DetectedDownloadLabel";
 import { CARD_PATTERNS } from "@/components/card-patterns";
@@ -12,6 +13,54 @@ const heroPosterSrc = "https://web.runmatstatic.com/video/posters/3D-wave-surfac
 const heroVideoSrc = "https://web.runmatstatic.com/video/3D-wave-surface-runmat.mp4";
 const pageDescription =
   "GPU-accelerated MATLAB-syntax math with real-time feedback and a runtime-aware agent. Open source across desktop, browser, and CLI. No license required.";
+
+const waveSurfaceExample = `% Wave surface demo
+n = 120;
+x = linspace(-6, 6, n);
+y = linspace(-6, 6, n);
+[X, Y] = meshgrid(x, y);
+R = sqrt(X.^2 + Y.^2);
+
+Z = sin(2.5 * R) .* exp(-0.08 * R.^2);
+surf(X, Y, Z);
+shading('interp');
+colormap('turbo');
+title('RunMat wave surface');`;
+
+const fastArrayExample = `% Fast array math example
+n = 400;
+t = linspace(0, 10, n);
+signal = sin(5 * t) .* exp(-t / 8);
+basis = [sin(t); cos(t); exp(-t / 5)];
+
+weights = basis * signal';
+bar(weights);
+title('Projected signal weights');`;
+
+const rippleSimulationExample = `% Ripple simulation example
+n = 120;
+x = linspace(-4, 4, n);
+y = linspace(-4, 4, n);
+[X, Y] = meshgrid(x, y);
+
+r1 = sqrt((X + 1.2).^2 + Y.^2);
+r2 = sqrt((X - 1.2).^2 + Y.^2);
+Z = sin(8 * r1) ./ (1 + 5 * r1) + sin(8 * r2) ./ (1 + 5 * r2);
+
+surf(X, Y, Z);
+shading('interp');
+title('Interfering ripples');`;
+
+const agentDiffStarter = `% Starter simulation for the RunMat agent
+n = 100;
+x = linspace(-5, 5, n);
+y = linspace(-5, 5, n);
+[X, Y] = meshgrid(x, y);
+R = sqrt(X.^2 + Y.^2);
+
+Z = sin(2 * R) .* exp(-0.05 * R.^2);
+surf(X, Y, Z);
+title('Baseline wave field');`;
 
 const jsonLd = {
   "@context": "https://schema.org",
@@ -216,6 +265,13 @@ const hero = {
     tone: "surface" as const,
     poster: heroPosterSrc,
     video: heroVideoSrc,
+    link: {
+      href: "/sandbox",
+      ariaLabel: "Open the wave surface demo in the RunMat sandbox",
+      code: waveSurfaceExample,
+      source: "homepage-hero-media",
+      exampleId: "homepage-wave-surface",
+    },
   },
 };
 
@@ -233,6 +289,13 @@ const features = [
     mediaLabel: "Runtime code media",
     mediaNote: "MATLAB code snippet with a matrix math error underline. Put logos for Apple, NVIDIA and ARM GPU under.",
     mediaImage: "https://web.runmatstatic.com/gpu-mistmatch.webp",
+    mediaLink: {
+      href: "/sandbox",
+      ariaLabel: "Open a fast array math example in the RunMat sandbox",
+      code: fastArrayExample,
+      source: "homepage-runtime-media",
+      exampleId: "homepage-fast-array-math",
+    },
     tone: "muted" as const,
   },
   {
@@ -252,6 +315,13 @@ const features = [
     mediaNote: "Showing a 3d simulation of raindrops on a surface of water.",
     mediaPoster: "https://web.runmatstatic.com/video/posters/runmat-wave-simulation-homepage.webp",
     mediaVideo: "https://web.runmatstatic.com/video/runmat-wave-simulation-homepage.mp4",
+    mediaLink: {
+      href: "/sandbox",
+      ariaLabel: "Open a ripple simulation example in the RunMat sandbox",
+      code: rippleSimulationExample,
+      source: "homepage-simulation-media",
+      exampleId: "homepage-ripple-simulation",
+    },
     tone: "brand" as const,
   },
   {
@@ -270,6 +340,15 @@ const features = [
     mediaLabel: "Agent workflow media",
     mediaNote: "Agent working with code, plots, and runtime state.",
     mediaImage: "https://web.runmatstatic.com/runmat-agent-diff-rain.webp",
+    mediaLink: {
+      href: "/sandbox",
+      ariaLabel: "Open the RunMat agent with a simulation editing prompt",
+      code: agentDiffStarter,
+      agentPrompt:
+        "Modify this wave simulation, run it, inspect the plot, and explain the change as a reviewable diff.",
+      source: "homepage-agent-media",
+      exampleId: "homepage-agent-diff",
+    },
     tone: "muted" as const,
   },
   {
@@ -287,6 +366,12 @@ const features = [
     mediaNote: "Run history, variable history, and collaboration.",
     mediaPoster: "https://web.runmatstatic.com/video/posters/fft-run-versions.webp",
     mediaVideo: "https://web.runmatstatic.com/video/fft-run-versions.mp4",
+    mediaLink: {
+      href: "/sandbox",
+      ariaLabel: "Open the RunMat sandbox",
+      source: "homepage-history-media",
+      exampleId: "homepage-history",
+    },
     tone: "brand" as const,
   },
 ] as const;
@@ -399,38 +484,40 @@ export default function HomePage() {
                       : "2xl:col-span-8 2xl:col-start-1 2xl:row-start-1"
                   }
                 >
-                  <div
-                    role="img"
-                    aria-label={feature.mediaLabel}
-                    className={cn(
-                      "relative aspect-[16/9] w-full overflow-hidden rounded-2xl border border-border 2xl:aspect-auto 2xl:min-h-[430px]",
-                      mediaToneClasses[feature.tone],
-                    )}
-                  >
-                    {"mediaVideo" in feature ? (
-                      <LazyVideo
-                        className="absolute inset-0 h-full w-full object-cover"
-                        muted
-                        loop
-                        playsInline
-                        deferPosterUntilVisible
-                        initialPosterVariant="poster"
-                        poster={feature.mediaPoster}
-                        aria-label={feature.mediaLabel}
-                      >
-                        <source src={feature.mediaVideo} type="video/mp4" />
-                      </LazyVideo>
-                    ) : (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={feature.mediaImage}
-                        alt={feature.mediaLabel}
-                        loading="lazy"
-                        decoding="async"
-                        className="absolute inset-0 h-full w-full object-cover"
-                      />
-                    )}
-                  </div>
+                  <TryInBrowserLink {...feature.mediaLink} className="rounded-2xl">
+                    <div
+                      role="img"
+                      aria-label={feature.mediaLabel}
+                      className={cn(
+                        "relative aspect-[16/9] w-full overflow-hidden rounded-2xl border border-border 2xl:aspect-auto 2xl:min-h-[430px]",
+                        mediaToneClasses[feature.tone],
+                      )}
+                    >
+                      {"mediaVideo" in feature ? (
+                        <LazyVideo
+                          className="absolute inset-0 h-full w-full object-cover"
+                          muted
+                          loop
+                          playsInline
+                          deferPosterUntilVisible
+                          initialPosterVariant="poster"
+                          poster={feature.mediaPoster}
+                          aria-label={feature.mediaLabel}
+                        >
+                          <source src={feature.mediaVideo} type="video/mp4" />
+                        </LazyVideo>
+                      ) : (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={feature.mediaImage}
+                          alt={feature.mediaLabel}
+                          loading="lazy"
+                          decoding="async"
+                          className="absolute inset-0 h-full w-full object-cover"
+                        />
+                      )}
+                    </div>
+                  </TryInBrowserLink>
                 </div>
               </div>
             ))}

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 import LazyVideo from "@/components/LazyVideo";
+import { TryInBrowserLink } from "@/components/TryInBrowserButton";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -40,6 +41,14 @@ interface HeroProps {
     image?: string;
     poster?: string;
     video?: string;
+    link?: {
+      href?: string;
+      ariaLabel: string;
+      code?: string;
+      agentPrompt?: string;
+      source?: string;
+      exampleId?: string;
+    };
   };
 }
 
@@ -51,6 +60,39 @@ export default function Hero({
   supportingLinks,
   media,
 }: HeroProps) {
+  const mediaBlock = (
+    <div
+      role="img"
+      aria-label={media.label}
+      className={cn(
+        "relative aspect-video w-full overflow-hidden rounded-3xl border",
+        mediaToneClasses[media.tone ?? "muted"],
+        mediaToneBorderClasses[media.tone ?? "muted"],
+      )}
+    >
+      {media.video ? (
+        <LazyVideo
+          className="absolute inset-0 h-full w-full object-cover"
+          muted
+          loop
+          playsInline
+          initialPosterVariant="poster"
+          poster={media.poster}
+          aria-label={media.label}
+        >
+          <source src={media.video} type="video/mp4" />
+        </LazyVideo>
+      ) : media.image ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={media.image}
+          alt={media.label}
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+      ) : null}
+    </div>
+  );
+
   return (
     <section
       className="relative isolate -mt-px overflow-hidden bg-background pt-24 text-foreground md:pt-32"
@@ -97,36 +139,13 @@ export default function Hero({
         </div>
 
         <div className="mx-auto mt-24 max-w-5xl pb-20 md:mt-32">
-          <div
-            role="img"
-            aria-label={media.label}
-            className={cn(
-              "relative aspect-video w-full overflow-hidden rounded-3xl border",
-              mediaToneClasses[media.tone ?? "muted"],
-              mediaToneBorderClasses[media.tone ?? "muted"],
-            )}
-          >
-            {media.video ? (
-              <LazyVideo
-                className="absolute inset-0 h-full w-full object-cover"
-                muted
-                loop
-                playsInline
-                initialPosterVariant="poster"
-                poster={media.poster}
-                aria-label={media.label}
-              >
-                <source src={media.video} type="video/mp4" />
-              </LazyVideo>
-            ) : media.image ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={media.image}
-                alt={media.label}
-                className="absolute inset-0 h-full w-full object-cover"
-              />
-            ) : null}
-          </div>
+          {media.link ? (
+            <TryInBrowserLink {...media.link} className="rounded-3xl">
+              {mediaBlock}
+            </TryInBrowserLink>
+          ) : (
+            mediaBlock
+          )}
         </div>
       </div>
     </section>

--- a/website/components/TryInBrowserButton.tsx
+++ b/website/components/TryInBrowserButton.tsx
@@ -122,24 +122,44 @@ export function TryInBrowserLink({
       data-ph-capture-attribute-cta="open-product-media"
       data-ph-capture-attribute-example-id={exampleId}
       onClick={(event) => {
+        const isNormalLeftClick =
+          event.button === 0 &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !event.shiftKey &&
+          !event.altKey;
+
+        if (!isNormalLeftClick) {
+          return;
+        }
+
         event.preventDefault();
-        openWorkspace(
-          [
+
+        try {
+          const url = openWorkspace(
+            [
+              {
+                path: "/example.m",
+                content: code ?? `% ${agentPrompt}`,
+              },
+            ],
             {
-              path: "/example.m",
-              content: code ?? `% ${agentPrompt}`,
+              targetPath: href,
+              agentPrompt,
+              newTab: false,
+              metadata: {
+                source,
+                ...(exampleId ? { exampleId } : {}),
+              },
             },
-          ],
-          {
-            targetPath: href,
-            agentPrompt,
-            newTab: false,
-            metadata: {
-              source,
-              ...(exampleId ? { exampleId } : {}),
-            },
-          },
-        );
+          );
+
+          if (!url) {
+            window.location.assign(href);
+          }
+        } catch {
+          window.location.assign(href);
+        }
       }}
     >
       {children}

--- a/website/components/TryInBrowserButton.tsx
+++ b/website/components/TryInBrowserButton.tsx
@@ -3,12 +3,25 @@
 import { Button } from "@/components/ui/button";
 import { openWorkspace } from "@/lib/desktop";
 import { cn } from "@/lib/utils";
+import Link from "next/link";
+import type { ReactNode } from "react";
 
 interface TryInBrowserButtonProps extends React.ComponentProps<typeof Button> {
   code?: string;
   agentPrompt?: string;
   source?: string;
   exampleId?: string;
+}
+
+interface TryInBrowserLinkProps {
+  href?: string;
+  ariaLabel: string;
+  code?: string;
+  agentPrompt?: string;
+  source?: string;
+  exampleId?: string;
+  className?: string;
+  children: ReactNode;
 }
 
 const normalizeExampleId = (value?: string) => value?.trim() || undefined;
@@ -65,5 +78,71 @@ export function TryInBrowserButton({
           </svg>
           {children ?? "Run in browser"}
       </Button>
+  );
+}
+
+export function TryInBrowserLink({
+  href = "/sandbox",
+  ariaLabel,
+  code,
+  agentPrompt,
+  source = "try-in-browser-link",
+  exampleId,
+  className,
+  children,
+}: TryInBrowserLinkProps) {
+  const linkClassName = cn(
+    "block focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+    className,
+  );
+
+  if (!code && !agentPrompt) {
+    return (
+      <Link
+        href={href}
+        aria-label={ariaLabel}
+        className={linkClassName}
+        data-ph-capture-attribute-destination="sandbox"
+        data-ph-capture-attribute-source={source}
+        data-ph-capture-attribute-cta="open-product-media"
+        data-ph-capture-attribute-example-id={exampleId}
+      >
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      aria-label={ariaLabel}
+      className={linkClassName}
+      data-ph-capture-attribute-destination="sandbox"
+      data-ph-capture-attribute-source={source}
+      data-ph-capture-attribute-cta="open-product-media"
+      data-ph-capture-attribute-example-id={exampleId}
+      onClick={(event) => {
+        event.preventDefault();
+        openWorkspace(
+          [
+            {
+              path: "/example.m",
+              content: code ?? `% ${agentPrompt}`,
+            },
+          ],
+          {
+            targetPath: href,
+            agentPrompt,
+            newTab: false,
+            metadata: {
+              source,
+              ...(exampleId ? { exampleId } : {}),
+            },
+          },
+        );
+      }}
+    >
+      {children}
+    </a>
   );
 }


### PR DESCRIPTION
…TryInBrowser functionality. Added new MATLAB code snippets for wave surface, fast array math, ripple simulation, and agent starter simulation. Updated Hero and TryInBrowserButton components to support new links and examples. Improved metadata and descriptions across pages for better SEO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side marketing and navigation changes only; sandbox hydration uses existing openWorkspace with fallback to /sandbox.
> 
> **Overview**
> Marketing pages now open the sandbox with **preloaded MATLAB starter code and optional agent prompts** via the existing `openWorkspace` payload flow, instead of bare `/sandbox` links.
> 
> A new **`TryInBrowserLink`** wraps hero and feature media on the homepage (and optional hero media config) so clicks hydrate `/example.m` plus analytics `source` / `exampleId`. **`TryInBrowserButton`** usage expands on the agent page: the **Start from anywhere** cards are refactored into a **`startCards`** config (damped oscillator, broken filter, lab data, thermal wall) each with code + `agentPrompt`.
> 
> The **MATLAB Online** page gets a content/SEO pass (titles, OG/Twitter images, JSON-LD dates), **swapped hero/agent/how-it-works videos**, softer **MathWorks limit/licensing** copy via `matlabOnlineLimits`, hero secondary CTA toward **download**, and a new **Try a prompt in the browser** section with three runnable examples. Minor **agent page hero** video chrome styling is simplified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc80648ef0c4da4a4fba97902ce4f329ad7415b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded "Try in Browser" across the site: homepage, MATLAB Online, and AI Agent start cards so examples and prompts open directly in the sandbox.
  * Added start/example card grids and a new "Runnable Prompts" section for ready-to-run workflows.

* **Documentation**
  * Centralized and updated SEO/social metadata and rich-snippet content.

* **Style**
  * Refined hero video and media presentation styling and layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->