### PR TITLE
Compiler Docs + Error Bindings

### DIFF
--- a/crates/runmat-wasm/src/api/plot.rs
+++ b/crates/runmat-wasm/src/api/plot.rs
@@ -564,7 +564,7 @@ fn figure_error_to_js(err: FigureError) -> JsValue {
 
 #[cfg(target_arch = "wasm32")]
 fn runtime_flow_to_js(err: RuntimeError) -> JsValue {
-    serde_wasm_bindgen::to_value(&runtime_error_payload(&err, None))
+    serde_wasm_bindgen::to_value(&runtime_error_payload(&err, None, None))
         .unwrap_or_else(|_| js_error(err.message()))
 }
 

--- a/crates/runmat-wasm/src/api/session.rs
+++ b/crates/runmat-wasm/src/api/session.rs
@@ -118,14 +118,18 @@ impl RunMatWasm {
     pub async fn execute_request_js(&self, request_value: JsValue) -> Result<JsValue, JsValue> {
         let request_payload: ExecuteRequestPayload = serde_wasm_bindgen::from_value(request_value)
             .map_err(|err| js_error(&format!("executeRequest payload parse failed: {err}")))?;
-        let source = match &request_payload.source {
+        let source_for_telemetry = match &request_payload.source {
             ExecuteRequestSourcePayload::Text { text, .. } => text.clone(),
             ExecuteRequestSourcePayload::Path { path } => path.clone(),
+        };
+        let (source_name, source_text) = match &request_payload.source {
+            ExecuteRequestSourcePayload::Text { name, text } => (Some(name.as_str()), Some(text.as_str())),
+            ExecuteRequestSourcePayload::Path { path } => (Some(path.as_str()), None),
         };
         init_logging_once();
         let exec_span = info_span!(
             "runmat.execute",
-            source_len = source.len() as u64,
+            source_len = source_for_telemetry.len() as u64,
             disposed = self.disposed.get()
         );
         let _enter = exec_span.enter();
@@ -223,7 +227,7 @@ impl RunMatWasm {
                         }
                     }
                 }
-                ExecutionPayload::from_outcome(outcome, &source)
+                ExecutionPayload::from_outcome(outcome, &source_for_telemetry)
             }
             Err(err) => ExecutionPayload {
                 flow: serde_json::json!({ "kind": "no-value" }),
@@ -232,7 +236,7 @@ impl RunMatWasm {
                 type_info: None,
                 execution_time_ms: 0,
                 used_jit: false,
-                error: Some(run_error_payload(&err, &source)),
+                error: Some(run_error_payload(&err, source_name, source_text)),
                 stdout: Vec::new(),
                 display_events: Vec::new(),
                 workspace: WorkspacePayload {
@@ -414,7 +418,7 @@ impl RunMatWasm {
         let mut session = self.session.borrow_mut();
         let snapshot = session
             .compile_fusion_plan(&source)
-            .map_err(|err| run_error_to_js(&err, &source))?;
+            .map_err(|err| run_error_to_js(&err, Some("<fusion_plan>"), Some(&source)))?;
         match snapshot {
             Some(plan) => serde_wasm_bindgen::to_value(&FusionPlanPayload::from(plan))
                 .map_err(|err| js_error(&format!("Failed to serialize fusion plan: {err}"))),

--- a/crates/runmat-wasm/src/wire/errors.rs
+++ b/crates/runmat-wasm/src/wire/errors.rs
@@ -71,8 +71,8 @@ pub(crate) fn runtime_error_to_js(err: &RuntimeError) -> JsValue {
     }
 }
 
-pub(crate) fn run_error_to_js(err: &RunError, source: &str) -> JsValue {
-    serde_wasm_bindgen::to_value(&run_error_payload(err, source))
+pub(crate) fn run_error_to_js(err: &RunError, source_name: Option<&str>, source: Option<&str>) -> JsValue {
+    serde_wasm_bindgen::to_value(&run_error_payload(err, source_name, source))
         .unwrap_or_else(|_| JsValue::from_str("RunMat error"))
 }
 
@@ -132,7 +132,8 @@ fn span_payload_from_source(source: &str, start: usize, end: usize) -> RunMatErr
     }
 }
 
-fn format_run_error(err: &RunError, source: &str) -> String {
+fn format_run_error(err: &RunError, source_name: Option<&str>, source: Option<&str>) -> String {
+    let span_source = source_name.zip(source);
     match err {
         RunError::Syntax(err) => {
             let mut message = err.message.clone();
@@ -147,7 +148,7 @@ fn format_run_error(err: &RunError, source: &str) -> String {
                 .with_identifier("RunMat:SyntaxError")
                 .with_span(span)
                 .build()
-                .format_diagnostic_with_source(Some("<wasm>"), Some(source))
+                .format_diagnostic_with_source(span_source.map(|(name, _)| name), span_source.map(|(_, src)| src))
         }
         RunError::Semantic(err) => {
             let span = err.span.map(|span| {
@@ -165,7 +166,7 @@ fn format_run_error(err: &RunError, source: &str) -> String {
             }
             builder
                 .build()
-                .format_diagnostic_with_source(Some("<wasm>"), Some(source))
+                .format_diagnostic_with_source(span_source.map(|(name, _)| name), span_source.map(|(_, src)| src))
         }
         RunError::Compile(err) => {
             let span = err.span.map(|span| {
@@ -183,14 +184,18 @@ fn format_run_error(err: &RunError, source: &str) -> String {
             }
             builder
                 .build()
-                .format_diagnostic_with_source(Some("<wasm>"), Some(source))
+                .format_diagnostic_with_source(span_source.map(|(name, _)| name), span_source.map(|(_, src)| src))
         }
-        RunError::Runtime(err) => err.format_diagnostic_with_source(Some("<wasm>"), Some(source)),
+        RunError::Runtime(err) => err.format_diagnostic_with_source(
+            span_source.map(|(name, _)| name),
+            span_source.map(|(_, src)| src),
+        ),
     }
 }
 
 pub(crate) fn runtime_error_payload(
     err: &RuntimeError,
+    source_name: Option<&str>,
     source: Option<&str>,
 ) -> RunMatErrorPayload {
     let identifier = err.identifier().map(|id| id.to_string());
@@ -203,7 +208,7 @@ pub(crate) fn runtime_error_payload(
         _ => None,
     };
     let diagnostic = match source {
-        Some(source) => err.format_diagnostic_with_source(Some("<wasm>"), Some(source)),
+        Some(source) => err.format_diagnostic_with_source(source_name, Some(source)),
         None => err.format_diagnostic(),
     };
     let callstack = if !err.context.call_stack.is_empty() {
@@ -226,8 +231,12 @@ pub(crate) fn runtime_error_payload(
     }
 }
 
-pub(crate) fn run_error_payload(err: &RunError, source: &str) -> RunMatErrorPayload {
-    let diagnostic = format_run_error(err, source);
+pub(crate) fn run_error_payload(
+    err: &RunError,
+    source_name: Option<&str>,
+    source: Option<&str>,
+) -> RunMatErrorPayload {
+    let diagnostic = format_run_error(err, source_name, source);
     match err {
         RunError::Syntax(err) => {
             let mut message = err.message.clone();
@@ -237,13 +246,13 @@ pub(crate) fn run_error_payload(err: &RunError, source: &str) -> RunMatErrorPayl
             if let Some(found) = &err.found_token {
                 message = format!("{message} (found '{found}')");
             }
-            let span = span_payload_from_source(source, err.position, err.position + 1);
+            let span = source.map(|src| span_payload_from_source(src, err.position, err.position + 1));
             RunMatErrorPayload {
                 kind: RunMatErrorKind::Syntax,
                 message,
                 identifier: Some("RunMat:SyntaxError".to_string()),
                 diagnostic,
-                span: Some(span),
+                span,
                 callstack: Vec::new(),
                 callstack_elided: 0,
             }
@@ -253,9 +262,11 @@ pub(crate) fn run_error_payload(err: &RunError, source: &str) -> RunMatErrorPayl
             message: err.message.clone(),
             identifier: err.identifier.clone(),
             diagnostic,
-            span: err.span.map(|span| {
-                let end = span.end.max(span.start + 1);
-                span_payload_from_source(source, span.start, end)
+            span: source.and_then(|src| {
+                err.span.map(|span| {
+                    let end = span.end.max(span.start + 1);
+                    span_payload_from_source(src, span.start, end)
+                })
             }),
             callstack: Vec::new(),
             callstack_elided: 0,
@@ -265,13 +276,15 @@ pub(crate) fn run_error_payload(err: &RunError, source: &str) -> RunMatErrorPayl
             message: err.message.clone(),
             identifier: err.identifier.clone(),
             diagnostic,
-            span: err.span.map(|span| {
-                let end = span.end.max(span.start + 1);
-                span_payload_from_source(source, span.start, end)
+            span: source.and_then(|src| {
+                err.span.map(|span| {
+                    let end = span.end.max(span.start + 1);
+                    span_payload_from_source(src, span.start, end)
+                })
             }),
             callstack: Vec::new(),
             callstack_elided: 0,
         },
-        RunError::Runtime(err) => runtime_error_payload(err, Some(source)),
+        RunError::Runtime(err) => runtime_error_payload(err, source_name, source),
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,9 @@
 # RunMat Runtime Documentation
 
-- [Changelog](./CHANGELOG.md)
-- [Values & Type Model](./VALUES.md)
-- [Glossary](./GLOSSARY.md)
-
 ## Getting Started
 
 - [Installation](./getting-started/install.md)
+- [Desktop](./getting-started/desktop.md)
 - [Command Line Interface](./getting-started/cli.md)
 - [Configuration](./getting-started/config)
 - [Language Compatability](./getting-started/compatability.md)
@@ -95,3 +92,9 @@
 - [Testing Strategy](./development/testing.md)
 - [Benchmarking](./development/benchmarking.md)
 - [Telemetry](./development/telemetry.md)
+
+## Reference
+
+- [Changelog](./CHANGELOG.md)
+- [Values & Type Model](./VALUES.md)
+- [Glossary](./GLOSSARY.md)

--- a/docs/development/supported-architectures.md
+++ b/docs/development/supported-architectures.md
@@ -2,16 +2,16 @@
 title: "Supported Architectures"
 category: "Development"
 section: "14.2"
-last_updated: "May 28, 2026"
+last_updated: "May 29, 2026"
 ---
 
 # Supported Architectures
 
 RunMat has two major build families: native binaries for the CLI/runtime and WebAssembly artifacts for browser and TypeScript hosts. Native releases are built for Windows, macOS, and Linux; WASM builds target `wasm32-unknown-unknown`.
 
-## Release Targets
+## Packaged Targets
 
-The native release matrix builds these targets:
+The release pipeline packages native CLI/runtime binaries for these targets:
 
 | Release artifact | Rust target |
 | --- | --- |
@@ -22,11 +22,51 @@ The native release matrix builds these targets:
 
 CI also cross-builds the same native targets before release. The main test matrix runs on Linux x86_64 and macOS; the release workflow additionally validates Windows before packaging.
 
+## CPU Architecture Support
+
+RunMat is written in Rust and much of the parser, compiler, VM, runtime, builtin library, and session engine is portable across CPU architectures that support Rust `std`. Packaged and CI-covered support is currently narrower than theoretical source-build support.
+
+| Target family | Support tier | Package | CI coverage | JIT | GPU path | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `x86_64-pc-windows-msvc` | Packaged native | Yes | Cross-build + release validation | Supported | WGPU / DX12 | Full CLI/runtime target. |
+| `x86_64-apple-darwin` | Packaged native | Yes | macOS tests + cross-build | Supported | WGPU / Metal | Full CLI/runtime target. |
+| `aarch64-apple-darwin` | Packaged native | Yes | macOS tests + cross-build | Supported | WGPU / Metal | Apple Silicon; best-supported ARM target today. |
+| `x86_64-unknown-linux-gnu` | Packaged native | Yes | Linux tests + cross-build | Supported | WGPU / Vulkan or host backend | Full CLI/runtime target when native dependencies are present. |
+| `aarch64-pc-windows-msvc` | Configured native | No | Build configuration only | AArch64 backend, unvalidated | WGPU / DX12 if the native stack works | `.cargo/config.toml` includes linker stack sizing, but this target is not packaged. |
+| `aarch64-unknown-linux-gnu` | Experimental source build | No | No routine coverage | AArch64 backend, unvalidated | Experimental WGPU / Linux graphics stack | Source-build target; treat as experimental until CI and packaging cover it. |
+| `armv7-*`, `arm-unknown-linux-*` | Untested source build | No | No routine coverage | Not supported | Platform-specific, untested | Interpreter-only builds may be possible, but native dependencies and GPU support vary by board. |
+| `wasm32-unknown-unknown` | Packaged WASM | Yes | WASM build + browser tests | Not supported | Browser WebGPU | Browser and TypeScript package target, not a native CLI target. |
+
+The JIT tier is more constrained than the interpreter. Turbine currently reports JIT support for `x86_64` and `aarch64`; other architectures should be expected to run interpreter-only even if the rest of the runtime builds.
+
+## Embedded And Edge Devices
+
+RunMat is not a `no_std` runtime and is not designed for bare-metal microcontrollers. It assumes an operating system, heap allocation, filesystem or filesystem-provider access, atomics, async/runtime support, and in several configurations native libraries such as BLAS/LAPACK, TLS, windowing, or GPU drivers.
+
+Practical embedded support depends on the class of device:
+
+| Device class | RunMat fit |
+| --- | --- |
+| Cortex-M / bare-metal MCUs | Not supported. These targets lack the OS, allocator, filesystem, and process model RunMat expects. |
+| Cortex-R / RTOS-style systems | Not supported unless they provide a Rust `std` environment close to Linux or another supported OS. |
+| Cortex-A Linux SBCs and edge boxes | Plausible as source builds, especially ARM64 Linux, but not packaged today. Start with CPU/interpreter validation before enabling JIT, BLAS/LAPACK, plotting, or WGPU. |
+| Android devices | Not currently packaged for the RunMat CLI. Browser/WASM use may work through WebGPU where the browser and device support it; native Android packaging is not part of the current build matrix. |
+
+For ARM Linux boards, the safest bring-up order is:
+
+```bash
+cargo check -p runmat-parser
+cargo check -p runmat-core --no-default-features
+cargo check -p runmat-runtime --no-default-features
+```
+
+Then add features and host layers back deliberately: JIT first on AArch64, BLAS/LAPACK after native math libraries are installed, and WGPU/GUI only after the graphics stack is known to work. The full CLI is a release-oriented package and should be brought up after the core crates compile.
+
 ## Toolchain
 
 Rust is pinned to `1.90.0` with `rustfmt` and `clippy`. CI validates the exact toolchain on self-hosted Linux and Windows runners, and installs the same channel on macOS.
 
-Windows MSVC builds use a larger linker stack through `.cargo/config.toml`. That setting covers `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`; the ARM64 Windows target is configured but not part of the current release matrix.
+Windows MSVC builds use a larger linker stack through `.cargo/config.toml`. That setting covers `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`; the ARM64 Windows target is configured but not currently packaged.
 
 ## Native Dependencies By Platform
 
@@ -81,6 +121,19 @@ Precision support depends on the active provider. Providers advertise supported 
 
 `RUNMAT_ALLOW_PRECISION_DOWNCAST=1` permits implicit downcast from double precision to provider-native precision and emits a warning.
 
+### ARM And Mali GPUs
+
+Mali GPUs are not targeted directly by RunMat, but they are reachable as an acceleration provider through the platform GPU API exposed to WGPU, usually Vulkan on Linux/Android or browser WebGPU in a supported browser.
+
+That means Mali support depends on the full driver stack:
+
+- The device must expose the backend WGPU can use on that platform.
+- The adapter must support the WebGPU/WGPU limits and features RunMat kernels require.
+- Shader compilation, buffer limits, storage-buffer support, and precision support are provider-reported at runtime.
+- CPU fallback remains the expected behavior when GPU initialization fails or when a workload is too small for offload to win.
+
+On ARM Linux systems with Mali GPUs, treat GPU acceleration as experimental until validated on the exact board, kernel, Mesa/vendor driver, windowing/headless setup, and workload. A CPU-only RunMat build can still be useful on these devices even when WGPU is unavailable.
+
 ## CI Coverage
 
 The main Unix CI jobs run:
@@ -92,4 +145,4 @@ cargo check --all-targets --all-features
 RUST_TEST_THREADS=1 cargo test --all-targets --all-features
 ```
 
-The cross-build job compiles all release targets in release mode. The WASM workflow builds `runmat-wasm` for `wasm32-unknown-unknown`, then runs the headless WASM test script.
+The cross-build job compiles all packaged native targets in release mode. The WASM workflow builds `runmat-wasm` for `wasm32-unknown-unknown`, then runs the headless WASM test script.

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -1,7 +1,7 @@
 ---
 title: "Command Line Interface"
 category: "Getting Started"
-section: "1.2"
+section: "1.3"
 last_updated: "May 29, 2026"
 ---
 

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -9,15 +9,15 @@ last_updated: "May 29, 2026"
 
 The RunMat CLI is a fast and easy way to run `.m` files locally, open an interactive REPL, inspect runtime behavior, and work with remote project filesystems.
 
-Install RunMat first if the `runmat` command is not already on your `PATH`.
+Install RunMat first if the `runmat` command is not already on your `PATH`. See [Installation](/docs/runtime/getting-started/install) for install options.
+
+To check the version of RunMat, run:
 
 ```bash
 runmat --version
 ```
 
-See [Installation](/docs/runtime/getting-started/install) for install options.
-
-## Start A REPL
+## REPL
 
 Run `runmat` with no command to open the interactive REPL.
 
@@ -57,7 +57,7 @@ The REPL also accepts piped input:
 printf "1 + 1\n" | runmat repl
 ```
 
-## Run Scripts
+## Run
 
 Run a local `.m` file by passing the path directly:
 
@@ -100,21 +100,21 @@ Common options:
 
 | Option | Use |
 | --- | --- |
-| `--config <path>` | Load a specific `runmat.toml` or `runmat.json`. |
+| `--config PATH` | Load a specific `runmat.toml` or `runmat.json`. |
 | `--debug` | Enable debug logging. |
-| `--log-level <error|warn|info|debug|trace>` | Set log verbosity. |
+| `--log-level LEVEL` | Set log verbosity. |
 | `--verbose` | Print more execution detail. |
-| `--snapshot <path>` | Preload a runtime snapshot. |
+| `--snapshot PATH` | Preload a runtime snapshot. |
 | `--no-jit` | Use the interpreter only. |
-| `--jit-threshold <n>` | Set the execution count before JIT tiering. |
-| `--jit-opt-level <none|size|speed|aggressive>` | Set JIT optimization policy. |
-| `--gc-preset <low-latency|high-throughput|low-memory|debug>` | Select a GC tuning preset. |
-| `--gc-young-size <MB>` | Override young generation size. |
-| `--gc-threads <n>` | Override GC worker count. |
+| `--jit-threshold N` | Set the execution count before JIT tiering. |
+| `--jit-opt-level LEVEL` | Set JIT optimization policy. |
+| `--gc-preset PRESET` | Select a GC tuning preset. |
+| `--gc-young-size MB` | Override young generation size. |
+| `--gc-threads N` | Override GC worker count. |
 | `--gc-stats` | Collect GC statistics. |
-| `--plot-mode <auto|gui|headless>` | Select plotting mode. |
+| `--plot-mode MODE` | Select plotting mode (auto | gui | headless). |
 | `--plot-headless` | Force headless plotting. |
-| `--plot-backend <auto|wgpu|static|web>` | Select plotting backend. |
+| `--plot-backend BACKEND` | Select plotting backend (auto | wgpu | static | web). |
 
 Configuration is resolved from built-in defaults, project files, environment variables, and CLI flags. CLI flags have the highest precedence. See [Configuration Reference](/docs/runtime/getting-started/config).
 
@@ -152,13 +152,13 @@ Artifact options:
 
 | Option | Use |
 | --- | --- |
-| `--artifacts-dir <path>` | Directory for run artifacts. |
-| `--artifacts-manifest <path>` | Exact JSON manifest path. |
-| `--capture-figures <off|auto|on>` | Figure export policy. |
-| `--figure-size <WIDTHxHEIGHT>` | Figure export dimensions. |
-| `--max-figures <n>` | Maximum number of touched figures to export. |
+| `--artifacts-dir PATH` | Directory for run artifacts. |
+| `--artifacts-manifest PATH` | Exact JSON manifest path. |
+| `--capture-figures MODE` | Figure export policy (off | auto | on). |
+| `--figure-size WIDTHxHEIGHT` | Figure export dimensions. |
+| `--max-figures N` | Maximum number of touched figures to export. |
 
-## Inspect The Runtime
+## Inspect Runtime
 
 Use these commands when filing issues, tuning performance, or checking what runtime configuration is active.
 
@@ -179,7 +179,7 @@ runmat accel-info
 | `accel-info` | Print acceleration provider and telemetry details. |
 | `accel-info --json` | Emit acceleration details as JSON. |
 
-## Manage Configuration
+## Configuration
 
 Generate a starter config:
 
@@ -203,7 +203,7 @@ runmat config paths
 
 `config generate` writes both project and runtime sections, so the generated file can be used as a starting point for named entrypoints and runtime tuning.
 
-## Benchmark Scripts
+## Benchmark
 
 Benchmark a script or named entrypoint with repeated execution in one session.
 
@@ -214,7 +214,7 @@ runmat benchmark main --iterations 25 --jit
 
 The benchmark command performs warmup runs, then reports total iterations, JIT executions, interpreter executions, total time, average time, and throughput.
 
-## Snapshot Commands
+## Snapshots
 
 Snapshots preload runtime assets so startup does less work.
 

--- a/docs/getting-started/compatability.md
+++ b/docs/getting-started/compatability.md
@@ -7,7 +7,7 @@ last_updated: "May 28, 2026"
 
 # MATLAB Language Compatability
 
-RunMat is a high-performance runtime designed for MATLAB-syntax code. It targets the core language grammar and semantics, enabling engineers to execute `.m` scripts, functions, and complex object-oriented systems without a license. Compatibility focuses on the core language (variables, operators, control flow, N-D indexing, and `classdef` OOP) and a standard library of 400+ built-in functions.
+RunMat is a high-performance runtime designed for MATLAB-syntax code. It targets the core language grammar and semantics, enabling engineers to execute `.m` scripts, functions, and complex object-oriented systems. Compatibility focuses on the core language (variables, operators, control flow, N-D indexing, and `classdef` OOP) and a standard library of 400+ built-in functions.
 
 ## Compatibility Modes
 
@@ -58,4 +58,4 @@ Unlike many alternative MATLAB syntax-based runtimes, RunMat provides full `clas
 
 The compatibility layer is primarily enforced during the "Lowering" phase, where the `runmat-parser` AST is converted into `runmat-hir`. This stage resolves identifiers based on MATLAB's complex precedence rules.
 
-See the [compiler pipeline](/docs/runtime/compiler) for a full breakdown of the compiler pipeline.
+See the [compiler pipeline](/docs/runtime/compiler) for a full breakdown of how RunMat resolves identifiers and implements the MATLAB language.

--- a/docs/getting-started/compatability.md
+++ b/docs/getting-started/compatability.md
@@ -1,7 +1,7 @@
 ---
 title: "MATLAB Language Compatability"
 category: "Getting Started"
-section: "1.4"
+section: "1.5"
 last_updated: "May 28, 2026"
 ---
 

--- a/docs/getting-started/config.md
+++ b/docs/getting-started/config.md
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Reference"
 category: "Getting Started"
-section: "1.3"
+section: "1.4"
 last_updated: "May 28, 2026"
 ---
 

--- a/docs/getting-started/desktop.md
+++ b/docs/getting-started/desktop.md
@@ -1,0 +1,10 @@
+---
+title: "Desktop"
+category: "Getting Started"
+section: "1.2"
+last_updated: "May 29, 2026"
+---
+
+# RunMat Desktop
+
+<TODO: placeholder>

--- a/docs/getting-started/desktop.md
+++ b/docs/getting-started/desktop.md
@@ -7,4 +7,98 @@ last_updated: "May 29, 2026"
 
 # RunMat Desktop
 
-<TODO: placeholder>
+RunMat Desktop is the full local RunMat experience: an editor, file tree, console, plots, variable inspector, notebooks, and project settings in one native app. It runs MATLAB-syntax code with the same RunMat runtime used by the CLI and browser, but adds native file access and hardware GPU support for local projects.
+
+Use Desktop when you want to work on files on your machine, inspect results interactively, and keep plots, stdout, variables, and run history visible while you iterate.
+
+## Install
+
+Download the latest build from [Download RunMat Desktop](/download/latest).
+
+RunMat Desktop is available for:
+
+| Platform | Package |
+| --- | --- |
+| macOS Apple Silicon | DMG |
+| macOS Intel | DMG |
+| Windows x86_64 | Installer |
+| Linux x86_64 | AppImage |
+
+After installing, open RunMat from your applications folder, start menu, or launcher.
+
+## Open a Project
+
+On first launch, you can either open a local folder or sign in to use cloud projects.
+
+- **Local projects** use files on your machine and can run offline.
+- **Cloud projects** sync through RunMat App and require sign-in.
+
+For local work, choose or create a folder for your scripts. RunMat treats that folder as the project root.
+
+## Run Your First Script
+
+Create a file named `hello.m`:
+
+```matlab
+x = linspace(0, 2*pi, 200);
+y = sin(x);
+
+plot(x, y);
+title("Hello from RunMat Desktop");
+disp("Done");
+```
+
+Open the file in RunMat Desktop and click **Run** or use the run shortcut shown in the app.
+
+Desktop sends the script to the RunMat runtime, then updates the runtime panel with:
+
+- stdout from `disp`, `fprintf`, and other console output
+- figures created by plotting commands
+- workspace variables such as `x` and `y`
+- diagnostics if parsing, compilation, or execution fails
+
+The workspace stays available after the run, so you can inspect variables and rerun after editing.
+
+## Work With Plots and Variables
+
+Plots appear in the runtime panel as interactive figures. You can switch between figures, resize the panel, and export images when you need to save results.
+
+Variables appear in the variables pane with type, shape, and residency information. Use the inspector to materialize values when you need to look at array contents without printing everything to the console.
+
+## Use Project Settings
+
+RunMat Desktop reads the same project manifests used by the CLI:
+
+```toml
+[package]
+name = "my-project"
+
+[entrypoints.analysis]
+path = "analysis.m"
+```
+
+Save this as `runmat.toml` in your project root. The CLI can run the same entrypoint with:
+
+```bash
+runmat run analysis
+```
+
+Desktop also stores app-specific project preferences, such as artifact location, notebook behavior, GPU preference, and run history settings. See the [Configuration Reference](/docs/runtime/getting-started/config) for the shared runtime settings.
+
+## Desktop, Browser, and CLI
+
+RunMat uses the same core runtime across all hosts:
+
+| Host | Best for |
+| --- | --- |
+| Desktop | Local projects, native files, interactive plots, variables, and hardware GPU access. |
+| Browser | Zero-install experiments and sharing small examples. |
+| CLI | Scripts, automation, CI, benchmarking, and terminal workflows. |
+
+You can move between them as your workflow changes. A script that runs in Desktop should also run from the CLI as long as it uses the same files, configuration, and runtime features.
+
+## Next Steps
+
+- Try the [Hello World](/docs/runtime/getting-started/hello-world) example.
+- Learn the [Command Line Interface](/docs/runtime/getting-started/cli) for scripts and automation.
+- Review [GPU Acceleration](/docs/runtime/gpu) if your project uses large arrays or plotting workloads.

--- a/docs/getting-started/hello-world.md
+++ b/docs/getting-started/hello-world.md
@@ -5,11 +5,9 @@ section: "1.6"
 last_updated: "May 28, 2026"
 ---
 
-# RunMat Hello World
+# Run your first script
 
-The RunMat Hello World example is a simple program that prints "Hello, World!" to the console.
-
-## RunMat Hello World in RunMat
+## Hello World in RunMat
 
 Save the file as `hello.m` and add the following content:
 

--- a/docs/getting-started/hello-world.md
+++ b/docs/getting-started/hello-world.md
@@ -1,7 +1,7 @@
 ---
 title: "Hello World"
 category: "Getting Started"
-section: "1.5"
+section: "1.6"
 last_updated: "May 28, 2026"
 ---
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -27,11 +27,10 @@ RunMat can be installed via pre-compiled binaries, package managers, or built fr
 
 ### Build from Source
 
-Building from source requires the Rust toolchain. The `gui` feature enables the `wgpu`-based plotting and windowing system.
+- Clone repository: `git clone https://github.com/runmat-org/runmat.git`
+- Build with GUI features: `cargo build --release --features gui`
 
-```bash
-git clone https://github.com/runmat-org/runmat.gitcd runmat && cargo build --release --features gui
-```
+Note: Building from source requires the Rust toolchain. The `gui` feature enables the `wgpu`-based plotting and windowing system.
 
 # Next Steps
 

--- a/docs/gpu/wgpu.md
+++ b/docs/gpu/wgpu.md
@@ -5,7 +5,7 @@ section: "4.2"
 last_updated: "May 28, 2026"
 ---
 
-# wgpu Backend & Accelerate Provider
+# WGPU Backend & Accelerate Provider
 
 The `wgpu` backend is RunMat's primary hardware acceleration provider. It implements the `AccelProvider` trait with a `WgpuProvider` that owns the device, queue, adapter metadata, buffer table, residency pool, compute pipelines, kernel resources, caches, telemetry, and autotuning state.
 

--- a/docs/vm/index.md
+++ b/docs/vm/index.md
@@ -9,44 +9,6 @@ last_updated: "May 28, 2026"
 
 The `runmat-vm` crate provides the core execution engine for RunMat. It defines the custom bytecode format, the compiler that lowers Mid-Level IR (MIR) into that format, and the asynchronous interpreter that executes it. The VM is designed as the middle tier of a tiered execution model, sitting between high-level semantic analysis and low-level JIT or GPU acceleration.
 
-### System Architecture & Code Entities
-
-The following diagram bridges the conceptual execution flow to the specific code entities within the `runmat-vm` crate.
-
-Execution Lifecycle: Source to Runtime
-
-```mermaid
-flowchart TD
-  %% Subgraph: Execution Space (runmat-vm::interpreter)
-  %% Subgraph: Entity Space (runmat-vm::bytecode)
-  %% Subgraph: Compilation Space (runmat-vm::compiler)
-  %% Subgraph: Code Entities
-  C_Path["crates/runmat-vm/src/compiler/core.rs"]
-  I_Path["crates/runmat-vm/src/interpreter/runner.rs"]
-  B_Path["crates/runmat-vm/src/bytecode/program.rs"]
-  A["MirAssembly"]
-  B["Compiler::new()"]
-  C["Compiler::compile()"]
-  D["Instr (Bytecode)"]
-  E["FunctionRegistry"]
-  F["Bytecode (Container)"]
-  G["run_interpreter_inner()"]
-  H["ExecutionContext"]
-  I["dispatch_instruction()"]
-  J["Sub-module Handlers (Arithmetic, Indexing, etc.)"]
-  A --> B
-  B --> C
-  C --> D
-  D --> E
-  E --> F
-  F --> G
-  G --> H
-  H --> I
-  I --> J
-```
-
----
-
 ## Bytecode Compilation (MIR → Bytecode)
 
 The `Compiler` struct is responsible for the final lowering of `MirAssembly` into a sequence of `Instr` opcodes This process includes:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> WASM diagnostic shaping is user-facing but localized; path-only runs may show fewer spans, which is intentional. Docs-only changes carry no runtime risk.
> 
> **Overview**
> **WASM error payloads** now take separate optional `source_name` and `source` instead of always labeling diagnostics as `<wasm>`. `executeRequest` passes the script **name** and **text** for text sources, or the **path** only for path sources—so line/column **spans** are omitted when full source is unavailable. Fusion-plan compile errors use `<fusion_plan>` as the synthetic name.
> 
> **Documentation** adds a **RunMat Desktop** getting-started page, moves Changelog/Values/Glossary into a **Reference** section, and expands **supported architectures** (CPU support tiers, embedded/edge guidance, Mali GPU notes). Getting-started pages are renumbered; **CLI** and **install** copy is tightened; the **VM** index drops a large architecture diagram; **wgpu** title is capitalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ce10065b946d565db7f71771357e215f2feeb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics with enhanced source context handling

* **New Features**
  * Added comprehensive Desktop getting-started guide with platform support and feature overview

* **Documentation**
  * Restructured getting-started navigation; added new "Desktop" guide and "Reference" section
  * Expanded architecture support documentation with CPU tier details and device guidance
  * Refined CLI documentation with clearer command organization
  * Updated installation and MATLAB compatibility information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runmat-org/runmat/pull/379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->