### PR TITLE
Implemented gca command

### DIFF
--- a/crates/runmat-runtime/src/builtins/plotting/ops/gca.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/gca.rs
@@ -9,7 +9,7 @@ use runmat_macros::runtime_builtin;
 
 use super::op_common::handles::handle_from_scalar;
 use super::plotting_error;
-use super::properties::map_figure_error;
+use super::properties::{map_figure_error, resolve_plot_handle, PlotHandle};
 use super::state::{
     current_axes_handle_for_figure, current_axes_state, encode_axes_handle, FigureAxesState,
     FigureHandle,
@@ -120,7 +120,7 @@ pub fn gca_builtin(rest: Vec<Value>) -> crate::BuiltinResult<Value> {
 
     Err(plotting_error(
         "gca",
-        "gca: unsupported arguments (pass no inputs or 'struct')",
+        "gca: unsupported arguments (pass no inputs, a figure handle, or 'struct')",
     ))
 }
 
@@ -138,6 +138,19 @@ fn axes_struct_response(state: FigureAxesState) -> Value {
 }
 
 fn figure_handle_arg(value: &Value) -> crate::BuiltinResult<Option<FigureHandle>> {
+    if let Ok(handle) = resolve_plot_handle(value, "gca") {
+        return match handle {
+            PlotHandle::Figure(handle) => Ok(Some(handle)),
+            PlotHandle::Axes(_, _)
+            | PlotHandle::Text(_, _, _)
+            | PlotHandle::Legend(_, _)
+            | PlotHandle::PlotChild(_) => Err(plotting_error(
+                "gca",
+                "gca: expected a figure handle, got a non-figure graphics handle",
+            )),
+        };
+    }
+
     match value {
         Value::Num(v) => Ok(Some(handle_from_scalar(*v, "gca")?)),
         Value::Int(i) => Ok(Some(handle_from_scalar(i.to_f64(), "gca")?)),
@@ -151,7 +164,7 @@ fn figure_handle_arg(value: &Value) -> crate::BuiltinResult<Option<FigureHandle>
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::builtins::plotting::tests::ensure_plot_test_env;
+    use crate::builtins::plotting::tests::{ensure_plot_test_env, lock_plot_registry};
     use runmat_builtins::{ResolveContext, Type};
 
     fn setup_plot_tests() {
@@ -208,6 +221,26 @@ pub(crate) mod tests {
             text.contains("gca: unsupported arguments"),
             "unexpected error: {text}"
         );
+        assert!(
+            text.contains("pass no inputs, a figure handle, or 'struct'"),
+            "unexpected error: {text}"
+        );
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn axes_handle_argument_is_rejected() {
+        let _guard = lock_plot_registry();
+        setup_plot_tests();
+        crate::builtins::plotting::reset_plot_state();
+
+        let axes = gca_builtin(Vec::new()).unwrap();
+        let err = gca_builtin(vec![axes]).expect_err("axes handle should not be accepted");
+        let text = err.to_string();
+        assert!(
+            text.contains("expected a figure handle"),
+            "unexpected error: {text}"
+        );
     }
 
     #[test]
@@ -216,7 +249,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn gca_type_with_args_returns_struct() {
+    fn gca_type_with_string_arg_returns_struct() {
         let out = gca_type(&[Type::String], &ResolveContext::new(Vec::new()));
         assert!(matches!(out, Type::Struct { .. }));
     }
@@ -226,6 +259,40 @@ pub(crate) mod tests {
         assert_eq!(
             gca_type(&[Type::Num], &ResolveContext::new(Vec::new())),
             Type::Num
+        );
+    }
+
+    #[test]
+    fn gca_type_with_multi_args_returns_unknown() {
+        assert_eq!(
+            gca_type(&[Type::Num, Type::String], &ResolveContext::new(Vec::new())),
+            Type::Unknown
+        );
+    }
+
+    #[test]
+    fn gca_type_with_scalar_tensor_arg_returns_num() {
+        assert_eq!(
+            gca_type(
+                &[Type::Tensor {
+                    shape: Some(vec![Some(1), Some(1)])
+                }],
+                &ResolveContext::new(Vec::new())
+            ),
+            Type::Num
+        );
+    }
+
+    #[test]
+    fn gca_type_with_non_scalar_tensor_arg_returns_unknown() {
+        assert_eq!(
+            gca_type(
+                &[Type::Tensor {
+                    shape: Some(vec![Some(1), Some(2)])
+                }],
+                &ResolveContext::new(Vec::new())
+            ),
+            Type::Unknown
         );
     }
 }

--- a/crates/runmat-runtime/src/builtins/plotting/ops/gca.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/gca.rs
@@ -7,8 +7,13 @@ use runmat_builtins::{
 use runmat_builtins::{StructValue, Value};
 use runmat_macros::runtime_builtin;
 
+use super::op_common::handles::handle_from_scalar;
 use super::plotting_error;
-use super::state::{current_axes_state, encode_axes_handle, FigureAxesState};
+use super::properties::map_figure_error;
+use super::state::{
+    current_axes_handle_for_figure, current_axes_state, encode_axes_handle, FigureAxesState,
+    FigureHandle,
+};
 use super::style::value_as_string;
 use crate::builtins::plotting::type_resolvers::gca_type;
 
@@ -38,10 +43,23 @@ const GCA_INPUTS_MODE: [BuiltinParamDescriptor; 1] = [BuiltinParamDescriptor {
     description: "Only 'struct' is supported.",
 }];
 
-const GCA_SIGNATURES: [BuiltinSignatureDescriptor; 2] = [
+const GCA_INPUTS_FIGURE: [BuiltinParamDescriptor; 1] = [BuiltinParamDescriptor {
+    name: "fig",
+    ty: BuiltinParamType::NumericScalar,
+    arity: BuiltinParamArity::Required,
+    default: None,
+    description: "Figure handle whose current axes should be returned.",
+}];
+
+const GCA_SIGNATURES: [BuiltinSignatureDescriptor; 3] = [
     BuiltinSignatureDescriptor {
         label: "ax = gca()",
         inputs: &GCA_INPUTS_NONE,
+        outputs: &GCA_OUTPUT_HANDLE,
+    },
+    BuiltinSignatureDescriptor {
+        label: "ax = gca(fig)",
+        inputs: &GCA_INPUTS_FIGURE,
         outputs: &GCA_OUTPUT_HANDLE,
     },
     BuiltinSignatureDescriptor {
@@ -78,8 +96,8 @@ pub const GCA_DESCRIPTOR: BuiltinDescriptor = BuiltinDescriptor {
     builtin_path = "crate::builtins::plotting::gca"
 )]
 pub fn gca_builtin(rest: Vec<Value>) -> crate::BuiltinResult<Value> {
-    let state = current_axes_state();
     if rest.is_empty() {
+        let state = current_axes_state();
         return Ok(Value::Num(encode_axes_handle(
             state.handle,
             state.active_index,
@@ -89,8 +107,14 @@ pub fn gca_builtin(rest: Vec<Value>) -> crate::BuiltinResult<Value> {
     if rest.len() == 1 {
         if let Some(mode) = value_as_string(&rest[0]) {
             if mode.trim().eq_ignore_ascii_case("struct") {
+                let state = current_axes_state();
                 return Ok(axes_struct_response(state));
             }
+        }
+        if let Some(handle) = figure_handle_arg(&rest[0])? {
+            let axes = current_axes_handle_for_figure(handle)
+                .map_err(|err| map_figure_error("gca", err))?;
+            return Ok(Value::Num(axes));
         }
     }
 
@@ -113,6 +137,17 @@ fn axes_struct_response(state: FigureAxesState) -> Value {
     Value::Struct(st)
 }
 
+fn figure_handle_arg(value: &Value) -> crate::BuiltinResult<Option<FigureHandle>> {
+    match value {
+        Value::Num(v) => Ok(Some(handle_from_scalar(*v, "gca")?)),
+        Value::Int(i) => Ok(Some(handle_from_scalar(i.to_f64(), "gca")?)),
+        Value::Tensor(tensor) if tensor.data.len() == 1 => {
+            Ok(Some(handle_from_scalar(tensor.data[0], "gca")?))
+        }
+        _ => Ok(None),
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
@@ -132,6 +167,7 @@ pub(crate) mod tests {
             .map(|sig| sig.label)
             .collect();
         assert!(labels.contains(&"ax = gca()"));
+        assert!(labels.contains(&"ax = gca(fig)"));
         assert!(labels.contains(&"s = gca('struct')"));
     }
 
@@ -154,6 +190,26 @@ pub(crate) mod tests {
         assert!(matches!(value, Value::Struct(_)));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn figure_handle_returns_that_figures_current_axes() {
+        setup_plot_tests();
+        let value = gca_builtin(vec![Value::Num(42.0)]).unwrap();
+        assert!(matches!(value, Value::Num(v) if v > 0.0));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[test]
+    fn invalid_arguments_return_plotting_error() {
+        setup_plot_tests();
+        let err = gca_builtin(vec![Value::String("unsupported".to_string())]).unwrap_err();
+        let text = err.to_string();
+        assert!(
+            text.contains("gca: unsupported arguments"),
+            "unexpected error: {text}"
+        );
+    }
+
     #[test]
     fn gca_type_no_args_returns_num() {
         assert_eq!(gca_type(&[], &ResolveContext::new(Vec::new())), Type::Num);
@@ -163,5 +219,13 @@ pub(crate) mod tests {
     fn gca_type_with_args_returns_struct() {
         let out = gca_type(&[Type::String], &ResolveContext::new(Vec::new()));
         assert!(matches!(out, Type::Struct { .. }));
+    }
+
+    #[test]
+    fn gca_type_with_figure_arg_returns_num() {
+        assert_eq!(
+            gca_type(&[Type::Num], &ResolveContext::new(Vec::new())),
+            Type::Num
+        );
     }
 }

--- a/crates/runmat-runtime/src/builtins/plotting/type_resolvers.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/type_resolvers.rs
@@ -14,6 +14,9 @@ pub fn gca_type(args: &[Type], _context: &ResolveContext) -> Type {
     if args.is_empty() {
         return Type::Num;
     }
+    if matches!(args.first(), Some(Type::Num | Type::Int)) {
+        return Type::Num;
+    }
     Type::Struct {
         known_fields: Some(vec![
             "handle".to_string(),

--- a/crates/runmat-runtime/src/builtins/plotting/type_resolvers.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/type_resolvers.rs
@@ -1,5 +1,7 @@
 use runmat_builtins::{ResolveContext, Type};
 
+use runmat_builtins::shape_rules::element_count_if_known;
+
 use crate::builtins::array::type_resolvers::{row_vector_type, size_vector_len};
 
 pub fn handle_scalar_type(_args: &[Type], _context: &ResolveContext) -> Type {
@@ -11,20 +13,22 @@ pub fn bool_type(_args: &[Type], _context: &ResolveContext) -> Type {
 }
 
 pub fn gca_type(args: &[Type], _context: &ResolveContext) -> Type {
-    if args.is_empty() {
-        return Type::Num;
-    }
-    if matches!(args.first(), Some(Type::Num | Type::Int)) {
-        return Type::Num;
-    }
-    Type::Struct {
-        known_fields: Some(vec![
-            "handle".to_string(),
-            "figure".to_string(),
-            "rows".to_string(),
-            "cols".to_string(),
-            "index".to_string(),
-        ]),
+    match args {
+        [] => Type::Num,
+        [Type::Num | Type::Int] => Type::Num,
+        [Type::Tensor { shape: Some(shape) }] if element_count_if_known(shape) == Some(1) => {
+            Type::Num
+        }
+        [Type::String] => Type::Struct {
+            known_fields: Some(vec![
+                "handle".to_string(),
+                "figure".to_string(),
+                "rows".to_string(),
+                "cols".to_string(),
+                "index".to_string(),
+            ]),
+        },
+        _ => Type::Unknown,
     }
 }
 

--- a/crates/runmat-vm/tests/plotting.rs
+++ b/crates/runmat-vm/tests/plotting.rs
@@ -78,6 +78,38 @@ fn bare_gca_can_set_axes_font_size() {
 }
 
 #[test]
+fn gca_returns_active_subplot_axes_handle() {
+    let _guard = disable_interactive_plots_for_test();
+    let input = "\
+        figure; \
+        ax = subplot(2, 2, 3); \
+        current = gca(); \
+        if current ~= ax; \
+            error('gca did not return active subplot axes'); \
+        end;";
+    execute_source(input).expect("execute gca subplot handle script");
+}
+
+#[test]
+fn gca_with_figure_handle_returns_that_figures_current_axes() {
+    let _guard = disable_interactive_plots_for_test();
+    let input = "\
+        f1 = figure(1); \
+        ax1 = subplot(2, 2, 3); \
+        f2 = figure(2); \
+        ax2 = subplot(1, 2, 2); \
+        current_f1_axes = gca(f1); \
+        current_f2_axes = gca(); \
+        if current_f1_axes ~= ax1; \
+            error('gca(fig) did not return target figure axes'); \
+        end; \
+        if current_f2_axes ~= ax2; \
+            error('plain gca did not keep current figure axes'); \
+        end;";
+    execute_source(input).expect("execute gca figure-handle script");
+}
+
+#[test]
 fn invalid_axes_shaped_handle_member_access_reports_non_object() {
     let _guard = disable_interactive_plots_for_test();
     let input = "bad_axes_handle = 1049575; out = bad_axes_handle.Type;";

--- a/crates/runmat-vm/tests/plotting.rs
+++ b/crates/runmat-vm/tests/plotting.rs
@@ -110,6 +110,20 @@ fn gca_with_figure_handle_returns_that_figures_current_axes() {
 }
 
 #[test]
+fn gca_rejects_axes_handle_argument() {
+    let _guard = disable_interactive_plots_for_test();
+    let input = "\
+        figure; \
+        ax = subplot(2, 2, 3); \
+        out = gca(ax);";
+    let err = execute_source(input).expect_err("gca(ax) should reject axes handles");
+    assert!(
+        err.to_string().contains("expected a figure handle"),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test]
 fn invalid_axes_shaped_handle_member_access_reports_non_object() {
     let _guard = disable_interactive_plots_for_test();
     let input = "bad_axes_handle = 1049575; out = bad_axes_handle.Type;";

--- a/docs/builtins/meta.json
+++ b/docs/builtins/meta.json
@@ -25272,6 +25272,27 @@
           ]
         },
         {
+          "label": "ax = gca(fig)",
+          "inputs": [
+            {
+              "name": "fig",
+              "ty": "NumericScalar",
+              "arity": "Required",
+              "default": null,
+              "description": "Figure handle whose current axes should be returned."
+            }
+          ],
+          "outputs": [
+            {
+              "name": "ax",
+              "ty": "NumericScalar",
+              "arity": "Required",
+              "default": null,
+              "description": "Current axes handle."
+            }
+          ]
+        },
+        {
           "label": "s = gca('struct')",
           "inputs": [
             {

--- a/docs/builtins/reference/gca.json
+++ b/docs/builtins/reference/gca.json
@@ -26,9 +26,10 @@
   "tested": {
     "unit": "builtins::plotting::gca::tests"
   },
-  "description": "`gca` returns the handle for the current axes in the active figure. Optional struct mode returns a snapshot of current axes context for diagnostics and tooling.",
+  "description": "`gca` returns the handle for the current axes in the active figure, or in a specific figure when a figure handle is supplied. Optional struct mode returns a snapshot of current axes context for diagnostics and tooling.",
   "behaviors": [
     "`gca()` returns a scalar numeric axes handle.",
+    "`gca(fig)` returns the current axes handle for the specified figure handle.",
     "`gca('struct')` returns a struct with fields `handle`, `figure`, `rows`, `cols`, and `index`.",
     "The current axes reflect the active subplot when `subplot` has been used.",
     "The numeric axes handle can be passed to `get` and `set`, including common axes styling such as `FontSize`.",
@@ -46,6 +47,11 @@
       "output": "info =\n  struct with fields:\n    handle\n    figure\n    rows\n    cols\n    index"
     },
     {
+      "description": "Read the current axes of a specific figure",
+      "input": "f1 = figure(1);\nsubplot(2, 2, 3);\nf2 = figure(2);\nax1 = gca(f1)",
+      "output": "% ax1 is the current axes handle for figure 1"
+    },
+    {
       "description": "Style the current axes",
       "input": "plot(1:3, [1 2 3]);\nset(gca, 'FontSize', 10);"
     }
@@ -58,6 +64,10 @@
     {
       "question": "Does `gca` reflect `subplot` selection?",
       "answer": "Yes. When a subplot is active, `gca` reports that subplot's axes handle and metadata."
+    },
+    {
+      "question": "Can `gca` inspect a non-current figure?",
+      "answer": "Yes. Pass a figure handle, for example `gca(fig)`, to read that figure's current axes without changing the active figure."
     },
     {
       "question": "Does `gca` run on the GPU?",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Plotting-state read path only, reuses existing figure/axes state helpers, and is covered by unit and VM tests with no auth or data-handling impact.
> 
> **Overview**
> **`gca` now accepts an optional figure handle** so callers can read that figure’s current axes without switching the active figure. The new **`gca(fig)`** path uses **`current_axes_handle_for_figure`** and maps figure registry errors through the same helpers as other plotting builtins.
> 
> Argument handling is tightened: **`'struct'`** still returns the axes snapshot struct; numeric/int/scalar-tensor inputs are treated as figure handles via **`figure_handle_arg`**, which rejects axes, text, legend, and other non-figure graphics handles with a clear error. Unsupported inputs get an updated message listing **no args, a figure handle, or `'struct'`**.
> 
> The **`gca_type`** resolver no longer treats any single argument as struct mode—only **`Type::String`** yields the struct type; figure-like scalars and 1-element tensors resolve to **`Num`**, and other shapes/arity return **`Unknown`**.
> 
> Coverage adds unit tests for the new signature, rejection paths, and type rules, plus VM integration tests for subplot **`gca()`**, cross-figure **`gca(f1)`**, and **`gca(ax)`** failure. Builtin metadata and **`gca.json`** document the new signature, example, and FAQ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce8d5878fed1132419521b72e4b2e513a9859f69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended `gca` to support `ax = gca(fig)`, returning the current axes for a specified figure.
* **Bug Fixes**
  * Improved argument handling and validation for `gca`, including clearer errors for unsupported inputs (e.g., passing an axes handle).
* **Tests**
  * Added integration and type-resolution coverage for `gca(fig)` behavior and error cases.
* **Documentation**
  * Updated `gca` references with the new signature, examples, and guidance for inspecting non-active figures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->