### PR TITLE
Implemented ss builtin

### DIFF
--- a/crates/runmat-runtime/src/builtins/builtins-json/ss.json
+++ b/crates/runmat-runtime/src/builtins/builtins-json/ss.json
@@ -1,0 +1,121 @@
+{
+  "title": "ss",
+  "category": "control",
+  "keywords": [
+    "ss",
+    "state space",
+    "control system",
+    "state matrix",
+    "sample time"
+  ],
+  "summary": "Create a state-space model object from A, B, C, and D matrices.",
+  "references": [],
+  "gpu_support": {
+    "elementwise": false,
+    "reduction": false,
+    "precisions": [],
+    "broadcasting": "none",
+    "notes": "`ss` constructs host-side metadata. If matrix inputs are gpuArray values, RunMat gathers them before validating dimensions and creating the object."
+  },
+  "fusion": {
+    "elementwise": false,
+    "reduction": false,
+    "max_inputs": 0,
+    "constants": "inline",
+    "notes": "`ss` is not fused; it constructs a host-side object."
+  },
+  "requires_feature": null,
+  "tested": {
+    "unit": "builtins::control::ss::tests",
+    "integration": "crates/runmat-vm/tests/control.rs"
+  },
+  "description": "`ss(A, B, C, D)` creates a lightweight state-space model object from finite real numeric matrices. `A` is the state matrix, `B` maps inputs to states, `C` maps states to outputs, and `D` is direct feedthrough.",
+  "behaviors": [
+    "Returns an object whose class name is `ss`.",
+    "Stores `A`, `B`, `C`, `D`, `Ts`, `InputDelay`, `OutputDelay`, `StateName`, `InputName`, and `OutputName` properties.",
+    "Preserves the input matrix orientations on the returned object.",
+    "Uses continuous-time defaults with `Ts` equal to `0`.",
+    "`ss(A, B, C, D, Ts)` stores a finite non-negative sample time.",
+    "`ss(A, B, C, D, 'Ts', Ts)` and `ss(A, B, C, D, 'SampleTime', Ts)` store a finite non-negative sample time.",
+    "Numeric scalar inputs are treated as 1-by-1 matrices and are accepted only when the resulting dimensions are consistent.",
+    "Complex, sparse, descriptor-form, uncertain, identified, and generalized models are not supported in this initial implementation."
+  ],
+  "examples": [
+    {
+      "description": "Creating a continuous-time state-space model",
+      "input": "A = [0 1; -2 -3];\nB = [0; 1];\nC = [1 0];\nD = 0;\nG = ss(A, B, C, D);\nclass(G)",
+      "output": "ans = \"ss\""
+    },
+    {
+      "description": "Reading stored state-space matrices",
+      "input": "G = ss([0 1; -2 -3], [0; 1], [1 0], 0);\nfprintf(\"%.0f %.0f %.0f %.0f %.0f %.0f\\n\", G.A(1), G.A(2), G.A(3), G.A(4), G.B(1), G.B(2));",
+      "output": "0 -2 1 -3 0 1"
+    },
+    {
+      "description": "Creating a discrete-time model",
+      "input": "G = ss(0.5, 1, 1, 0, 0.1);\nfprintf(\"%.1f\\n\", G.Ts);",
+      "output": "0.1"
+    },
+    {
+      "description": "Specifying sample time with a name-value pair",
+      "input": "G = ss(0.5, 1, 1, 0, 'SampleTime', 0.2);\nfprintf(\"%.1f\\n\", G.Ts);",
+      "output": "0.2"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Does `ss` simulate step or impulse responses?",
+      "answer": "No. This builtin constructs a state-space object. Response functions can add `ss` parsing separately."
+    },
+    {
+      "question": "Does `ss` accept complex or sparse matrices?",
+      "answer": "Not yet. Inputs must be finite real numeric scalars or dense matrices."
+    },
+    {
+      "question": "How are dimensions validated?",
+      "answer": "`A` must be n-by-n, `B` must be n-by-nu, `C` must be ny-by-n, and `D` must be ny-by-nu."
+    },
+    {
+      "question": "Will `ss(gpuArray(A), B, C, D)` return a gpuArray-backed object?",
+      "answer": "No. `ss` gathers gpuArray inputs and stores host tensors on the returned object."
+    }
+  ],
+  "links": [
+    {
+      "label": "tf",
+      "url": "./tf"
+    },
+    {
+      "label": "step",
+      "url": "./step"
+    },
+    {
+      "label": "impulse",
+      "url": "./impulse"
+    }
+  ],
+  "source": {
+    "label": "`crates/runmat-runtime/src/builtins/control/ss.rs`",
+    "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/control/ss.rs"
+  },
+  "syntax": {
+    "example": {
+      "description": "Supported forms",
+      "input": "G = ss(A, B, C, D)\nG = ss(A, B, C, D, Ts)\nG = ss(A, B, C, D, 'Ts', Ts)\nG = ss(A, B, C, D, 'SampleTime', Ts)",
+      "output": "G is an ss object."
+    },
+    "points": [
+      "`A`, `B`, `C`, and `D` must be finite real numeric scalars or dense matrices.",
+      "`Ts` is optional and must be a finite non-negative scalar.",
+      "The object stores matrices exactly in the provided orientation after gpuArray gathering."
+    ]
+  },
+  "validation": {
+    "summary": "`ss` validates finite real matrix inputs, state-space dimension consistency, supported name-value options, and sample-time constraints before constructing the host-side object. Unit and integration tests cover continuous and discrete constructors, property access, invalid dimensions, invalid sample times, descriptor signatures, and gpuArray gathering.",
+    "implementation": {
+      "label": "`crates/runmat-runtime/src/builtins/control/ss.rs`",
+      "url": "https://github.com/runmat-org/runmat/blob/main/crates/runmat-runtime/src/builtins/control/ss.rs"
+    }
+  },
+  "gpu_residency": "`ss` is a host-side object constructor. gpuArray matrix inputs are gathered before object construction, and the returned state-space object does not live on the GPU."
+}

