### PR TITLE
fixing native plotting state marking

### DIFF
--- a/crates/runmat-plot/src/core/plot_renderer.rs
+++ b/crates/runmat-plot/src/core/plot_renderer.rs
@@ -391,6 +391,22 @@ impl PlotRenderer {
         }
     }
 
+    pub fn set_axes_camera_interaction_flags(&mut self, flags: &[bool]) {
+        self.axes_2d_camera_user_controlled
+            .resize(self.axes_cameras.len(), false);
+        let mut any_user_controlled = false;
+        for idx in 0..self.axes_cameras.len() {
+            let controlled = flags.get(idx).copied().unwrap_or(false);
+            if let Some(flag) = self.axes_2d_camera_user_controlled.get_mut(idx) {
+                *flag = controlled;
+            }
+            any_user_controlled |= controlled;
+        }
+        if any_user_controlled {
+            self.note_camera_interaction();
+        }
+    }
+
     fn clear_axes_camera_interaction(&mut self, axes_index: usize) {
         if let Some(flag) = self.axes_2d_camera_user_controlled.get_mut(axes_index) {
             *flag = false;

--- a/crates/runmat-plot/src/export/native_surface.rs
+++ b/crates/runmat-plot/src/export/native_surface.rs
@@ -129,7 +129,18 @@ impl NativeSurfaceRenderContext {
         camera: Option<&Camera>,
         axes_cameras: Option<&[Camera]>,
     ) -> Result<RenderResult, String> {
-        self.prepare_scene(figure, camera, axes_cameras);
+        self.render_to_view_with_camera_state(figure, view, camera, axes_cameras, None)
+    }
+
+    pub fn render_to_view_with_camera_state(
+        &mut self,
+        figure: &Figure,
+        view: &wgpu::TextureView,
+        camera: Option<&Camera>,
+        axes_cameras: Option<&[Camera]>,
+        axes_camera_user_controlled: Option<&[bool]>,
+    ) -> Result<RenderResult, String> {
+        self.prepare_scene(figure, camera, axes_cameras, axes_camera_user_controlled);
 
         let mut encoder = self.renderer.wgpu_renderer.device.create_command_encoder(
             &wgpu::CommandEncoderDescriptor {
@@ -154,6 +165,17 @@ impl NativeSurfaceRenderContext {
         camera: Option<&Camera>,
         axes_cameras: Option<&[Camera]>,
     ) -> Result<Vec<u8>, String> {
+        self.render_to_rgba_with_camera_state(figure, camera, axes_cameras, None)
+            .await
+    }
+
+    pub async fn render_to_rgba_with_camera_state(
+        &mut self,
+        figure: &Figure,
+        camera: Option<&Camera>,
+        axes_cameras: Option<&[Camera]>,
+        axes_camera_user_controlled: Option<&[bool]>,
+    ) -> Result<Vec<u8>, String> {
         log::debug!(
             "runmat-plot: native_surface.render_to_rgba.start width={} height={} axes={} overrides={}",
             self.config.width.max(1),
@@ -161,7 +183,7 @@ impl NativeSurfaceRenderContext {
             figure.axes_metadata.len(),
             axes_cameras.map(|items| items.len()).unwrap_or(0)
         );
-        self.prepare_scene(figure, camera, axes_cameras);
+        self.prepare_scene(figure, camera, axes_cameras, axes_camera_user_controlled);
 
         let width = self.config.width.max(1);
         let height = self.config.height.max(1);
@@ -263,6 +285,7 @@ impl NativeSurfaceRenderContext {
         figure: &Figure,
         camera: Option<&Camera>,
         axes_cameras: Option<&[Camera]>,
+        axes_camera_user_controlled: Option<&[bool]>,
     ) {
         // Keep runtime config aligned with figure metadata, but treat the default figure
         // white background as "unspecified" and prefer active theme background for app parity.
@@ -286,6 +309,9 @@ impl NativeSurfaceRenderContext {
                     *target = override_camera.clone();
                 }
             }
+        }
+        if let Some(flags) = axes_camera_user_controlled {
+            self.renderer.set_axes_camera_interaction_flags(flags);
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, additive API surface in plot rendering; behavior change is limited to respecting supplied interaction flags during native prepare/render.
> 
> **Overview**
> Native export/render paths can now carry **per-axes “user controlled” camera state** alongside camera overrides, so headless/native draws match interactive pan/zoom behavior instead of being refit on figure update.
> 
> **`PlotRenderer`** gains **`set_axes_camera_interaction_flags`**, which resizes and sets `axes_2d_camera_user_controlled` per axes and calls **`note_camera_interaction`** when any axis is marked controlled (disabling auto-fit).
> 
> **`NativeSurfaceRenderContext`** adds **`render_to_view_with_camera_state`** and **`render_to_rgba_with_camera_state`**; existing **`render_to_view`** / **`render_to_rgba`** delegate with `None` for flags. **`prepare_scene`** applies optional flags after camera overrides via the new renderer API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60e035b20af35d51a93f5f118a6c080cd6405398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced plot rendering with improved control over per-axis camera interaction. New rendering modes now available for more precise management of viewport behavior in multi-axis visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->