### PR TITLE
Aligned colormap command syntax with supported runtime names

### DIFF
--- a/crates/runmat-core/src/tests.rs
+++ b/crates/runmat-core/src/tests.rs
@@ -2320,28 +2320,54 @@ fn compile_input_lowers_axis_command_keyword_to_semantic_builtin_call() {
 
 #[test]
 fn compile_input_lowers_colormap_command_keyword_to_semantic_builtin_call() {
-    let mut session = RunMatSession::with_snapshot_bytes(false, false, None).expect("session init");
-    let prepared = session
-        .compile_input("colormap jet;")
-        .expect("colormap command syntax should compile");
+    for colormap_name in [
+        "parula", "viridis", "plasma", "inferno", "magma", "turbo", "jet", "hot", "cool", "spring",
+        "summer", "autumn", "winter", "gray", "grey", "bone", "copper", "pink", "lines",
+    ] {
+        let mut session =
+            RunMatSession::with_snapshot_bytes(false, false, None).expect("session init");
+        let source = format!("colormap {colormap_name};");
+        let prepared = session
+            .compile_input(&source)
+            .unwrap_or_else(|err| panic!("{source}: colormap command syntax failed: {err:?}"));
 
+        assert!(
+            prepared.bytecode.layout.is_some(),
+            "{source}: colormap command syntax should compile through semantic HIR/MIR/VM"
+        );
+        assert!(
+            prepared
+                .bytecode
+                .instructions
+                .iter()
+                .any(|instr| matches!(instr, runmat_vm::Instr::LoadString(s) if s == colormap_name)),
+            "{source}: colormap command should carry normalized keyword as semantic string argument"
+        );
+        assert!(
+            prepared.bytecode.instructions.iter().any(
+                |instr| matches!(instr, runmat_vm::Instr::CallBuiltinMulti(name, 1, _) if name == "colormap")
+            ),
+            "{source}: colormap command should lower to builtin dispatch with one normalized argument"
+        );
+    }
+}
+
+#[test]
+fn compile_input_rejects_unsupported_hsv_colormap_command_keyword() {
+    let mut session = RunMatSession::with_snapshot_bytes(false, false, None).expect("session init");
+    let err = match session.compile_input("colormap hsv;") {
+        Ok(_) => panic!("unsupported hsv colormap command syntax should fail"),
+        Err(err) => err,
+    };
+    let RunError::Syntax(syntax) = err else {
+        panic!("expected syntax error for unsupported colormap command keyword");
+    };
     assert!(
-        prepared.bytecode.layout.is_some(),
-        "colormap command syntax should compile through semantic HIR/MIR/VM"
-    );
-    assert!(
-        prepared
-            .bytecode
-            .instructions
-            .iter()
-            .any(|instr| matches!(instr, runmat_vm::Instr::LoadString(s) if s == "jet")),
-        "colormap command should carry normalized keyword as semantic string argument"
-    );
-    assert!(
-        prepared.bytecode.instructions.iter().any(
-            |instr| matches!(instr, runmat_vm::Instr::CallBuiltinMulti(name, 1, _) if name == "colormap")
-        ),
-        "colormap command should lower to builtin dispatch with one normalized argument"
+        syntax
+            .message
+            .contains("'colormap' command syntax does not support 'hsv'"),
+        "unexpected colormap hsv syntax error: {}",
+        syntax.message
     );
 }
 

--- a/crates/runmat-parser/src/parser/command.rs
+++ b/crates/runmat-parser/src/parser/command.rs
@@ -25,6 +25,10 @@ enum CommandArgKind {
 
 const REQUIRED_PATH_WORDS: CommandArgKind = CommandArgKind::PathWords { optional: false };
 const OPTIONAL_PATH_WORDS: CommandArgKind = CommandArgKind::PathWords { optional: true };
+const COLORMAP_COMMAND_KEYWORDS: &[&str] = &[
+    "parula", "viridis", "plasma", "inferno", "magma", "turbo", "jet", "hot", "cool", "spring",
+    "summer", "autumn", "winter", "gray", "grey", "bone", "copper", "pink", "lines",
+];
 
 const COMMAND_VERBS: &[CommandVerb] = &[
     CommandVerb {
@@ -67,10 +71,7 @@ const COMMAND_VERBS: &[CommandVerb] = &[
     CommandVerb {
         name: "colormap",
         arg_kind: CommandArgKind::Keyword {
-            allowed: &[
-                "parula", "jet", "hsv", "hot", "cool", "spring", "summer", "autumn", "winter",
-                "gray", "bone", "copper", "pink",
-            ],
+            allowed: COLORMAP_COMMAND_KEYWORDS,
             optional: false,
         },
     },

--- a/crates/runmat-parser/tests/command_syntax.rs
+++ b/crates/runmat-parser/tests/command_syntax.rs
@@ -601,6 +601,28 @@ fn assert_command_string_args(source: &str, expected_name: &str, expected_args: 
 }
 
 #[test]
+fn colormap_command_accepts_supported_runtime_names() {
+    for name in [
+        "parula", "viridis", "plasma", "inferno", "magma", "turbo", "jet", "hot", "cool", "spring",
+        "summer", "autumn", "winter", "gray", "grey", "bone", "copper", "pink", "lines",
+    ] {
+        assert_command_string_args(&format!("colormap {name}"), "colormap", &[name]);
+    }
+}
+
+#[test]
+fn colormap_command_rejects_unsupported_hsv() {
+    let err = parse_with_options("colormap hsv", ParserOptions::new(CompatMode::Matlab))
+        .expect_err("colormap hsv should be rejected");
+    assert!(
+        err.message
+            .contains("'colormap' command syntax does not support 'hsv'"),
+        "unexpected error: {}",
+        err.message
+    );
+}
+
+#[test]
 fn invalid_keyword_rejected() {
     let err = parse_with_options("grid maybe", ParserOptions::new(CompatMode::Matlab));
     assert!(err.is_err());

--- a/crates/runmat-plot/src/event.rs
+++ b/crates/runmat-plot/src/event.rs
@@ -2171,27 +2171,7 @@ fn parse_marker_style(value: &str) -> MarkerStyle {
 }
 
 fn parse_colormap(value: &str) -> ColorMap {
-    match value {
-        "Jet" => ColorMap::Jet,
-        "Hot" => ColorMap::Hot,
-        "Cool" => ColorMap::Cool,
-        "Spring" => ColorMap::Spring,
-        "Summer" => ColorMap::Summer,
-        "Autumn" => ColorMap::Autumn,
-        "Winter" => ColorMap::Winter,
-        "Gray" => ColorMap::Gray,
-        "Bone" => ColorMap::Bone,
-        "Copper" => ColorMap::Copper,
-        "Pink" => ColorMap::Pink,
-        "Lines" => ColorMap::Lines,
-        "Viridis" => ColorMap::Viridis,
-        "Plasma" => ColorMap::Plasma,
-        "Inferno" => ColorMap::Inferno,
-        "Magma" => ColorMap::Magma,
-        "Turbo" => ColorMap::Turbo,
-        "Parula" => ColorMap::Parula,
-        _ => ColorMap::Parula,
-    }
+    ColorMap::from_name(value).unwrap_or(ColorMap::Parula)
 }
 
 fn parse_shading_mode(value: &str) -> ShadingMode {
@@ -2347,26 +2327,8 @@ fn parse_line_style_name(name: &str) -> crate::plots::line::LineStyle {
 }
 
 fn parse_colormap_name(name: &str) -> crate::plots::surface::ColorMap {
-    match name.trim().to_ascii_lowercase().as_str() {
-        "viridis" => crate::plots::surface::ColorMap::Viridis,
-        "plasma" => crate::plots::surface::ColorMap::Plasma,
-        "inferno" => crate::plots::surface::ColorMap::Inferno,
-        "magma" => crate::plots::surface::ColorMap::Magma,
-        "turbo" => crate::plots::surface::ColorMap::Turbo,
-        "jet" => crate::plots::surface::ColorMap::Jet,
-        "hot" => crate::plots::surface::ColorMap::Hot,
-        "cool" => crate::plots::surface::ColorMap::Cool,
-        "spring" => crate::plots::surface::ColorMap::Spring,
-        "summer" => crate::plots::surface::ColorMap::Summer,
-        "autumn" => crate::plots::surface::ColorMap::Autumn,
-        "winter" => crate::plots::surface::ColorMap::Winter,
-        "gray" | "grey" => crate::plots::surface::ColorMap::Gray,
-        "bone" => crate::plots::surface::ColorMap::Bone,
-        "copper" => crate::plots::surface::ColorMap::Copper,
-        "pink" => crate::plots::surface::ColorMap::Pink,
-        "lines" => crate::plots::surface::ColorMap::Lines,
-        _ => crate::plots::surface::ColorMap::Parula,
-    }
+    crate::plots::surface::ColorMap::from_name(name)
+        .unwrap_or(crate::plots::surface::ColorMap::Parula)
 }
 
 fn vec4_to_rgba(value: Vec4) -> [f32; 4] {

--- a/crates/runmat-plot/src/plots/surface.rs
+++ b/crates/runmat-plot/src/plots/surface.rs
@@ -87,6 +87,39 @@ pub enum ColorMap {
     Custom(Vec4, Vec4), // (min_color, max_color)
 }
 
+impl ColorMap {
+    pub const CANONICAL_NAMES: &[&str] = &[
+        "parula", "viridis", "plasma", "inferno", "magma", "turbo", "jet", "hot", "cool", "spring",
+        "summer", "autumn", "winter", "gray", "bone", "copper", "pink", "lines",
+    ];
+
+    pub const ALIASES: &[&str] = &["grey"];
+
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "parula" => Some(Self::Parula),
+            "viridis" => Some(Self::Viridis),
+            "plasma" => Some(Self::Plasma),
+            "inferno" => Some(Self::Inferno),
+            "magma" => Some(Self::Magma),
+            "turbo" => Some(Self::Turbo),
+            "jet" => Some(Self::Jet),
+            "hot" => Some(Self::Hot),
+            "cool" => Some(Self::Cool),
+            "spring" => Some(Self::Spring),
+            "summer" => Some(Self::Summer),
+            "autumn" => Some(Self::Autumn),
+            "winter" => Some(Self::Winter),
+            "gray" | "grey" => Some(Self::Gray),
+            "bone" => Some(Self::Bone),
+            "copper" => Some(Self::Copper),
+            "pink" => Some(Self::Pink),
+            "lines" => Some(Self::Lines),
+            _ => None,
+        }
+    }
+}
+
 /// Surface shading modes
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ShadingMode {
@@ -914,15 +947,8 @@ pub mod matlab_compat {
         z: Vec<Vec<f64>>,
         colormap: &str,
     ) -> Result<SurfacePlot, String> {
-        let cmap = match colormap {
-            "jet" => ColorMap::Jet,
-            "hot" => ColorMap::Hot,
-            "cool" => ColorMap::Cool,
-            "viridis" => ColorMap::Viridis,
-            "plasma" => ColorMap::Plasma,
-            "gray" | "grey" => ColorMap::Gray,
-            _ => return Err(format!("Unknown colormap: {colormap}")),
-        };
+        let cmap =
+            ColorMap::from_name(colormap).ok_or_else(|| format!("Unknown colormap: {colormap}"))?;
 
         Ok(SurfacePlot::new(x, y, z)?.with_colormap(cmap))
     }
@@ -1048,5 +1074,54 @@ mod tests {
 
         let colormap_surface = surf_with_colormap(x, y, z, "viridis").unwrap();
         assert_eq!(colormap_surface.colormap, ColorMap::Viridis);
+    }
+
+    #[test]
+    fn colormap_from_name_accepts_canonical_names_and_aliases() {
+        let cases = [
+            ("parula", ColorMap::Parula),
+            ("viridis", ColorMap::Viridis),
+            ("plasma", ColorMap::Plasma),
+            ("inferno", ColorMap::Inferno),
+            ("magma", ColorMap::Magma),
+            ("turbo", ColorMap::Turbo),
+            ("jet", ColorMap::Jet),
+            ("hot", ColorMap::Hot),
+            ("cool", ColorMap::Cool),
+            ("spring", ColorMap::Spring),
+            ("summer", ColorMap::Summer),
+            ("autumn", ColorMap::Autumn),
+            ("winter", ColorMap::Winter),
+            ("gray", ColorMap::Gray),
+            ("grey", ColorMap::Gray),
+            ("bone", ColorMap::Bone),
+            ("copper", ColorMap::Copper),
+            ("pink", ColorMap::Pink),
+            ("lines", ColorMap::Lines),
+        ];
+
+        for (name, expected) in cases {
+            assert_eq!(ColorMap::from_name(name), Some(expected), "{name}");
+        }
+        for name in ColorMap::CANONICAL_NAMES
+            .iter()
+            .chain(ColorMap::ALIASES.iter())
+            .copied()
+        {
+            assert!(
+                ColorMap::from_name(name).is_some(),
+                "colormap table entry should parse: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn colormap_from_name_normalizes_and_rejects_unknown_names() {
+        assert_eq!(ColorMap::from_name(" Turbo "), Some(ColorMap::Turbo));
+        assert_eq!(ColorMap::from_name("GREY"), Some(ColorMap::Gray));
+        assert_eq!(ColorMap::from_name("hsv"), None);
+        assert!(!ColorMap::CANONICAL_NAMES.contains(&"hsv"));
+        assert!(!ColorMap::ALIASES.contains(&"hsv"));
+        assert_eq!(ColorMap::from_name("not-a-colormap"), None);
     }
 }

--- a/crates/runmat-runtime/src/builtins/plotting/core/properties.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/core/properties.rs
@@ -3566,30 +3566,12 @@ fn parse_colormap_name(
     name: &str,
     builtin: &'static str,
 ) -> BuiltinResult<runmat_plot::plots::surface::ColorMap> {
-    match name.trim().to_ascii_lowercase().as_str() {
-        "parula" => Ok(runmat_plot::plots::surface::ColorMap::Parula),
-        "viridis" => Ok(runmat_plot::plots::surface::ColorMap::Viridis),
-        "plasma" => Ok(runmat_plot::plots::surface::ColorMap::Plasma),
-        "inferno" => Ok(runmat_plot::plots::surface::ColorMap::Inferno),
-        "magma" => Ok(runmat_plot::plots::surface::ColorMap::Magma),
-        "turbo" => Ok(runmat_plot::plots::surface::ColorMap::Turbo),
-        "jet" => Ok(runmat_plot::plots::surface::ColorMap::Jet),
-        "hot" => Ok(runmat_plot::plots::surface::ColorMap::Hot),
-        "cool" => Ok(runmat_plot::plots::surface::ColorMap::Cool),
-        "spring" => Ok(runmat_plot::plots::surface::ColorMap::Spring),
-        "summer" => Ok(runmat_plot::plots::surface::ColorMap::Summer),
-        "autumn" => Ok(runmat_plot::plots::surface::ColorMap::Autumn),
-        "winter" => Ok(runmat_plot::plots::surface::ColorMap::Winter),
-        "gray" | "grey" => Ok(runmat_plot::plots::surface::ColorMap::Gray),
-        "bone" => Ok(runmat_plot::plots::surface::ColorMap::Bone),
-        "copper" => Ok(runmat_plot::plots::surface::ColorMap::Copper),
-        "pink" => Ok(runmat_plot::plots::surface::ColorMap::Pink),
-        "lines" => Ok(runmat_plot::plots::surface::ColorMap::Lines),
-        other => Err(plotting_error(
+    runmat_plot::plots::surface::ColorMap::from_name(name).ok_or_else(|| {
+        plotting_error(
             builtin,
-            format!("{builtin}: unknown colormap '{other}'"),
-        )),
-    }
+            format!("{builtin}: unknown colormap '{}'", name.trim()),
+        )
+    })
 }
 
 fn apply_axes_text_alias(

--- a/crates/runmat-runtime/src/builtins/plotting/core/style.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/core/style.rs
@@ -868,27 +868,7 @@ fn parse_colormap_option(opts: &LineStyleParseOptions, value: &Value) -> Builtin
 }
 
 fn parse_colormap_name(name: &str) -> Option<ColorMap> {
-    match name.trim().to_ascii_lowercase().as_str() {
-        "parula" => Some(ColorMap::Parula),
-        "jet" => Some(ColorMap::Jet),
-        "turbo" => Some(ColorMap::Turbo),
-        "viridis" => Some(ColorMap::Viridis),
-        "plasma" => Some(ColorMap::Plasma),
-        "inferno" => Some(ColorMap::Inferno),
-        "magma" => Some(ColorMap::Magma),
-        "hot" => Some(ColorMap::Hot),
-        "cool" => Some(ColorMap::Cool),
-        "spring" => Some(ColorMap::Spring),
-        "summer" => Some(ColorMap::Summer),
-        "autumn" => Some(ColorMap::Autumn),
-        "winter" => Some(ColorMap::Winter),
-        "gray" | "grey" => Some(ColorMap::Gray),
-        "bone" => Some(ColorMap::Bone),
-        "copper" => Some(ColorMap::Copper),
-        "pink" => Some(ColorMap::Pink),
-        "lines" => Some(ColorMap::Lines),
-        _ => None,
-    }
+    ColorMap::from_name(name)
 }
 
 fn parse_shading_option(opts: &LineStyleParseOptions, value: &Value) -> BuiltinResult<ShadingMode> {

--- a/crates/runmat-runtime/src/builtins/plotting/ops/cmds.rs
+++ b/crates/runmat-runtime/src/builtins/plotting/ops/cmds.rs
@@ -542,35 +542,16 @@ pub fn colormap_builtin(args: Vec<Value>) -> crate::BuiltinResult<bool> {
             &COLORMAP_ERROR_INVALID_ARGUMENT,
         ));
     };
-    let cmap = match name.trim() {
-        "parula" => runmat_plot::plots::surface::ColorMap::Parula,
-        "viridis" => runmat_plot::plots::surface::ColorMap::Viridis,
-        "plasma" => runmat_plot::plots::surface::ColorMap::Plasma,
-        "inferno" => runmat_plot::plots::surface::ColorMap::Inferno,
-        "magma" => runmat_plot::plots::surface::ColorMap::Magma,
-        "turbo" => runmat_plot::plots::surface::ColorMap::Turbo,
-        "jet" => runmat_plot::plots::surface::ColorMap::Jet,
-        "hot" => runmat_plot::plots::surface::ColorMap::Hot,
-        "cool" => runmat_plot::plots::surface::ColorMap::Cool,
-        "spring" => runmat_plot::plots::surface::ColorMap::Spring,
-        "summer" => runmat_plot::plots::surface::ColorMap::Summer,
-        "autumn" => runmat_plot::plots::surface::ColorMap::Autumn,
-        "winter" => runmat_plot::plots::surface::ColorMap::Winter,
-        "gray" | "grey" => runmat_plot::plots::surface::ColorMap::Gray,
-        "bone" => runmat_plot::plots::surface::ColorMap::Bone,
-        "copper" => runmat_plot::plots::surface::ColorMap::Copper,
-        "pink" => runmat_plot::plots::surface::ColorMap::Pink,
-        "lines" => runmat_plot::plots::surface::ColorMap::Lines,
-        other => {
-            return Err(cmd_error_with_message(
-                "colormap",
-                format!(
-                    "{}: unknown colormap '{other}'",
-                    COLORMAP_ERROR_INVALID_ARGUMENT.message
-                ),
-                &COLORMAP_ERROR_INVALID_ARGUMENT,
-            ))
-        }
+    let Some(cmap) = runmat_plot::plots::surface::ColorMap::from_name(&name) else {
+        let other = name.trim();
+        return Err(cmd_error_with_message(
+            "colormap",
+            format!(
+                "{}: unknown colormap '{other}'",
+                COLORMAP_ERROR_INVALID_ARGUMENT.message
+            ),
+            &COLORMAP_ERROR_INVALID_ARGUMENT,
+        ));
     };
     set_colormap(cmap);
     Ok(true)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Intentionally breaks scripts that used `colormap hsv`; otherwise behavior is consolidation with broader accepted command keywords aligned to runtime.
> 
> **Overview**
> **Unifies colormap name handling** so the `colormap` command, plotting builtins, and event deserialization all resolve names through **`ColorMap::from_name`** on `runmat_plot` instead of scattered `match` blocks.
> 
> The parser’s **`colormap` keyword list** is updated to match supported runtime names (adds perceptual maps like `viridis`/`plasma`/`turbo`, **`grey`** as an alias, and **`lines`**; drops **`hsv`**, which is not implemented). **`colormap hsv`** now fails at parse/compile with an explicit “does not support 'hsv'” message rather than being accepted and failing later.
> 
> Compile and parser tests loop over the full supported name set; **`surface.rs`** adds unit tests for normalization, aliases, and rejection of unknown names including `hsv`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29abd7843b74fed0f8975b780bbbc17a313c5b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded colormap support to include additional named palettes.
  * Colormap names now accept minor formatting differences like extra whitespace and case variations.

* **Bug Fixes**
  * Improved validation so unsupported colormap values are rejected with clearer error messages.
  * Tightened compatibility behavior for `hsv`, which is now reported as unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->