### PR TITLE
Support shell escapes in the runmat CLI REPL

### DIFF
--- a/crates/runmat-cli/src/commands/repl.rs
+++ b/crates/runmat-cli/src/commands/repl.rs
@@ -8,7 +8,7 @@ use runmat_core::{
 };
 use runmat_gc::gc_collect_major;
 use runmat_time::Instant;
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 use std::process::Command;
 use supports_color::Stream;
 
@@ -468,6 +468,7 @@ fn run_shell_escape(command: &str) {
     match shell.output() {
         Ok(output) => {
             print!("{}", String::from_utf8_lossy(&output.stdout));
+            let _ = io::stdout().flush();
             eprint!("{}", String::from_utf8_lossy(&output.stderr));
             if !output.status.success() {
                 if let Some(code) = output.status.code() {

--- a/crates/runmat-cli/src/commands/repl.rs
+++ b/crates/runmat-cli/src/commands/repl.rs
@@ -9,6 +9,7 @@ use runmat_core::{
 use runmat_gc::gc_collect_major;
 use runmat_time::Instant;
 use std::io::{self, Read};
+use std::process::Command;
 use supports_color::Stream;
 
 use crate::commands::session::create_session;
@@ -55,10 +56,9 @@ pub async fn execute_repl(config: &RunMatRuntimeConfig) -> Result<()> {
         io::stdin()
             .read_to_string(&mut buffer)
             .context("Failed to read piped input")?;
-        for raw_line in buffer.lines() {
-            if !process_repl_line(raw_line, &mut engine, config).await? {
-                break;
-            }
+        if !process_repl_input(&buffer, &mut engine, config).await? {
+            finalize_repl_session(&engine, session_start, repl_run);
+            return Ok(());
         }
         finalize_repl_session(&engine, session_start, repl_run);
         return Ok(());
@@ -70,10 +70,9 @@ pub async fn execute_repl(config: &RunMatRuntimeConfig) -> Result<()> {
         let readline = rl.readline("runmat> ");
         match readline {
             Ok(line) => {
-                let line = line.trim();
-                let _ = rl.add_history_entry(line);
+                let _ = rl.add_history_entry(line.as_str());
 
-                if !process_repl_line(line, &mut engine, config).await? {
+                if !process_repl_input(&line, &mut engine, config).await? {
                     break;
                 }
             }
@@ -253,6 +252,7 @@ fn format_runtime_line(
 fn format_help_line(caps: &BannerCapabilities) -> String {
     let help = style_text("help", caps, BannerTone::Bright);
     let info = style_text(".info", caps, BannerTone::Bright);
+    let shell = style_text("!cmd", caps, BannerTone::Bright);
     let exit = style_text("exit", caps, BannerTone::Bright);
     [
         style_text("Enter code to execute, or", caps, BannerTone::Muted),
@@ -261,6 +261,9 @@ fn format_help_line(caps: &BannerCapabilities) -> String {
         format!(" `{exit}`"),
         style_text(" or", caps, BannerTone::Muted),
         format!(" `{info}`"),
+        style_text("; use", caps, BannerTone::Muted),
+        format!(" `{shell}`"),
+        style_text(" for shell", caps, BannerTone::Muted),
         style_text(".", caps, BannerTone::Muted),
     ]
     .concat()
@@ -328,6 +331,24 @@ fn style_text(text: &str, caps: &BannerCapabilities, tone: BannerTone) -> String
     }
 }
 
+async fn process_repl_input(
+    input: &str,
+    engine: &mut RunMatSession,
+    config: &RunMatRuntimeConfig,
+) -> Result<bool> {
+    if input.is_empty() {
+        return process_repl_line("", engine, config).await;
+    }
+
+    for raw_line in input.lines() {
+        if !process_repl_line(raw_line.trim(), engine, config).await? {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
 async fn process_repl_line(
     line: &str,
     engine: &mut RunMatSession,
@@ -377,7 +398,11 @@ async fn process_repl_line(
         println!("Statistics reset");
         return Ok(true);
     }
-    if line.is_empty() {
+    if line.trim().is_empty() {
+        return Ok(true);
+    }
+    if let Some(command) = line.trim_start().strip_prefix('!') {
+        run_shell_escape(command);
         return Ok(true);
     }
 
@@ -423,6 +448,41 @@ async fn process_repl_line(
     Ok(true)
 }
 
+fn run_shell_escape(command: &str) {
+    let command = command.trim_start();
+    if command.is_empty() {
+        eprintln!("Shell command is empty");
+        return;
+    }
+
+    let mut shell = if cfg!(windows) {
+        let mut command_process = Command::new("cmd");
+        command_process.args(["/C", command]);
+        command_process
+    } else {
+        let mut command_process = Command::new("sh");
+        command_process.args(["-c", command]);
+        command_process
+    };
+
+    match shell.output() {
+        Ok(output) => {
+            print!("{}", String::from_utf8_lossy(&output.stdout));
+            eprint!("{}", String::from_utf8_lossy(&output.stderr));
+            if !output.status.success() {
+                if let Some(code) = output.status.code() {
+                    eprintln!("Shell command exited with status {code}");
+                } else {
+                    eprintln!("Shell command terminated without exit status");
+                }
+            }
+        }
+        Err(err) => {
+            eprintln!("Failed to execute shell command: {err}");
+        }
+    }
+}
+
 fn finalize_repl_session(
     engine: &RunMatSession,
     session_start: Instant,
@@ -462,11 +522,13 @@ fn show_repl_help() {
     println!("  .gc-info        Show garbage collector summary with header");
     println!("  .gc-collect     Force garbage collection");
     println!("  .reset-stats    Reset execution statistics");
+    println!("  !cmd            Run a shell command and print its output");
     println!();
     println!("Examples");
     println!("  x = 1 + 2");
     println!("  y = [1, 2; 3, 4]");
     println!("  for i = 1:5; disp(i); end");
+    println!("  !pwd");
     println!();
     println!("Use `.info` for runtime details.");
 }

--- a/crates/runmat-cli/src/commands/repl.rs
+++ b/crates/runmat-cli/src/commands/repl.rs
@@ -9,7 +9,8 @@ use runmat_core::{
 use runmat_gc::gc_collect_major;
 use runmat_time::Instant;
 use std::io::{self, Read, Write};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
 use supports_color::Stream;
 
 use crate::commands::session::create_session;
@@ -465,16 +466,87 @@ fn run_shell_escape(command: &str) {
         command_process
     };
 
-    match shell.output() {
-        Ok(output) => {
-            print!("{}", String::from_utf8_lossy(&output.stdout));
-            let _ = io::stdout().flush();
-            eprint!("{}", String::from_utf8_lossy(&output.stderr));
-            if !output.status.success() {
-                if let Some(code) = output.status.code() {
-                    eprintln!("Shell command exited with status {code}");
-                } else {
-                    eprintln!("Shell command terminated without exit status");
+    match shell.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
+        Ok(mut child) => {
+            let stdout = child.stdout.take();
+            let stderr = child.stderr.take();
+            let (sender, receiver) = mpsc::channel();
+
+            let stdout_thread = stdout.map(|mut stdout| {
+                let sender = sender.clone();
+                std::thread::spawn(move || -> io::Result<()> {
+                    let mut buffer = [0; 8192];
+                    loop {
+                        let bytes_read = stdout.read(&mut buffer)?;
+                        if bytes_read == 0 {
+                            break;
+                        }
+                        if sender.send((true, buffer[..bytes_read].to_vec())).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(())
+                })
+            });
+            let stderr_thread = stderr.map(|mut stderr| {
+                let sender = sender.clone();
+                std::thread::spawn(move || -> io::Result<()> {
+                    let mut buffer = [0; 8192];
+                    loop {
+                        let bytes_read = stderr.read(&mut buffer)?;
+                        if bytes_read == 0 {
+                            break;
+                        }
+                        if sender.send((false, buffer[..bytes_read].to_vec())).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(())
+                })
+            });
+            drop(sender);
+
+            {
+                let mut stdout = io::stdout().lock();
+                let mut stderr = io::stderr().lock();
+                for (is_stdout, chunk) in receiver {
+                    if is_stdout {
+                        let _ = stdout.write_all(&chunk);
+                        let _ = stdout.flush();
+                    } else {
+                        let _ = stderr.write_all(&chunk);
+                        let _ = stderr.flush();
+                    }
+                }
+            }
+
+            if let Some(stdout_thread) = stdout_thread {
+                match stdout_thread.join() {
+                    Ok(Ok(())) => {}
+                    Ok(Err(err)) => eprintln!("Failed to read shell stdout: {err}"),
+                    Err(_) => eprintln!("Failed to read shell stdout"),
+                }
+            }
+            if let Some(stderr_thread) = stderr_thread {
+                match stderr_thread.join() {
+                    Ok(Ok(())) => {}
+                    Ok(Err(err)) => eprintln!("Failed to read shell stderr: {err}"),
+                    Err(_) => eprintln!("Failed to read shell stderr"),
+                }
+            }
+
+            match child.wait() {
+                Ok(status) => {
+                    if !status.success() {
+                        if let Some(code) = status.code() {
+                            eprintln!("Shell command exited with status {code}");
+                        } else {
+                            eprintln!("Shell command terminated without exit status");
+                        }
+                    }
+                }
+                Err(err) => {
+                    eprintln!("Failed to wait for shell command: {err}");
                 }
             }
         }

--- a/crates/runmat-cli/tests/cli.rs
+++ b/crates/runmat-cli/tests/cli.rs
@@ -27,6 +27,32 @@ fn run_runmat(args: &[&str]) -> std::process::Output {
         .expect("Failed to execute runmat binary")
 }
 
+fn run_repl_with_piped_input(
+    input: &str,
+    current_dir: Option<&Path>,
+) -> Result<std::process::Output, Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let config_path = write_test_config(temp_dir.path());
+    let mut command = Command::new(get_binary_path());
+    command
+        .args(["repl"])
+        .env("RUNMAT_CONFIG", &config_path)
+        .env("NO_GUI", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(current_dir) = current_dir {
+        command.current_dir(current_dir);
+    }
+
+    let mut child = command.spawn()?;
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin.write_all(input.as_bytes())?;
+    }
+    drop(child.stdin.take());
+    Ok(child.wait_with_output()?)
+}
+
 fn write_test_config(dir: &Path) -> PathBuf {
     let config_path = dir.join("runmat.toml");
     fs::write(
@@ -359,24 +385,103 @@ fn test_repl_command() {
 
 #[test]
 fn test_repl_processes_piped_input() -> Result<(), Box<dyn std::error::Error>> {
-    let temp_dir = TempDir::new()?;
-    let config_path = write_test_config(temp_dir.path());
-    let mut child = Command::new(get_binary_path())
-        .args(["repl"])
-        .env("RUNMAT_CONFIG", &config_path)
-        .env("NO_GUI", "1")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()?;
-    if let Some(stdin) = child.stdin.as_mut() {
-        stdin.write_all(b"1+1\n")?;
-    }
-    drop(child.stdin.take());
-    let output = child.wait_with_output()?;
+    let output = run_repl_with_piped_input("1+1\n", None)?;
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("ans = 2"));
     Ok(())
+}
+
+#[test]
+fn test_repl_shell_escape_runs_pwd() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let command = if cfg!(windows) { "!cd\n" } else { "!pwd\n" };
+    let output = run_repl_with_piped_input(command, Some(temp_dir.path()))?;
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let dir_name = temp_dir
+        .path()
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("temp dir should have a UTF-8 final component");
+    assert!(
+        stdout.contains(dir_name),
+        "stdout did not include current directory component `{dir_name}`:\n{stdout}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_repl_shell_escape_handles_quoted_args() -> Result<(), Box<dyn std::error::Error>> {
+    let output = run_repl_with_piped_input("!echo \"runmat bang quoted arg\"\n", None)?;
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("runmat bang quoted arg"),
+        "stdout did not include quoted echo output:\n{stdout}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_repl_shell_escape_reports_nonzero_and_continues() -> Result<(), Box<dyn std::error::Error>>
+{
+    let command = if cfg!(windows) {
+        "!exit 7\n1+1\n"
+    } else {
+        "!false\n1+1\n"
+    };
+    let output = run_repl_with_piped_input(command, None)?;
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("ans = 2"),
+        "REPL did not continue after non-zero shell command:\n{stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Shell command exited with status"),
+        "stderr did not report non-zero shell status:\n{stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_repl_shell_escape_reports_empty_command_and_continues(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output = run_repl_with_piped_input("!   \n1+1\n", None)?;
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("ans = 2"),
+        "REPL did not continue after empty shell command:\n{stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Shell command is empty"),
+        "stderr did not report empty shell command:\n{stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_script_leading_bang_is_not_repl_shell_escape() {
+    let temp_dir = TempDir::new().unwrap();
+    let script_path = temp_dir.path().join("bang_script.m");
+    fs::write(&script_path, "!echo runmat-script-should-not-shell").unwrap();
+
+    let output = run_runmat(&["run", script_path.to_str().unwrap()]);
+    assert!(!output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("runmat-script-should-not-shell"),
+        "script execution unexpectedly treated leading bang as shell escape:\n{stdout}"
+    );
 }
 
 #[test]

--- a/crates/runmat-cli/tests/cli.rs
+++ b/crates/runmat-cli/tests/cli.rs
@@ -46,11 +46,12 @@ fn run_repl_with_piped_input(
     }
 
     let mut child = command.spawn()?;
-    if let Some(stdin) = child.stdin.as_mut() {
-        stdin.write_all(input.as_bytes())?;
-    }
-    drop(child.stdin.take());
-    Ok(child.wait_with_output()?)
+    let mut stdin = child.stdin.take().expect("stdin should be piped");
+    let input = input.to_owned();
+    let writer = std::thread::spawn(move || stdin.write_all(input.as_bytes()));
+    let output = child.wait_with_output()?;
+    writer.join().expect("stdin writer thread panicked")?;
+    Ok(output)
 }
 
 fn write_test_config(dir: &Path) -> PathBuf {

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -50,11 +50,15 @@ REPL commands:
 | `.gc`, `.gc-info` | Show garbage collector statistics. |
 | `.gc-collect` | Force a major collection. |
 | `.reset-stats` | Reset execution statistics. |
+| `!cmd` | Run `cmd` in the platform shell and print stdout/stderr. |
+
+Shell escapes are local CLI REPL behavior. A line such as `!pwd` runs `pwd` through the host shell without submitting it to the RunMat parser. Non-zero shell exits are reported at the prompt and do not close the REPL. `.m` scripts and other hosts do not treat leading `!` as a shell escape.
 
 The REPL also accepts piped input:
 
 ```bash
 printf "1 + 1\n" | runmat repl
+printf "!pwd\n1 + 1\n" | runmat repl
 ```
 
 ## Run

--- a/docs/session/host-integration.md
+++ b/docs/session/host-integration.md
@@ -11,7 +11,9 @@ The session API is intentionally host-neutral. Different frontends wrap it diffe
 
 ## CLI REPL
 
-The CLI REPL creates one `RunMatSession`, keeps it alive for the process, and submits each line as `SourceInput::Text { name: "<repl>", text }`. Special dot commands such as `.stats`, `.gc`, and `.info` are handled by the CLI before code reaches the session.
+The CLI REPL creates one `RunMatSession`, keeps it alive for the process, and submits ordinary source lines as `SourceInput::Text { name: "<repl>", text }`. Special dot commands such as `.stats`, `.gc`, and `.info` are handled by the CLI before code reaches the session.
+
+Lines beginning with `!` are also CLI-only shell escapes. The native CLI runs the rest of the line in the platform shell, prints stdout and stderr, reports non-zero exits, and then returns to the REPL. This is host execution, not a `runmat-core` ABI feature: `.m` scripts, WASM, notebook hosts, and editor hosts do not receive implicit shell execution by submitting source that starts with `!`.
 
 The CLI uses in-memory line-editor history. Persistent notebook or command history is not part of `runmat-core`.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> REPL shell escapes execute arbitrary host commands for CLI users; scope is limited to the REPL (not script execution), but misuse or social-engineering around `!` remains a local security concern.
> 
> **Overview**
> The CLI REPL gains **`!cmd` host-shell escapes**: lines starting with `!` run the remainder through `cmd /C` or `sh -c`, stream stdout/stderr to the terminal, report empty commands and non-zero exits on stderr, and keep the REPL running. This is handled in `process_repl_line` before any `ExecutionRequest` is built, so it never reaches the RunMat session.
> 
> Input handling is refactored so **piped and interactive paths** both go through `process_repl_input`, which splits on newlines and trims each line. Whitespace-only lines are ignored; `exit`/`quit` work the same for piped multi-line input. The banner, help text, and docs describe `!cmd` and clarify that **only the native CLI REPL** treats leading `!` as shell—`.m` scripts and other hosts do not.
> 
> CLI integration tests add a piped-REPL helper and cover shell output, quoted args, error reporting, and continuation after failures, plus a regression that **`run` on a script** with a leading `!` does not shell out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50d4bf24f7da34189c3aa1bd953054cadeb2b28f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REPL now supports host-shell escapes via `!cmd`, streaming stdout/stderr and reporting non-zero exit status, including quoted arguments.
* **Bug Fixes**
  * Whitespace-only input is treated as a no-op.
  * REPL exit behavior is consistent for typed vs piped input; `!` inside script files is treated as script content (not a shell escape).
* **Documentation**
  * Updated REPL help text and CLI docs/examples to include `!cmd` (e.g., `!pwd`) and clarify host-only behavior.
* **Tests**
  * Added and expanded REPL tests covering `!` behavior across platforms and piped-input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->