### PR TITLE
making execution response contract for wasm carry source span for diagnostic messages

### DIFF
--- a/crates/runmat-cli/src/commands/benchmark.rs
+++ b/crates/runmat-cli/src/commands/benchmark.rs
@@ -58,7 +58,8 @@ pub async fn execute_benchmark(
             HostExecutionPolicy::default(),
             engine.workspace_handle(),
         );
-        match engine.execute_request(request).await {
+        let response = engine.execute_request(request).await;
+        match response.result {
             Ok(outcome) if outcome_error_code(&outcome).is_none() => {}
             Ok(outcome) => {
                 let error =
@@ -100,9 +101,9 @@ pub async fn execute_benchmark(
                         provider: capture_provider_snapshot(),
                     });
                 }
-                if let Some(diag) =
-                    format_frontend_error(&err, file.to_string_lossy().as_ref(), &content)
-                {
+                if let Some(diag) = response.source_context.source_text().and_then(|source| {
+                    format_frontend_error(&err, response.source_context.source_name(), source)
+                }) {
                     eprintln!("{diag}");
                 } else {
                     eprintln!("Benchmark error: {err}");
@@ -123,7 +124,8 @@ pub async fn execute_benchmark(
             HostExecutionPolicy::default(),
             engine.workspace_handle(),
         );
-        let outcome = match engine.execute_request(request).await {
+        let response = engine.execute_request(request).await;
+        let outcome = match response.result {
             Ok(outcome) => outcome,
             Err(err) => {
                 let failure = err.telemetry_failure_info();
@@ -144,9 +146,9 @@ pub async fn execute_benchmark(
                         provider: capture_provider_snapshot(),
                     });
                 }
-                if let Some(diag) =
-                    format_frontend_error(&err, file.to_string_lossy().as_ref(), &content)
-                {
+                if let Some(diag) = response.source_context.source_text().and_then(|source| {
+                    format_frontend_error(&err, response.source_context.source_name(), source)
+                }) {
                     eprintln!("{diag}");
                 } else {
                     eprintln!("Benchmark error: {err}");

--- a/crates/runmat-cli/src/commands/repl.rs
+++ b/crates/runmat-cli/src/commands/repl.rs
@@ -390,7 +390,8 @@ async fn process_repl_line(
         HostExecutionPolicy::default(),
         engine.workspace_handle(),
     );
-    match engine.execute_request(request).await {
+    let response = engine.execute_request(request).await;
+    match response.result {
         Ok(outcome) => {
             emit_execution_streams(&outcome.streams);
             for diagnostic in &outcome.diagnostics {
@@ -409,7 +410,9 @@ async fn process_repl_line(
             }
         }
         Err(e) => {
-            if let Some(diag) = format_frontend_error(&e, "<repl>", line) {
+            if let Some(diag) = response.source_context.source_text().and_then(|source| {
+                format_frontend_error(&e, response.source_context.source_name(), source)
+            }) {
                 eprintln!("{diag}");
             } else {
                 eprintln!("Execution error: {e}");

--- a/crates/runmat-cli/src/commands/script.rs
+++ b/crates/runmat-cli/src/commands/script.rs
@@ -90,7 +90,6 @@ pub(crate) async fn execute_script_contents(
             name: source_name,
             text: content.clone(),
         },
-        Some(content),
         cli,
         config,
     )
@@ -103,13 +102,12 @@ async fn execute_script_path(
     config: &RunMatRuntimeConfig,
 ) -> Result<()> {
     let source_name = script.to_string_lossy().to_string();
-    execute_script_request(script, SourceInput::Path(source_name), None, cli, config).await
+    execute_script_request(script, SourceInput::Path(source_name), cli, config).await
 }
 
 async fn execute_script_request(
     script: PathBuf,
     request_source: SourceInput,
-    diagnostic_source_text: Option<String>,
     cli: &Cli,
     config: &RunMatRuntimeConfig,
 ) -> Result<()> {
@@ -133,7 +131,8 @@ async fn execute_script_request(
         HostExecutionPolicy::default(),
         engine.workspace_handle(),
     );
-    let outcome = match engine.execute_request(request).await {
+    let response = engine.execute_request(request).await;
+    let outcome = match response.result {
         Ok(outcome) => outcome,
         Err(err) => {
             let failure = err.telemetry_failure_info();
@@ -149,12 +148,9 @@ async fn execute_script_request(
                     provider: capture_provider_snapshot(),
                 });
             }
-            let source_name = script.to_string_lossy().to_string();
-            let content_for_diagnostics = diagnostic_source_text
-                .unwrap_or_else(|| fs::read_to_string(&script).unwrap_or_default());
-            if let Some(diag) =
-                format_frontend_error(&err, source_name.as_str(), &content_for_diagnostics)
-            {
+            if let Some(diag) = response.source_context.source_text().and_then(|source| {
+                format_frontend_error(&err, response.source_context.source_name(), source)
+            }) {
                 eprintln!("{diag}");
             } else {
                 eprintln!("Execution error: {err}");

--- a/crates/runmat-core/src/abi.rs
+++ b/crates/runmat-core/src/abi.rs
@@ -57,6 +57,29 @@ impl ExecutionRequest {
 }
 
 #[derive(Debug, Clone)]
+pub struct ExecutionSourceContext {
+    pub name: String,
+    pub text: Option<String>,
+    pub identity: Option<SourceIdentity>,
+}
+
+impl ExecutionSourceContext {
+    pub fn source_name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn source_text(&self) -> Option<&str> {
+        self.text.as_deref()
+    }
+}
+
+#[derive(Debug)]
+pub struct ExecutionResponse {
+    pub source_context: ExecutionSourceContext,
+    pub result: std::result::Result<ExecutionOutcome, crate::RunError>,
+}
+
+#[derive(Debug, Clone)]
 pub struct ExecutionOutcome {
     pub flow: RuntimeFlow,
     pub workspace_delta: WorkspaceDelta,
@@ -194,6 +217,8 @@ pub struct RuntimeDiagnostic {
     pub severity: DiagnosticSeverity,
     pub message: String,
     pub span: Option<Span>,
+    pub callstack: Vec<String>,
+    pub callstack_elided: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/runmat-core/src/lib.rs
+++ b/crates/runmat-core/src/lib.rs
@@ -47,7 +47,8 @@ pub fn execute_text_request_for_testing(
         abi::HostExecutionPolicy::default(),
         session.workspace_handle(),
     );
-    let outcome = futures::executor::block_on(session.execute_request(request))?;
+    let response = futures::executor::block_on(session.execute_request(request));
+    let outcome = response.result?;
     let workspace = session.workspace_snapshot();
     let warnings = outcome
         .diagnostics

--- a/crates/runmat-core/src/session/run.rs
+++ b/crates/runmat-core/src/session/run.rs
@@ -88,10 +88,19 @@ impl RunMatSession {
     pub async fn execute_request(
         &mut self,
         request: crate::abi::ExecutionRequest,
-    ) -> std::result::Result<crate::abi::ExecutionOutcome, RunError> {
+    ) -> crate::abi::ExecutionResponse {
         let requested_outputs = request.requested_outputs.clone();
         let source_input = request.source.clone();
-        let (source_name, source_text) = source_input_text(request.source).await?;
+        let (source_name, source_text) = match source_input_text(request.source).await {
+            Ok(resolved) => resolved,
+            Err(err) => {
+                return crate::abi::ExecutionResponse {
+                    source_context: unresolved_source_context(&source_input),
+                    result: Err(err),
+                };
+            }
+        };
+        let source_identity = resolve_source_identity(&source_input, &source_text);
         let previous_compat = self.compat_mode;
         let previous_top_level_await_enabled = self.top_level_await_enabled;
         let previous_dynamic_eval_enabled = self.dynamic_eval_enabled;
@@ -102,9 +111,9 @@ impl RunMatSession {
         self.compat_mode = request.compatibility;
         self.top_level_await_enabled = request.host_policy.top_level_await;
         self.dynamic_eval_enabled = request.host_policy.dynamic_eval;
-        self.active_source_name = source_name;
+        self.active_source_name = source_name.clone();
         self.abi_workspace_handle = request.workspace;
-        self.active_source_identity = resolve_source_identity(&source_input, &source_text);
+        self.active_source_identity = source_identity.clone();
 
         let result = self.run(&source_text).await;
 
@@ -116,7 +125,15 @@ impl RunMatSession {
         self.active_source_identity = previous_source_identity;
         self.pending_companion_source_discovery = None;
 
-        result.map(|outcome| apply_requested_output_policy(outcome, &requested_outputs))
+        crate::abi::ExecutionResponse {
+            source_context: crate::abi::ExecutionSourceContext {
+                name: source_name,
+                text: Some(source_text),
+                identity: source_identity,
+            },
+            result: result
+                .map(|outcome| apply_requested_output_policy(outcome, &requested_outputs)),
+        }
     }
 
     async fn execute_internal(
@@ -1035,7 +1052,18 @@ impl RunMatSession {
                     .to_string(),
                 severity: crate::abi::DiagnosticSeverity::Error,
                 message: error.message().to_string(),
-                span: None,
+                span: runtime_error_span(error),
+                callstack: if !error.context.call_stack.is_empty() {
+                    error.context.call_stack.clone()
+                } else {
+                    error
+                        .context
+                        .call_frames
+                        .iter()
+                        .map(|frame| frame.function.clone())
+                        .collect()
+                },
+                callstack_elided: error.context.call_frames_elided,
             });
         }
         diagnostics.extend(
@@ -1046,6 +1074,8 @@ impl RunMatSession {
                     severity: crate::abi::DiagnosticSeverity::Warning,
                     message: warning.message.clone(),
                     span: None,
+                    callstack: Vec::new(),
+                    callstack_elided: 0,
                 }),
         );
 
@@ -1222,6 +1252,33 @@ fn source_text_hash(source_text: &str) -> String {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     source_text.hash(&mut hasher);
     format!("{:016x}", hasher.finish())
+}
+
+fn unresolved_source_context(
+    source: &crate::abi::SourceInput,
+) -> crate::abi::ExecutionSourceContext {
+    let name = match source {
+        crate::abi::SourceInput::Path(path) => path.clone(),
+        crate::abi::SourceInput::Text { name, .. } => name.clone(),
+    };
+    crate::abi::ExecutionSourceContext {
+        name,
+        text: match source {
+            crate::abi::SourceInput::Text { text, .. } => Some(text.clone()),
+            crate::abi::SourceInput::Path(_) => None,
+        },
+        identity: None,
+    }
+}
+
+fn runtime_error_span(error: &runmat_runtime::RuntimeError) -> Option<runmat_hir::Span> {
+    error.span.as_ref().map(|span| {
+        let start = span.offset();
+        runmat_hir::Span {
+            start,
+            end: start + span.len().max(1),
+        }
+    })
 }
 
 fn compile_eval_hook_bytecode(

--- a/crates/runmat-core/src/tests.rs
+++ b/crates/runmat-core/src/tests.rs
@@ -81,7 +81,7 @@ fn execute_text_request_named_source(
         abi::HostExecutionPolicy::default(),
         session.workspace_handle(),
     );
-    block_on(session.execute_request(request))
+    block_on(session.execute_request(request)).result
 }
 
 fn execute_path_request(
@@ -94,7 +94,7 @@ fn execute_path_request(
         abi::HostExecutionPolicy::default(),
         session.workspace_handle(),
     );
-    block_on(session.execute_request(request))
+    block_on(session.execute_request(request)).result
 }
 
 fn outcome_has_named_upsert(
@@ -1799,6 +1799,7 @@ fn execute_request_supports_command_syntax_rewrites_through_semantic_pipeline() 
         requested_outputs: runmat_hir::RequestedOutputCount::Zero,
         workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(17)),
     }))
+    .result
     .expect("command syntax should execute");
     let h_is_logical_scalar = outcome.workspace_delta.upserts.iter().any(|upsert| {
         let is_h = match &upsert.key {
@@ -1835,6 +1836,7 @@ fn execute_request_rejects_command_syntax_in_strict_mode() {
         requested_outputs: runmat_hir::RequestedOutputCount::Zero,
         workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(18)),
     }))
+    .result
     .expect_err("strict compatibility should reject command syntax");
     let RunError::Syntax(syntax) = err else {
         panic!("expected syntax error for strict command syntax rejection");
@@ -1861,6 +1863,7 @@ fn execute_request_supports_warning_off_all_command_rewrite() {
         requested_outputs: runmat_hir::RequestedOutputCount::Zero,
         workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(19)),
     }))
+    .result
     .expect("warning command syntax should execute");
     assert!(outcome_has_named_upsert(
         &outcome,
@@ -1885,6 +1888,7 @@ fn execute_request_supports_clearvars_name_command_rewrite() {
             workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(20)),
         }),
     )
+    .result
     .expect("clearvars command syntax should execute");
     assert!(outcome_has_named_upsert(
         &outcome,
@@ -1911,6 +1915,7 @@ fn execute_request_supports_close_all_command_rewrite() {
         requested_outputs: runmat_hir::RequestedOutputCount::Zero,
         workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(21)),
     }))
+    .result
     .expect("close all command syntax should execute");
     assert!(outcome_has_named_upsert(
         &outcome,
@@ -1934,6 +1939,7 @@ fn execute_request_supports_clearvars_except_command_rewrite() {
         requested_outputs: runmat_hir::RequestedOutputCount::Zero,
         workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(22)),
     }))
+    .result
     .expect("clearvars -except command syntax should execute");
     assert!(outcome_has_named_upsert(
         &outcome,
@@ -1965,6 +1971,7 @@ fn execute_request_rejects_clearvars_except_without_names_command_rewrite() {
         requested_outputs: runmat_hir::RequestedOutputCount::Zero,
         workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(23)),
     }))
+    .result
     .expect("request should complete with runtime diagnostic");
     assert!(
         outcome.diagnostics.iter().any(|diag| diag
@@ -2050,6 +2057,7 @@ fn execute_request_supports_format_command_rewrite_through_semantic_pipeline() {
         requested_outputs: runmat_hir::RequestedOutputCount::Zero,
         workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(24)),
     }))
+    .result
     .expect("format command syntax should execute");
     assert!(outcome_has_named_upsert(
         &outcome,
@@ -2308,6 +2316,7 @@ fn execute_request_uses_request_workspace_handle() {
         requested_outputs: runmat_hir::RequestedOutputCount::Zero,
         workspace,
     }))
+    .result
     .expect("exec succeeds");
 
     assert!(outcome.workspace_delta.upserts.iter().any(|upsert| {
@@ -2332,10 +2341,74 @@ fn execute_request_honors_zero_requested_outputs() {
         requested_outputs: runmat_hir::RequestedOutputCount::Zero,
         workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(9)),
     }))
+    .result
     .expect("exec succeeds");
 
     assert!(outcome.flow.is_no_value());
     assert_eq!(outcome.display_events.len(), 1);
+}
+
+#[test]
+fn execute_request_path_error_returns_resolved_source_context() {
+    let mut session = RunMatSession::with_snapshot_bytes(false, false, None).expect("session init");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let source_path = dir.path().join("source-context-error.m");
+    let source_text = "ss\nx = 1;\n";
+    std::fs::write(&source_path, source_text).expect("write test source");
+    let source_path = source_path.to_string_lossy().to_string();
+
+    let response = block_on(session.execute_request(abi::ExecutionRequest {
+        source: abi::SourceInput::Path(source_path.clone()),
+        compatibility: CompatMode::Matlab,
+        host_policy: abi::HostExecutionPolicy::default(),
+        requested_outputs: runmat_hir::RequestedOutputCount::Zero,
+        workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(25)),
+    }));
+
+    assert_eq!(response.source_context.source_name(), source_path);
+    assert_eq!(response.source_context.source_text(), Some(source_text));
+    assert!(matches!(
+        response.source_context.identity,
+        Some(abi::SourceIdentity::PathAndContentHash { .. })
+    ));
+    let err = response.result.expect_err("undefined name should fail");
+    let RunError::Semantic(err) = err else {
+        panic!("expected semantic error for undefined path source name");
+    };
+    assert_eq!(err.identifier.as_deref(), Some("RunMat:UndefinedVariable"));
+    assert!(err.span.is_some(), "semantic error should carry a span");
+}
+
+#[test]
+fn execute_request_runtime_diagnostic_preserves_span_and_callstack() {
+    let mut session = RunMatSession::with_snapshot_bytes(false, false, None).expect("session init");
+    let source = "x = [1];\ny = x(2);\n";
+    let outcome = block_on(session.execute_request(abi::ExecutionRequest {
+        source: abi::SourceInput::Text {
+            name: "runtime-span.m".to_string(),
+            text: source.to_string(),
+        },
+        compatibility: CompatMode::Matlab,
+        host_policy: abi::HostExecutionPolicy::default(),
+        requested_outputs: runmat_hir::RequestedOutputCount::Zero,
+        workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(26)),
+    }))
+    .result
+    .expect("runtime failures are returned as outcome diagnostics");
+
+    let diagnostic = outcome
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.severity == abi::DiagnosticSeverity::Error)
+        .expect("runtime error diagnostic");
+    assert!(
+        diagnostic.span.is_some(),
+        "runtime diagnostic should preserve VM source span"
+    );
+    assert!(
+        !diagnostic.callstack.is_empty(),
+        "runtime diagnostic should preserve VM callstack"
+    );
 }
 
 #[test]
@@ -2354,6 +2427,7 @@ fn execute_request_honors_top_level_await_host_policy() {
         requested_outputs: runmat_hir::RequestedOutputCount::Zero,
         workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(11)),
     }))
+    .result
     .expect_err("request should reject top-level await when host policy disables it");
     let RunError::Semantic(err) = err else {
         panic!("expected semantic top-level-await policy error");
@@ -9477,6 +9551,7 @@ fn dynamic_workspace_execute_request_can_disable_dynamic_eval_host_policy() {
         requested_outputs: runmat_hir::RequestedOutputCount::Zero,
         workspace: session.workspace_handle(),
     }))