--- a/crates/runmat-runtime/src/builtins/control/mod.rs
+++ b/crates/runmat-runtime/src/builtins/control/mod.rs
@@ -5,6 +5,7 @@ use crate::RuntimeError;
 pub mod db;
 pub mod impulse;
 pub mod nyquist;
+pub mod ss;
 pub mod step;
 pub mod tf;
 pub(crate) mod type_resolvers;

--- a/crates/runmat-runtime/src/builtins/control/ss.rs
+++ b/crates/runmat-runtime/src/builtins/control/ss.rs
@@ -1,0 +1,719 @@
+//! MATLAB-compatible `ss` state-space model constructor for RunMat.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use runmat_builtins::{
+    Access, BuiltinCompletionPolicy, BuiltinDescriptor, BuiltinErrorDescriptor, BuiltinOutputMode,
+    BuiltinParamArity, BuiltinParamDescriptor, BuiltinParamType, BuiltinSignatureDescriptor,
+    CellArray, CharArray, ClassDef, MethodDef, ObjectInstance, PropertyDef, Tensor, Value,
+};
+use runmat_macros::runtime_builtin;
+
+use crate::builtins::common::spec::{
+    BroadcastSemantics, BuiltinFusionSpec, BuiltinGpuSpec, ConstantStrategy, GpuOpKind,
+    ReductionNaN, ResidencyPolicy, ShapeRequirements,
+};
+use crate::builtins::control::type_resolvers::ss_type;
+use crate::{build_runtime_error, dispatcher, BuiltinResult, RuntimeError};
+
+const BUILTIN_NAME: &str = "ss";
+const SS_CLASS: &str = "ss";
+
+static SS_CLASS_REGISTERED: OnceLock<()> = OnceLock::new();
+
+const SS_OUTPUT_SYS: [BuiltinParamDescriptor; 1] = [BuiltinParamDescriptor {
+    name: "sys",
+    ty: BuiltinParamType::Any,
+    arity: BuiltinParamArity::Required,
+    default: None,
+    description: "State-space model object.",
+}];
+const SS_PARAM_A: BuiltinParamDescriptor = BuiltinParamDescriptor {
+    name: "A",
+    ty: BuiltinParamType::NumericArray,
+    arity: BuiltinParamArity::Required,
+    default: None,
+    description: "State matrix with shape n-by-n.",
+};
+const SS_PARAM_B: BuiltinParamDescriptor = BuiltinParamDescriptor {
+    name: "B",
+    ty: BuiltinParamType::NumericArray,
+    arity: BuiltinParamArity::Required,
+    default: None,
+    description: "Input matrix with shape n-by-nu.",
+};
+const SS_PARAM_C: BuiltinParamDescriptor = BuiltinParamDescriptor {
+    name: "C",
+    ty: BuiltinParamType::NumericArray,
+    arity: BuiltinParamArity::Required,
+    default: None,
+    description: "Output matrix with shape ny-by-n.",
+};
+const SS_PARAM_D: BuiltinParamDescriptor = BuiltinParamDescriptor {
+    name: "D",
+    ty: BuiltinParamType::NumericArray,
+    arity: BuiltinParamArity::Required,
+    default: None,
+    description: "Feedthrough matrix with shape ny-by-nu.",
+};
+const SS_INPUTS_ABCD: [BuiltinParamDescriptor; 4] =
+    [SS_PARAM_A, SS_PARAM_B, SS_PARAM_C, SS_PARAM_D];
+const SS_INPUTS_ABCD_TS: [BuiltinParamDescriptor; 5] = [
+    SS_PARAM_A,
+    SS_PARAM_B,
+    SS_PARAM_C,
+    SS_PARAM_D,
+    BuiltinParamDescriptor {
+        name: "Ts",
+        ty: BuiltinParamType::NumericScalar,
+        arity: BuiltinParamArity::Optional,
+        default: Some("0.0"),
+        description: "Sample time (0 for continuous-time model).",
+    },
+];
+const SS_INPUTS_ABCD_NAMEVALUE: [BuiltinParamDescriptor; 6] = [
+    SS_PARAM_A,
+    SS_PARAM_B,
+    SS_PARAM_C,
+    SS_PARAM_D,
+    BuiltinParamDescriptor {
+        name: "name",
+        ty: BuiltinParamType::StringScalar,
+        arity: BuiltinParamArity::Variadic,
+        default: None,
+        description: "Option name ('Ts' or 'SampleTime').",
+    },
+    BuiltinParamDescriptor {
+        name: "value",
+        ty: BuiltinParamType::Any,
+        arity: BuiltinParamArity::Variadic,
+        default: None,
+        description: "Option value.",
+    },
+];
+const SS_SIGNATURES: [BuiltinSignatureDescriptor; 4] = [
+    BuiltinSignatureDescriptor {
+        label: "sys = ss(A, B, C, D)",
+        inputs: &SS_INPUTS_ABCD,
+        outputs: &SS_OUTPUT_SYS,
+    },
+    BuiltinSignatureDescriptor {
+        label: "sys = ss(A, B, C, D, Ts)",
+        inputs: &SS_INPUTS_ABCD_TS,
+        outputs: &SS_OUTPUT_SYS,
+    },
+    BuiltinSignatureDescriptor {
+        label: "sys = ss(A, B, C, D, \"Ts\", Ts)",
+        inputs: &SS_INPUTS_ABCD_NAMEVALUE,
+        outputs: &SS_OUTPUT_SYS,
+    },
+    BuiltinSignatureDescriptor {
+        label: "sys = ss(A, B, C, D, name, value, ...)",
+        inputs: &SS_INPUTS_ABCD_NAMEVALUE,
+        outputs: &SS_OUTPUT_SYS,
+    },
+];
+const SS_ERROR_INVALID_ARGUMENT: BuiltinErrorDescriptor = BuiltinErrorDescriptor {
+    code: "RM.SS.INVALID_ARGUMENT",
+    identifier: Some("RunMat:ss:InvalidArgument"),
+    when: "Arguments do not match supported ss invocation forms.",
+    message: "ss: invalid argument",
+};
+const SS_ERROR_INVALID_OPTION: BuiltinErrorDescriptor = BuiltinErrorDescriptor {
+    code: "RM.SS.INVALID_OPTION",
+    identifier: Some("RunMat:ss:InvalidOption"),
+    when: "A name/value option token is unsupported or malformed.",
+    message: "ss: invalid option",
+};
+const SS_ERROR_INVALID_SAMPLE_TIME: BuiltinErrorDescriptor = BuiltinErrorDescriptor {
+    code: "RM.SS.INVALID_SAMPLE_TIME",
+    identifier: Some("RunMat:ss:InvalidSampleTime"),
+    when: "Sample time is not a finite non-negative scalar.",
+    message: "ss: sample time must be a finite non-negative scalar",
+};
+const SS_ERROR_INVALID_DIMENSIONS: BuiltinErrorDescriptor = BuiltinErrorDescriptor {
+    code: "RM.SS.INVALID_DIMENSIONS",
+    identifier: Some("RunMat:ss:InvalidDimensions"),
+    when: "A, B, C, and D dimensions do not define a consistent state-space model.",
+    message: "ss: invalid state-space matrix dimensions",
+};
+const SS_ERROR_UNSUPPORTED_INPUT: BuiltinErrorDescriptor = BuiltinErrorDescriptor {
+    code: "RM.SS.UNSUPPORTED_INPUT",
+    identifier: Some("RunMat:ss:UnsupportedInput"),
+    when: "An input is complex, sparse, logical, or another unsupported model form.",
+    message: "ss: unsupported input",
+};
+const SS_ERROR_INTERNAL: BuiltinErrorDescriptor = BuiltinErrorDescriptor {
+    code: "RM.SS.INTERNAL",
+    identifier: Some("RunMat:ss:Internal"),
+    when: "Internal tensor/object construction failed.",
+    message: "ss: internal error",
+};
+const SS_ERRORS: [BuiltinErrorDescriptor; 6] = [
+    SS_ERROR_INVALID_ARGUMENT,
+    SS_ERROR_INVALID_OPTION,
+    SS_ERROR_INVALID_SAMPLE_TIME,
+    SS_ERROR_INVALID_DIMENSIONS,
+    SS_ERROR_UNSUPPORTED_INPUT,
+    SS_ERROR_INTERNAL,
+];
+pub const SS_DESCRIPTOR: BuiltinDescriptor = BuiltinDescriptor {
+    signatures: &SS_SIGNATURES,
+    output_mode: BuiltinOutputMode::Fixed,
+    completion_policy: BuiltinCompletionPolicy::Public,
+    errors: &SS_ERRORS,
+};
+
+#[runmat_macros::register_gpu_spec(builtin_path = "crate::builtins::control::ss")]
+pub const GPU_SPEC: BuiltinGpuSpec = BuiltinGpuSpec {
+    name: "ss",
+    op_kind: GpuOpKind::Custom("state-space-model-constructor"),
+    supported_precisions: &[],
+    broadcast: BroadcastSemantics::None,
+    provider_hooks: &[],
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    residency: ResidencyPolicy::GatherImmediately,
+    nan_mode: ReductionNaN::Include,
+    two_pass_threshold: None,
+    workgroup_size: None,
+    accepts_nan_mode: false,
+    notes: "Object construction runs on the host. gpuArray matrix inputs are gathered before validating and storing the state-space metadata.",
+};
+
+#[runmat_macros::register_fusion_spec(builtin_path = "crate::builtins::control::ss")]
+pub const FUSION_SPEC: BuiltinFusionSpec = BuiltinFusionSpec {
+    name: "ss",
+    shape: ShapeRequirements::Any,
+    constant_strategy: ConstantStrategy::InlineLiteral,
+    elementwise: None,
+    reduction: None,
+    emits_nan: false,
+    notes: "State-space construction is metadata-only and terminates numeric fusion chains.",
+};
+
+fn ss_error(error: &'static BuiltinErrorDescriptor) -> RuntimeError {
+    ss_error_with_message(error.message, error)
+}
+
+fn ss_error_with_detail(
+    error: &'static BuiltinErrorDescriptor,
+    detail: impl AsRef<str>,
+) -> RuntimeError {
+    ss_error_with_message(format!("{}: {}", error.message, detail.as_ref()), error)
+}
+
+fn ss_error_with_message(
+    message: impl Into<String>,
+    error: &'static BuiltinErrorDescriptor,
+) -> RuntimeError {
+    let mut builder = build_runtime_error(message).with_builtin(BUILTIN_NAME);
+    if let Some(identifier) = error.identifier {
+        builder = builder.with_identifier(identifier);
+    }
+    builder.build()
+}
+
+fn ensure_ss_class_registered() {
+    SS_CLASS_REGISTERED.get_or_init(|| {
+        let mut properties = HashMap::new();
+        for name in [
+            "A",
+            "B",
+            "C",
+            "D",
+            "Ts",
+            "InputDelay",
+            "OutputDelay",
+            "StateName",
+            "InputName",
+            "OutputName",
+        ] {
+            properties.insert(
+                name.to_string(),
+                PropertyDef {
+                    name: name.to_string(),
+                    is_static: false,
+                    is_dependent: false,
+                    get_access: Access::Public,
+                    set_access: Access::Public,
+                    default_value: None,
+                },
+            );
+        }
+
+        let methods: HashMap<String, MethodDef> = HashMap::new();
+        runmat_builtins::register_class(ClassDef {
+            name: SS_CLASS.to_string(),
+            parent: None,
+            properties,
+            methods,
+        });
+    });
+}
+
+#[runtime_builtin(
+    name = "ss",
+    category = "control",
+    summary = "Create a state-space model object from A, B, C, and D matrices.",
+    keywords = "ss,state space,control system,model,matrices",
+    type_resolver(ss_type),
+    descriptor(crate::builtins::control::ss::SS_DESCRIPTOR),
+    builtin_path = "crate::builtins::control::ss"
+)]
+async fn ss_builtin(
+    a: Value,
+    b: Value,
+    c: Value,
+    d: Value,
+    rest: Vec<Value>,
+) -> BuiltinResult<Value> {
+    let options = SsOptions::parse(&rest)?;
+    let a = RealMatrix::parse("A", a).await?;
+    let b = RealMatrix::parse("B", b).await?;
+    let c = RealMatrix::parse("C", c).await?;
+    let d = RealMatrix::parse("D", d).await?;
+
+    validate_state_space_dimensions(&a, &b, &c, &d)?;
+
+    let state_count = a.rows;
+    let input_count = b.cols;
+    let output_count = c.rows;
+
+    ensure_ss_class_registered();
+    let mut object = ObjectInstance::new(SS_CLASS.to_string());
+    object.properties.insert("A".to_string(), a.into_value());
+    object.properties.insert("B".to_string(), b.into_value());
+    object.properties.insert("C".to_string(), c.into_value());
+    object.properties.insert("D".to_string(), d.into_value());
+    object
+        .properties
+        .insert("Ts".to_string(), Value::Num(options.sample_time));
+    object.properties.insert(
+        "InputDelay".to_string(),
+        zero_tensor_value(vec![1, input_count])?,
+    );
+    object.properties.insert(
+        "OutputDelay".to_string(),
+        zero_tensor_value(vec![output_count, 1])?,
+    );
+    object.properties.insert(
+        "StateName".to_string(),
+        empty_name_cell_value(state_count, 1)?,
+    );
+    object.properties.insert(
+        "InputName".to_string(),
+        empty_name_cell_value(input_count, 1)?,
+    );
+    object.properties.insert(
+        "OutputName".to_string(),
+        empty_name_cell_value(output_count, 1)?,
+    );
+    Ok(Value::Object(object))
+}
+
+#[derive(Clone)]
+struct SsOptions {
+    sample_time: f64,
+}
+
+impl SsOptions {
+    fn parse(rest: &[Value]) -> BuiltinResult<Self> {
+        let mut options = Self { sample_time: 0.0 };
+
+        match rest {
+            [] => {}
+            [sample_time] => options.sample_time = parse_sample_time(sample_time)?,
+            _ => {
+                if !rest.len().is_multiple_of(2) {
+                    return Err(ss_error_with_detail(
+                        &SS_ERROR_INVALID_ARGUMENT,
+                        "optional arguments must be name-value pairs or a scalar sample time",
+                    ));
+                }
+                let mut idx = 0;
+                while idx < rest.len() {
+                    let name = scalar_text(&rest[idx], "option name")?;
+                    let lowered = name.trim().to_ascii_lowercase();
+                    let value = &rest[idx + 1];
+                    match lowered.as_str() {
+                        "ts" | "sampletime" => options.sample_time = parse_sample_time(value)?,
+                        _ => {
+                            return Err(ss_error_with_detail(
+                                &SS_ERROR_INVALID_OPTION,
+                                format!("unsupported option '{name}'"),
+                            ));
+                        }
+                    }
+                    idx += 2;
+                }
+            }
+        }
+
+        Ok(options)
+    }
+}
+
+fn parse_sample_time(value: &Value) -> BuiltinResult<f64> {
+    let sample_time = match value {
+        Value::Num(n) => *n,
+        Value::Int(i) => i.to_f64(),
+        other => {
+            return Err(ss_error_with_detail(
+                &SS_ERROR_INVALID_SAMPLE_TIME,
+                format!("expected non-negative scalar, got {other:?}"),
+            ))
+        }
+    };
+    if !sample_time.is_finite() || sample_time < 0.0 {
+        return Err(ss_error(&SS_ERROR_INVALID_SAMPLE_TIME));
+    }
+    Ok(sample_time)
+}
+
+fn scalar_text(value: &Value, context: &str) -> BuiltinResult<String> {
+    match value {
+        Value::String(text) => Ok(text.clone()),
+        Value::StringArray(array) if array.data.len() == 1 => Ok(array.data[0].clone()),
+        Value::CharArray(array) if array.rows == 1 => Ok(array.data.iter().collect()),
+        other => Err(ss_error_with_detail(
+            &SS_ERROR_INVALID_ARGUMENT,
+            format!("{context} must be a string scalar or character vector, got {other:?}"),
+        )),
+    }
+}
+
+#[derive(Clone)]
+struct RealMatrix {
+    tensor: Tensor,
+    rows: usize,
+    cols: usize,
+}
+
+impl RealMatrix {
+    async fn parse(label: &str, value: Value) -> BuiltinResult<Self> {
+        let gathered = dispatcher::gather_if_needed_async(&value).await?;
+        let tensor = match gathered {
+            Value::Tensor(tensor) => tensor,
+            Value::Num(n) => Tensor::new(vec![n], vec![1, 1]).map_err(|err| {
+                ss_error_with_detail(&SS_ERROR_INTERNAL, format!("failed to build tensor: {err}"))
+            })?,
+            Value::Int(i) => Tensor::new(vec![i.to_f64()], vec![1, 1]).map_err(|err| {
+                ss_error_with_detail(&SS_ERROR_INTERNAL, format!("failed to build tensor: {err}"))
+            })?,
+            Value::Complex(_, _) | Value::ComplexTensor(_) => {
+                return Err(ss_error_with_detail(
+                    &SS_ERROR_UNSUPPORTED_INPUT,
+                    format!(
+                        "{label} must be finite real numeric data; complex input is unsupported"
+                    ),
+                ));
+            }
+            other => {
+                return Err(ss_error_with_detail(
+                    &SS_ERROR_UNSUPPORTED_INPUT,
+                    format!("{label} must be a finite real numeric matrix, got {other:?}"),
+                ));
+            }
+        };
+
+        if tensor.shape.len() > 2 {
+            return Err(ss_error_with_detail(
+                &SS_ERROR_INVALID_DIMENSIONS,
+                format!("{label} must be a 2-D matrix, got shape {:?}", tensor.shape),
+            ));
+        }
+        if tensor.data.iter().any(|value| !value.is_finite()) {
+            return Err(ss_error_with_detail(
+                &SS_ERROR_UNSUPPORTED_INPUT,
+                format!("{label} must contain only finite real values"),
+            ));
+        }
+
+        Ok(Self {
+            rows: tensor.rows,
+            cols: tensor.cols,
+            tensor,
+        })
+    }
+
+    fn into_value(self) -> Value {
+        Value::Tensor(self.tensor)
+    }
+}
+
+fn validate_state_space_dimensions(
+    a: &RealMatrix,
+    b: &RealMatrix,
+    c: &RealMatrix,
+    d: &RealMatrix,
+) -> BuiltinResult<()> {
+    if a.rows != a.cols {
+        return Err(ss_error_with_detail(
+            &SS_ERROR_INVALID_DIMENSIONS,
+            format!("A must be square, got {}x{}", a.rows, a.cols),
+        ));
+    }
+
+    let state_count = a.rows;
+    if b.rows != state_count {
+        return Err(ss_error_with_detail(
+            &SS_ERROR_INVALID_DIMENSIONS,
+            format!(
+                "B must have {} rows to match A, got {}x{}",
+                state_count, b.rows, b.cols
+            ),
+        ));
+    }
+    if c.cols != state_count {
+        return Err(ss_error_with_detail(
+            &SS_ERROR_INVALID_DIMENSIONS,
+            format!(
+                "C must have {} columns to match A, got {}x{}",
+                state_count, c.rows, c.cols
+            ),
+        ));
+    }
+    if d.rows != c.rows || d.cols != b.cols {
+        return Err(ss_error_with_detail(
+            &SS_ERROR_INVALID_DIMENSIONS,
+            format!(
+                "D must have shape {}x{} to match C outputs and B inputs, got {}x{}",
+                c.rows, b.cols, d.rows, d.cols
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+fn zero_tensor_value(shape: Vec<usize>) -> BuiltinResult<Value> {
+    let len = shape.iter().product();
+    Tensor::new(vec![0.0; len], shape)
+        .map(Value::Tensor)
+        .map_err(|err| {
+            ss_error_with_detail(&SS_ERROR_INTERNAL, format!("failed to build tensor: {err}"))
+        })
+}
+
+fn empty_name_cell_value(rows: usize, cols: usize) -> BuiltinResult<Value> {
+    let len = rows * cols;
+    let values = (0..len)
+        .map(|_| Value::CharArray(CharArray::new_row("")))
+        .collect();
+    CellArray::new(values, rows, cols)
+        .map(Value::Cell)
+        .map_err(|err| {
+            ss_error_with_detail(
+                &SS_ERROR_INTERNAL,
+                format!("failed to build cell array: {err}"),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtins::common::test_support;
+    use futures::executor::block_on;
+    use runmat_builtins::IntValue;
+
+    fn run_ss(a: Value, b: Value, c: Value, d: Value, rest: Vec<Value>) -> BuiltinResult<Value> {
+        block_on(ss_builtin(a, b, c, d, rest))
+    }
+
+    fn property<'a>(value: &'a Value, name: &str) -> &'a Value {
+        let Value::Object(object) = value else {
+            panic!("expected object, got {value:?}");
+        };
+        object
+            .properties
+            .get(name)
+            .unwrap_or_else(|| panic!("missing property {name}"))
+    }
+
+    fn assert_tensor(value: &Value, shape: &[usize], data: &[f64]) {
+        match value {
+            Value::Tensor(tensor) => {
+                assert_eq!(tensor.shape, shape);
+                assert_eq!(tensor.data, data);
+            }
+            other => panic!("expected tensor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ss_descriptor_signatures_cover_core_forms() {
+        let labels: Vec<&str> = SS_DESCRIPTOR
+            .signatures
+            .iter()
+            .map(|sig| sig.label)
+            .collect();
+        assert!(labels.contains(&"sys = ss(A, B, C, D)"));
+        assert!(labels.contains(&"sys = ss(A, B, C, D, Ts)"));
+        assert!(labels.contains(&"sys = ss(A, B, C, D, \"Ts\", Ts)"));
+        assert!(labels.contains(&"sys = ss(A, B, C, D, name, value, ...)"));
+    }
+
+    #[test]
+    fn ss_constructs_continuous_state_space_object() {
+        let sys = run_ss(
+            Value::Tensor(Tensor::new(vec![0.0, -2.0, 1.0, -3.0], vec![2, 2]).unwrap()),
+            Value::Tensor(Tensor::new(vec![0.0, 1.0], vec![2, 1]).unwrap()),
+            Value::Tensor(Tensor::new(vec![1.0, 0.0], vec![1, 2]).unwrap()),
+            Value::Num(0.0),
+            Vec::new(),
+        )
+        .expect("ss");
+
+        let Value::Object(object) = &sys else {
+            panic!("expected object");
+        };
+        assert_eq!(object.class_name, "ss");
+        assert_eq!(property(&sys, "Ts"), &Value::Num(0.0));
+        assert_tensor(property(&sys, "A"), &[2, 2], &[0.0, -2.0, 1.0, -3.0]);
+        assert_tensor(property(&sys, "B"), &[2, 1], &[0.0, 1.0]);
+        assert_tensor(property(&sys, "C"), &[1, 2], &[1.0, 0.0]);
+        assert_tensor(property(&sys, "D"), &[1, 1], &[0.0]);
+        assert_tensor(property(&sys, "InputDelay"), &[1, 1], &[0.0]);
+        assert_tensor(property(&sys, "OutputDelay"), &[1, 1], &[0.0]);
+    }
+
+    #[test]
+    fn ss_preserves_matrix_orientation_for_mimo_systems() {
+        let sys = run_ss(
+            Value::Num(-1.0),
+            Value::Tensor(Tensor::new(vec![1.0, 2.0], vec![1, 2]).unwrap()),
+            Value::Tensor(Tensor::new(vec![3.0, 4.0], vec![2, 1]).unwrap()),
+            Value::Tensor(Tensor::new(vec![0.0, 0.1, 0.2, 0.3], vec![2, 2]).unwrap()),
+            Vec::new(),
+        )
+        .expect("ss");
+
+        assert_tensor(property(&sys, "A"), &[1, 1], &[-1.0]);
+        assert_tensor(property(&sys, "B"), &[1, 2], &[1.0, 2.0]);
+        assert_tensor(property(&sys, "C"), &[2, 1], &[3.0, 4.0]);
+        assert_tensor(property(&sys, "D"), &[2, 2], &[0.0, 0.1, 0.2, 0.3]);
+        assert_tensor(property(&sys, "InputDelay"), &[1, 2], &[0.0, 0.0]);
+        assert_tensor(property(&sys, "OutputDelay"), &[2, 1], &[0.0, 0.0]);
+    }
+
+    #[test]
+    fn ss_accepts_discrete_sample_time() {
+        let sys = run_ss(
+            Value::Int(IntValue::I32(1)),
+            Value::Int(IntValue::I32(2)),
+            Value::Int(IntValue::I32(3)),
+            Value::Int(IntValue::I32(4)),
+            vec![Value::Num(0.25)],
+        )
+        .expect("ss");
+
+        assert_eq!(property(&sys, "Ts"), &Value::Num(0.25));
+    }
+
+    #[test]
+    fn ss_accepts_sample_time_name_value_options() {
+        let sys = run_ss(
+            Value::Num(1.0),
+            Value::Num(2.0),
+            Value::Num(3.0),
+            Value::Num(4.0),
+            vec![Value::from("SampleTime"), Value::Num(0.5)],
+        )
+        .expect("ss");
+
+        assert_eq!(property(&sys, "Ts"), &Value::Num(0.5));
+    }
+
+    #[test]
+    fn ss_rejects_nonsquare_a_matrix() {
+        let err = run_ss(
+            Value::Tensor(Tensor::new(vec![1.0, 2.0], vec![1, 2]).unwrap()),
+            Value::Tensor(Tensor::new(vec![1.0], vec![1, 1]).unwrap()),
+            Value::Tensor(Tensor::new(vec![1.0, 2.0], vec![1, 2]).unwrap()),
+            Value::Tensor(Tensor::new(vec![0.0], vec![1, 1]).unwrap()),
+            Vec::new(),
+        )
+        .expect_err("nonsquare A should fail");
+        assert!(err.message().contains("A must be square"));
+        assert_eq!(err.identifier(), SS_ERROR_INVALID_DIMENSIONS.identifier);
+    }
+
+    #[test]
+    fn ss_rejects_b_row_mismatch() {
+        let err = run_ss(
+            Value::Tensor(Tensor::new(vec![1.0, 0.0, 0.0, 1.0], vec![2, 2]).unwrap()),
+            Value::Tensor(Tensor::new(vec![1.0], vec![1, 1]).unwrap()),
+            Value::Tensor(Tensor::new(vec![1.0, 0.0], vec![1, 2]).unwrap()),
+            Value::Tensor(Tensor::new(vec![0.0], vec![1, 1]).unwrap()),
+            Vec::new(),
+        )
+        .expect_err("B mismatch should fail");
+        assert!(err.message().contains("B must have 2 rows"));
+        assert_eq!(err.identifier(), SS_ERROR_INVALID_DIMENSIONS.identifier);
+    }
+
+    #[test]
+    fn ss_rejects_d_shape_mismatch() {
+        let err = run_ss(
+            Value::Tensor(Tensor::new(vec![1.0, 0.0, 0.0, 1.0], vec![2, 2]).unwrap()),
+            Value::Tensor(Tensor::new(vec![1.0, 0.0], vec![2, 1]).unwrap()),
+            Value::Tensor(Tensor::new(vec![1.0, 0.0], vec![1, 2]).unwrap()),
+            Value::Tensor(Tensor::new(vec![0.0, 0.0], vec![1, 2]).unwrap()),
+            Vec::new(),
+        )
+        .expect_err("D mismatch should fail");
+        assert!(err.message().contains("D must have shape 1x1"));
+        assert_eq!(err.identifier(), SS_ERROR_INVALID_DIMENSIONS.identifier);
+    }
+
+    #[test]
+    fn ss_rejects_invalid_sample_time() {
+        let err = run_ss(
+            Value::Num(1.0),
+            Value::Num(1.0),
+            Value::Num(1.0),
+            Value::Num(0.0),
+            vec![Value::Num(-0.1)],
+        )
+        .expect_err("negative Ts should fail");
+        assert_eq!(err.identifier(), SS_ERROR_INVALID_SAMPLE_TIME.identifier);
+    }
+
+    #[test]
+    fn ss_rejects_complex_inputs() {
+        let err = run_ss(
+            Value::Complex(1.0, 1.0),
+            Value::Num(1.0),
+            Value::Num(1.0),
+            Value::Num(0.0),
+            Vec::new(),
+        )
+        .expect_err("complex A should fail");
+        assert!(err.message().contains("complex input is unsupported"));
+        assert_eq!(err.identifier(), SS_ERROR_UNSUPPORTED_INPUT.identifier);
+    }
+
+    #[test]
+    fn ss_gpu_matrix_input_gathers_to_host() {
+        test_support::with_test_provider(|provider| {
+            let tensor = Tensor::new(vec![1.0], vec![1, 1]).unwrap();
+            let view = runmat_accelerate_api::HostTensorView {
+                data: &tensor.data,
+                shape: &tensor.shape,
+            };
+            let handle = provider.upload(&view).expect("upload");
+            let sys = run_ss(
+                Value::GpuTensor(handle),
+                Value::Num(2.0),
+                Value::Num(3.0),
+                Value::Num(4.0),
+                Vec::new(),
+            )
+            .expect("ss");
+
+            assert_tensor(property(&sys, "A"), &[1, 1], &[1.0]);
+        });
+    }
+}

--- a/crates/runmat-runtime/src/builtins/control/ss.rs
+++ b/crates/runmat-runtime/src/builtins/control/ss.rs
@@ -291,7 +291,7 @@ async fn ss_builtin(
         .insert("Ts".to_string(), Value::Num(options.sample_time));
     object.properties.insert(
         "InputDelay".to_string(),
-        zero_tensor_value(vec![1, input_count])?,
+        zero_tensor_value(vec![input_count, 1])?,
     );
     object.properties.insert(
         "OutputDelay".to_string(),
@@ -594,7 +594,7 @@ mod tests {
         assert_tensor(property(&sys, "B"), &[1, 2], &[1.0, 2.0]);
         assert_tensor(property(&sys, "C"), &[2, 1], &[3.0, 4.0]);
         assert_tensor(property(&sys, "D"), &[2, 2], &[0.0, 0.1, 0.2, 0.3]);
-        assert_tensor(property(&sys, "InputDelay"), &[1, 2], &[0.0, 0.0]);
+        assert_tensor(property(&sys, "InputDelay"), &[2, 1], &[0.0, 0.0]);
         assert_tensor(property(&sys, "OutputDelay"), &[2, 1], &[0.0, 0.0]);
     }
 

--- a/crates/runmat-runtime/src/builtins/control/type_resolvers.rs
+++ b/crates/runmat-runtime/src/builtins/control/type_resolvers.rs
@@ -28,8 +28,24 @@ pub fn step_type(_args: &[Type], _context: &ResolveContext) -> Type {
     Type::tensor()
 }
 
-pub fn ss_type(_args: &[Type], _context: &ResolveContext) -> Type {
-    Type::Unknown
+pub fn ss_type(args: &[Type], context: &ResolveContext) -> Type {
+    let rest = match args {
+        [a, b, c, d, rest @ ..] if valid_state_space_matrix_types(a, b, c, d) => rest,
+        _ => return Type::Unknown,
+    };
+
+    if !valid_state_space_shapes(&args[0], &args[1], &args[2], &args[3]) {
+        return Type::Unknown;
+    }
+
+    match rest {
+        [] => ss_object_type(),
+        [sample_time] if is_sample_time_type(sample_time) => ss_object_type(),
+        _ if rest.len().is_multiple_of(2) && valid_ss_name_value_options(rest, context) => {
+            ss_object_type()
+        }
+        _ => Type::Unknown,
+    }
 }
 
 pub fn tf_type(_args: &[Type], _context: &ResolveContext) -> Type {
@@ -42,4 +58,222 @@ pub fn impulse_type(_args: &[Type], _context: &ResolveContext) -> Type {
 
 pub fn nyquist_type(_args: &[Type], _context: &ResolveContext) -> Type {
     Type::tensor()
+}
+
+fn ss_object_type() -> Type {
+    Type::Struct {
+        known_fields: Some(vec![
+            "A".to_string(),
+            "B".to_string(),
+            "C".to_string(),
+            "D".to_string(),
+            "InputDelay".to_string(),
+            "InputName".to_string(),
+            "OutputDelay".to_string(),
+            "OutputName".to_string(),
+            "StateName".to_string(),
+            "Ts".to_string(),
+        ]),
+    }
+}
+
+fn valid_state_space_matrix_types(a: &Type, b: &Type, c: &Type, d: &Type) -> bool {
+    [a, b, c, d].iter().all(|ty| is_real_matrix_type(ty))
+}
+
+fn is_real_matrix_type(ty: &Type) -> bool {
+    matches!(ty, Type::Num | Type::Int | Type::Tensor { .. })
+}
+
+fn is_sample_time_type(ty: &Type) -> bool {
+    matches!(ty, Type::Num | Type::Int | Type::Unknown)
+}
+
+fn valid_ss_name_value_options(rest: &[Type], context: &ResolveContext) -> bool {
+    rest.chunks_exact(2)
+        .enumerate()
+        .all(|(idx, pair)| valid_ss_option_pair(pair, 4 + idx * 2, context))
+}
+
+fn valid_ss_option_pair(pair: &[Type], arg_index: usize, context: &ResolveContext) -> bool {
+    let [name, value] = pair else {
+        return false;
+    };
+    if !is_text_mode_type(name) || !is_sample_time_type(value) {
+        return false;
+    }
+    match context.literal_string_at(arg_index) {
+        Some(name) => matches!(name.trim(), "ts" | "sampletime"),
+        None => true,
+    }
+}
+
+#[derive(Clone, Copy)]
+struct MatrixShape {
+    rows: Option<usize>,
+    cols: Option<usize>,
+}
+
+fn valid_state_space_shapes(a: &Type, b: &Type, c: &Type, d: &Type) -> bool {
+    let Some(a_shape) = matrix_shape(a) else {
+        return false;
+    };
+    let Some(b_shape) = matrix_shape(b) else {
+        return false;
+    };
+    let Some(c_shape) = matrix_shape(c) else {
+        return false;
+    };
+    let Some(d_shape) = matrix_shape(d) else {
+        return false;
+    };
+
+    known_equal_or_unknown(a_shape.rows, a_shape.cols)
+        && known_equal_or_unknown(b_shape.rows, a_shape.rows)
+        && known_equal_or_unknown(c_shape.cols, a_shape.rows)
+        && known_equal_or_unknown(d_shape.rows, c_shape.rows)
+        && known_equal_or_unknown(d_shape.cols, b_shape.cols)
+}
+
+fn matrix_shape(ty: &Type) -> Option<MatrixShape> {
+    match ty {
+        Type::Num | Type::Int => Some(MatrixShape {
+            rows: Some(1),
+            cols: Some(1),
+        }),
+        Type::Tensor { shape: None } => Some(MatrixShape {
+            rows: None,
+            cols: None,
+        }),
+        Type::Tensor { shape: Some(shape) } => match shape.as_slice() {
+            [] => Some(MatrixShape {
+                rows: Some(1),
+                cols: Some(1),
+            }),
+            [cols] => Some(MatrixShape {
+                rows: Some(1),
+                cols: *cols,
+            }),
+            [rows, cols] => Some(MatrixShape {
+                rows: *rows,
+                cols: *cols,
+            }),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn known_equal_or_unknown(lhs: Option<usize>, rhs: Option<usize>) -> bool {
+    match (lhs, rhs) {
+        (Some(lhs), Some(rhs)) => lhs == rhs,
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ResolveContext {
+        ResolveContext::new(Vec::new())
+    }
+
+    fn tensor(rows: usize, cols: usize) -> Type {
+        Type::Tensor {
+            shape: Some(vec![Some(rows), Some(cols)]),
+        }
+    }
+
+    fn assert_ss_struct(ty: Type) {
+        assert_eq!(ty, ss_object_type());
+    }
+
+    #[test]
+    fn ss_type_returns_known_fields_for_valid_core_form() {
+        assert_ss_struct(ss_type(
+            &[tensor(2, 2), tensor(2, 1), tensor(1, 2), tensor(1, 1)],
+            &ctx(),
+        ));
+    }
+
+    #[test]
+    fn ss_type_accepts_positional_sample_time() {
+        assert_ss_struct(ss_type(
+            &[
+                tensor(1, 1),
+                tensor(1, 2),
+                tensor(2, 1),
+                tensor(2, 2),
+                Type::Num,
+            ],
+            &ctx(),
+        ));
+    }
+
+    #[test]
+    fn ss_type_accepts_supported_name_value_sample_time() {
+        let ctx = ResolveContext::new(vec![
+            runmat_builtins::LiteralValue::Unknown,
+            runmat_builtins::LiteralValue::Unknown,
+            runmat_builtins::LiteralValue::Unknown,
+            runmat_builtins::LiteralValue::Unknown,
+            runmat_builtins::LiteralValue::String("Ts".to_string()),
+        ]);
+        assert_ss_struct(ss_type(
+            &[
+                tensor(1, 1),
+                tensor(1, 1),
+                tensor(1, 1),
+                tensor(1, 1),
+                Type::String,
+                Type::Int,
+            ],
+            &ctx,
+        ));
+    }
+
+    #[test]
+    fn ss_type_rejects_invalid_argument_count() {
+        assert_eq!(
+            ss_type(&[tensor(1, 1), tensor(1, 1), tensor(1, 1)], &ctx()),
+            Type::Unknown
+        );
+    }
+
+    #[test]
+    fn ss_type_rejects_incompatible_known_shapes() {
+        assert_eq!(
+            ss_type(
+                &[tensor(2, 2), tensor(3, 1), tensor(1, 2), tensor(1, 1)],
+                &ctx(),
+            ),
+            Type::Unknown
+        );
+    }
+
+    #[test]
+    fn ss_type_rejects_unsupported_literal_option_name() {
+        let ctx = ResolveContext::new(vec![
+            runmat_builtins::LiteralValue::Unknown,
+            runmat_builtins::LiteralValue::Unknown,
+            runmat_builtins::LiteralValue::Unknown,
+            runmat_builtins::LiteralValue::Unknown,
+            runmat_builtins::LiteralValue::String("BadOption".to_string()),
+        ]);
+        assert_eq!(
+            ss_type(
+                &[
+                    tensor(1, 1),
+                    tensor(1, 1),
+                    tensor(1, 1),
+                    tensor(1, 1),
+                    Type::String,
+                    Type::Num,
+                ],
+                &ctx,
+            ),
+            Type::Unknown
+        );
+    }
 }

--- a/crates/runmat-runtime/src/builtins/control/type_resolvers.rs
+++ b/crates/runmat-runtime/src/builtins/control/type_resolvers.rs
@@ -28,6 +28,10 @@ pub fn step_type(_args: &[Type], _context: &ResolveContext) -> Type {
     Type::tensor()
 }
 
+pub fn ss_type(_args: &[Type], _context: &ResolveContext) -> Type {
+    Type::Unknown
+}
+
 pub fn tf_type(_args: &[Type], _context: &ResolveContext) -> Type {
     Type::Unknown
 }

--- a/crates/runmat-vm/tests/control.rs
+++ b/crates/runmat-vm/tests/control.rs
@@ -29,6 +29,34 @@ fn tf_constructs_object_through_vm_dispatch() {
 }
 
 #[test]
+fn ss_constructs_object_through_vm_dispatch() {
+    let program = r#"
+        G = ss([0 1; -2 -3], [0; 1], [1 0], 0, 0.1);
+        c = class(G);
+        a = G.A;
+        b = G.B;
+        ts = G.Ts;
+    "#;
+    let vars = execute_source(program).unwrap();
+
+    assert!(vars
+        .iter()
+        .any(|value| matches!(value, Value::Object(object) if object.class_name == "ss")));
+    assert!(vars
+        .iter()
+        .any(|value| matches!(value, Value::String(class_name) if class_name == "ss")));
+    assert!(vars.iter().any(|value| {
+        matches!(value, Value::Tensor(tensor) if tensor.shape == vec![2, 2] && tensor.data == vec![0.0, -2.0, 1.0, -3.0])
+    }));
+    assert!(vars.iter().any(|value| {
+        matches!(value, Value::Tensor(tensor) if tensor.shape == vec![2, 1] && tensor.data == vec![0.0, 1.0])
+    }));
+    assert!(vars
+        .iter()
+        .any(|value| matches!(value, Value::Num(n) if (*n - 0.1).abs() < 1.0e-12)));
+}
+
+#[test]
 fn step_returns_siso_response_through_vm_dispatch() {
     let program = r#"
         H = tf(1, [1 1]);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New public control API with dimension and input validation; host-only object construction limits GPU/fusion risk, but incorrect validation could affect downstream control workflows.
> 
> **Overview**
> Adds a MATLAB-style **`ss(A, B, C, D, …)`** builtin that builds a host-side **`ss`** object from finite real dense matrices, with optional discrete sample time via a positional **`Ts`** or **`'Ts'` / `'SampleTime'`** name-value pairs.
> 
> The returned object exposes **`A`**, **`B`**, **`C`**, **`D`**, **`Ts`**, zero delay vectors, and empty name cell arrays; **`gpuArray`** matrix inputs are gathered to host tensors before validation. Inputs reject complex/sparse data and inconsistent **n×n / n×nu / ny×n / ny×nu** shapes, with structured runtime errors and GPU/fusion specs that mark construction as non-fusable host metadata.
> 
> Compile-time typing adds **`ss_type`** (struct with known fields when ABCD types and shapes align). Documentation lands in **`ss.json`**, wired through **`control/mod.rs`**, with unit tests on the builtin and a VM integration test for **`class(G)`** and property access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4722b7b98820a0bab79e7ea436f2c00df76853f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ss() constructor for state-space models producing an object with derived fields (A, B, C, D, Ts) and supports continuous/discrete sample time plus name/value options.

* **Documentation**
  * Added user-facing metadata, examples, syntax, and validation notes for ss().

* **Tests**
  * Added unit tests for construction, Ts handling, option parsing, dimension/validation errors, and GPU input gathering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->