+    .result
     .expect("request should return an outcome with a policy diagnostic");
     assert_eq!(outcome.diagnostics.len(), 1);
     assert_eq!(outcome.diagnostics[0].code, "RunMat:DynamicEvalDisabled");
@@ -9502,6 +9577,7 @@ fn dynamic_workspace_execute_request_dynamic_eval_policy_does_not_block_assignin
         requested_outputs: runmat_hir::RequestedOutputCount::Zero,
         workspace: session.workspace_handle(),
     }))
+    .result
     .expect("assignin should remain available");
     assert!(outcome.diagnostics.is_empty());
     assert!(outcome_has_named_upsert(

--- a/crates/runmat-core/tests/error_namespace_compat.rs
+++ b/crates/runmat-core/tests/error_namespace_compat.rs
@@ -33,8 +33,8 @@ fn assert_error_prefix(namespace: &str, code: &str) {
         session.workspace_handle(),
     );
 
-    let (identifier, message) = match futures::executor::block_on(session.execute_request(request))
-    {
+    let response = futures::executor::block_on(session.execute_request(request));
+    let (identifier, message) = match response.result {
         Ok(outcome) => {
             let diag = outcome
                 .diagnostics

--- a/crates/runmat-core/tests/integration.rs
+++ b/crates/runmat-core/tests/integration.rs
@@ -215,6 +215,7 @@ fn test_request_host_policy_disables_top_level_await() {
             requested_outputs: runmat_hir::RequestedOutputCount::Zero,
             workspace: abi::WorkspaceHandle(uuid::Uuid::from_u128(13)),
         }))
+        .result
         .expect_err("request should reject top-level await when host policy disables it");
         let RunError::Semantic(err) = err else {
             panic!("expected semantic top-level-await policy error");

--- a/crates/runmat-core/tests/printf_semantics.rs
+++ b/crates/runmat-core/tests/printf_semantics.rs
@@ -145,7 +145,8 @@ fn fprintf_format_error_propagates_to_session_boundary() {
         engine.workspace_handle(),
     );
 
-    match futures::executor::block_on(engine.execute_request(request)) {
+    let response = futures::executor::block_on(engine.execute_request(request));
+    match response.result {
         Ok(outcome) => {
             assert!(
                 outcome.diagnostics.iter().any(|d| d.severity

--- a/crates/runmat-wasm/src/api/session.rs
+++ b/crates/runmat-wasm/src/api/session.rs
@@ -122,13 +122,6 @@ impl RunMatWasm {
             ExecuteRequestSourcePayload::Text { text, .. } => text.clone(),
             ExecuteRequestSourcePayload::Path { path } => path.clone(),
         };
-        let (source_name, source_text): (Option<String>, Option<String>) =
-            match &request_payload.source {
-                ExecuteRequestSourcePayload::Text { name, text } => {
-                    (Some(name.clone()), Some(text.clone()))
-                }
-                ExecuteRequestSourcePayload::Path { path } => (Some(path.clone()), None),
-            };
         init_logging_once();
         let exec_span = info_span!(
             "runmat.execute",
@@ -215,9 +208,9 @@ impl RunMatWasm {
                 count => runmat_hir::RequestedOutputCount::Exactly(count as usize),
             };
         }
-        let exec_result = session.execute_request(request).await;
+        let exec_response = session.execute_request(request).await;
         *self.session.borrow_mut() = session;
-        let payload = match exec_result {
+        let payload = match exec_response.result {
             Ok(outcome) => {
                 if !outcome.diagnostics.iter().any(|diagnostic| {
                     diagnostic.severity == runmat_core::abi::DiagnosticSeverity::Error
@@ -230,7 +223,7 @@ impl RunMatWasm {
                         }
                     }
                 }
-                ExecutionPayload::from_outcome(outcome, &source_for_telemetry)
+                ExecutionPayload::from_outcome(outcome, &exec_response.source_context)
             }
             Err(err) => ExecutionPayload {
                 flow: serde_json::json!({ "kind": "no-value" }),
@@ -241,8 +234,8 @@ impl RunMatWasm {
                 used_jit: false,
                 error: Some(run_error_payload(
                     &err,
-                    source_name.as_deref(),
-                    source_text.as_deref(),
+                    Some(exec_response.source_context.source_name()),
+                    exec_response.source_context.source_text(),
                 )),
                 stdout: Vec::new(),
                 display_events: Vec::new(),

--- a/crates/runmat-wasm/src/wire/payloads.rs
+++ b/crates/runmat-wasm/src/wire/payloads.rs
@@ -8,8 +8,8 @@ use crate::wire::value::{value_to_json, MAX_DATA_PREVIEW};
 use runmat_builtins::Value;
 use runmat_core::{
     abi::{
-        DiagnosticSeverity, DisplayEvent, DisplayLabel, ExecutionOutcome, RuntimeDiagnostic,
-        RuntimeFlow, WorkspaceBindingKey,
+        DiagnosticSeverity, DisplayEvent, DisplayLabel, ExecutionOutcome, ExecutionSourceContext,
+        RuntimeDiagnostic, RuntimeFlow, WorkspaceBindingKey,
     },
     approximate_size_bytes, matlab_class_name, numeric_dtype_label, preview_numeric_values,
     value_shape, ExecutionProfiling, ExecutionStreamEntry, ExecutionStreamKind, FusionPlanDecision,
@@ -69,7 +69,10 @@ pub(crate) struct MemoryUsagePayload {
 }
 
 impl ExecutionPayload {
-    pub(crate) fn from_outcome(outcome: ExecutionOutcome, source: &str) -> Self {
+    pub(crate) fn from_outcome(
+        outcome: ExecutionOutcome,
+        source_context: &ExecutionSourceContext,
+    ) -> Self {
         let workspace = WorkspacePayload::from_outcome(&outcome);
         let flow = runtime_flow_to_json(&outcome.flow);
         let value = outcome.flow.durable_workspace_value().cloned();
@@ -77,7 +80,7 @@ impl ExecutionPayload {
             .diagnostics
             .iter()
             .find(|diagnostic| diagnostic.severity == DiagnosticSeverity::Error)
-            .map(|diagnostic| error_payload_from_diagnostic(diagnostic, source));
+            .map(|diagnostic| error_payload_from_diagnostic(diagnostic, source_context));
         Self {
             flow,
             display_events: outcome
@@ -368,25 +371,39 @@ fn workspace_entry_from_value(name: String, value: &Value) -> WorkspaceEntryPayl
 
 fn error_payload_from_diagnostic(
     diagnostic: &RuntimeDiagnostic,
-    source: &str,
+    source_context: &ExecutionSourceContext,
 ) -> RunMatErrorPayload {
-    let span = diagnostic.span.map(|span| {
-        let (line, column) = line_col_from_source(source, span.start);
-        RunMatErrorSpanPayload {
-            start: span.start,
-            end: span.end,
-            line,
-            column,
-        }
+    let span = source_context.source_text().and_then(|source| {
+        diagnostic.span.map(|span| {
+            let (line, column) = line_col_from_source(source, span.start);
+            RunMatErrorSpanPayload {
+                start: span.start,
+                end: span.end,
+                line,
+                column,
+            }
+        })
     });
+    let diagnostic_text = match (source_context.source_text(), diagnostic.span) {
+        (Some(source), Some(span)) => {
+            runmat_runtime::build_runtime_error(diagnostic.message.clone())
+                .with_identifier(diagnostic.code.clone())
+                .with_span((span.start, span.end.saturating_sub(span.start).max(1)).into())
+                .with_call_stack(diagnostic.callstack.clone())
+                .with_call_frames_elided(diagnostic.callstack_elided)
+                .build()
+                .format_diagnostic_with_source(Some(source_context.source_name()), Some(source))
+        }
+        _ => diagnostic.message.clone(),
+    };
     RunMatErrorPayload {
         kind: RunMatErrorKind::Runtime,
         message: diagnostic.message.clone(),
         identifier: Some(diagnostic.code.clone()),
-        diagnostic: diagnostic.message.clone(),
+        diagnostic: diagnostic_text,
         span,
-        callstack: Vec::new(),
-        callstack_elided: 0,
+        callstack: diagnostic.callstack.clone(),
+        callstack_elided: diagnostic.callstack_elided,
     }
 }
 
@@ -808,8 +825,16 @@ pub(crate) fn parse_materialize_options(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use runmat_core::abi::{WorkspaceBindingValue, WorkspaceDelta};
+    use runmat_core::abi::{ExecutionSourceContext, WorkspaceBindingValue, WorkspaceDelta};
     use runmat_hir::BindingName;
+
+    fn test_source_context() -> ExecutionSourceContext {
+        ExecutionSourceContext {
+            name: "<test>".to_string(),
+            text: Some(String::new()),
+            identity: None,
+        }
+    }
 
     #[test]
     fn execution_payload_serializes_runtime_flow_kind() {
@@ -818,7 +843,7 @@ mod tests {
             ..ExecutionOutcome::default()
         };
 
-        let payload = ExecutionPayload::from_outcome(outcome, "");
+        let payload = ExecutionPayload::from_outcome(outcome, &test_source_context());
         assert_eq!(payload.flow["kind"], "output-list");
         assert_eq!(
             payload.flow["values"],
@@ -849,10 +874,36 @@ mod tests {
             ..ExecutionOutcome::default()
         };
 
-        let payload = ExecutionPayload::from_outcome(outcome, "");
+        let payload = ExecutionPayload::from_outcome(outcome, &test_source_context());
         assert_eq!(payload.workspace.version, 42);
         assert_eq!(payload.workspace.removals, vec!["x".to_string()]);
         assert_eq!(payload.workspace.values.len(), 1);
         assert_eq!(payload.workspace.values[0].name, "x");
+    }
+
+    #[test]
+    fn execution_payload_formats_runtime_diagnostic_with_source_context() {
+        let outcome = ExecutionOutcome {
+            diagnostics: vec![RuntimeDiagnostic {
+                code: "RunMat:IndexOutOfBounds".to_string(),
+                severity: DiagnosticSeverity::Error,
+                message: "Index out of bounds".to_string(),
+                span: Some(runmat_hir::Span { start: 7, end: 11 }),
+                callstack: vec!["<main> @ path-source.m:2:5".to_string()],
+                callstack_elided: 0,
+            }],
+            ..ExecutionOutcome::default()
+        };
+        let source_context = ExecutionSourceContext {
+            name: "path-source.m".to_string(),
+            text: Some("x = 1;\ny = x(2);\n".to_string()),
+            identity: None,
+        };
+
+        let payload = ExecutionPayload::from_outcome(outcome, &source_context);
+        let error = payload.error.expect("error payload");
+        assert!(error.diagnostic.contains("--> path-source.m:2:1"));
+        assert_eq!(error.span.expect("span").line, 2);
+        assert_eq!(error.callstack, vec!["<main> @ path-source.m:2:5"]);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the core execution ABI and all execute_request call sites; behavior shifts for path-based scripts and error display, though updates are largely mechanical with new tests.
> 
> **Overview**
> **`execute_request`** now returns an **`ExecutionResponse`** pairing **`ExecutionSourceContext`** (resolved name, optional full source text, identity) with the existing **`Result<ExecutionOutcome, RunError>`**, including partial context when path resolution fails.
> 
> **Runtime error diagnostics** on the ABI gain **source spans** and **callstack** fields; the session maps VM/runtime errors into those fields. **CLI** (script, REPL, benchmark) and **WASM** wire payloads use the response’s source context to format frontend/runtime diagnostics (line/column, `-->` snippets, callstacks) instead of re-reading files or duplicating source in callers. Script execution drops the extra **`diagnostic_source_text`** parameter.
> 
> Tests cover path-source error context and runtime diagnostic span/callstack preservation through WASM payload formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f780f51fca434277cc2f72044caee57d8daa6eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error diagnostic reporting with improved source context tracking across CLI, REPL, and script execution modes
  * Added callstack information to runtime error diagnostics for better error visibility and debugging

* **Improvements**
  * Error messages now include more accurate source identification and metadata for better error context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->